### PR TITLE
docker entrypoint fix for claude accept both creds

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -71,8 +71,9 @@ elif [ "$HARNESS_PROVIDER" = "codex" ]; then
     fi
 else
     # Claude auth (default)
-    if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
-        echo "Error: CLAUDE_CODE_OAUTH_TOKEN environment variable is required"
+    # Allow both Oauth and ANTHROPIC_API_KEY for flexibility, but require at least one
+    if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
+        echo "Error: Claude provider requires either CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY environment variable"
         exit 1
     fi
 fi


### PR DESCRIPTION
## Community Template Submission

### Template Info

- **Name**: <!-- e.g., devops -->
- **Display Name**: <!-- e.g., DevOps Engineer -->
- **Category**: community
- **Role**: <!-- worker or lead -->

### Checklist

- [ ] `config.json` is present and valid JSON
- [ ] All 5 profile files are present (CLAUDE.md, SOUL.md, IDENTITY.md, TOOLS.md, start-up.sh)
- [ ] Template uses `{{agent.name}}` and `{{agent.role}}` placeholders where appropriate
- [ ] `start-up.sh` is executable and starts with `#!/bin/bash`
- [ ] Tested locally with `TEMPLATE_ID=community/<name>`
- [ ] Template follows the structure of existing official templates

### Description

<!-- Describe what this template does and why it's useful -->

### Testing

<!-- How did you test this template? -->

---

Questions? Contact us at contact@agent-swarm.dev
