### PR TITLE
fix(claude-adapter): fail loud on MCP server fetch errors

### DIFF
--- a/src/providers/claude-adapter.ts
+++ b/src/providers/claude-adapter.ts
@@ -7,7 +7,6 @@ import {
   SessionErrorTracker,
   trackErrorFromJson,
 } from "../utils/error-tracker";
-import { fetchInstalledMcpServers } from "../utils/mcp-server-fetcher";
 import { scrubSecrets } from "../utils/secret-scrubber";
 import type {
   CostData,
@@ -24,6 +23,127 @@ interface TaskFileData {
   agentId: string;
   startedAt: string;
 }
+
+/**
+ * Thrown when the installed-MCP-servers API call fails after all retries.
+ * Caller is expected to refuse spawning the session — a Claude session without
+ * swarm tools cannot call store-progress and ends up auto-completed by the
+ * runner with "no output captured", wasting tokens and losing task work.
+ */
+class ClaudeMcpFetchError extends Error {
+  constructor(
+    message: string,
+    readonly cause: { status?: number; statusText?: string; error?: unknown },
+  ) {
+    super(message);
+    this.name = "ClaudeMcpFetchError";
+  }
+}
+
+const MCP_FETCH_MAX_ATTEMPTS = 3;
+const MCP_FETCH_BASE_BACKOFF_MS = 250;
+
+function isRetriableMcpStatus(status: number): boolean {
+  return status >= 500 || status === 408 || status === 425 || status === 429;
+}
+
+/**
+ * Fetch the agent's installed MCP servers with retry + logging.
+ *
+ * Returns a (possibly empty) record on success — empty means the agent has
+ * no active MCP servers configured, which is a valid steady state.
+ * Throws `ClaudeMcpFetchError` after `MCP_FETCH_MAX_ATTEMPTS` on transient
+ * failures (5xx, network) or immediately on non-retriable 4xx.
+ *
+ * Inlined here (rather than in `src/utils/mcp-server-fetcher.ts`) because the
+ * Claude adapter is the only caller that needs the strict throw-on-failure
+ * semantics — opencode adds the swarm endpoint explicitly and tolerates an
+ * empty installed set.
+ */
+async function fetchInstalledMcpServersForClaude(
+  apiUrl: string,
+  apiKey: string,
+  agentId: string,
+): Promise<Record<string, Record<string, unknown>>> {
+  const url = `${apiUrl}/api/agents/${agentId}/mcp-servers?resolveSecrets=true`;
+
+  let lastError: { status?: number; statusText?: string; error?: unknown } = {};
+  for (let attempt = 1; attempt <= MCP_FETCH_MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${apiKey}`, "X-Agent-ID": agentId },
+      });
+
+      if (!res.ok) {
+        lastError = { status: res.status, statusText: res.statusText };
+        const retriable = isRetriableMcpStatus(res.status);
+        console.warn(
+          `\x1b[33m[claude/mcp-fetch]\x1b[0m attempt ${attempt}/${MCP_FETCH_MAX_ATTEMPTS} GET ${url} -> ${res.status} ${res.statusText}${retriable ? " (will retry)" : " (fatal)"}`,
+        );
+        if (!retriable) break;
+        if (attempt < MCP_FETCH_MAX_ATTEMPTS)
+          await new Promise((r) => setTimeout(r, MCP_FETCH_BASE_BACKOFF_MS * 2 ** (attempt - 1)));
+        continue;
+      }
+
+      const data = (await res.json()) as {
+        servers: Array<{
+          name: string;
+          transport: string;
+          isActive: boolean;
+          isEnabled: boolean;
+          command?: string;
+          args?: string;
+          url?: string;
+          headers?: string;
+          resolvedEnv?: Record<string, string>;
+          resolvedHeaders?: Record<string, string>;
+        }>;
+      };
+
+      const entries: Record<string, Record<string, unknown>> = {};
+      for (const srv of data.servers.filter((s) => s.isActive && s.isEnabled)) {
+        if (srv.transport === "stdio" && srv.command) {
+          let args: string[] = [];
+          try {
+            args = srv.args ? JSON.parse(srv.args) : [];
+          } catch {
+            // invalid JSON — use empty args
+          }
+          entries[srv.name] = { command: srv.command, args, env: srv.resolvedEnv || {} };
+        } else if ((srv.transport === "http" || srv.transport === "sse") && srv.url) {
+          let parsedHeaders: Record<string, string> = {};
+          try {
+            parsedHeaders = srv.headers ? JSON.parse(srv.headers) : {};
+          } catch {
+            // invalid JSON — use empty headers
+          }
+          entries[srv.name] = {
+            type: srv.transport,
+            url: srv.url,
+            headers: { ...parsedHeaders, ...(srv.resolvedHeaders || {}) },
+          };
+        }
+      }
+      return entries;
+    } catch (err) {
+      lastError = { error: err };
+      console.warn(
+        `\x1b[33m[claude/mcp-fetch]\x1b[0m attempt ${attempt}/${MCP_FETCH_MAX_ATTEMPTS} GET ${url} threw: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      if (attempt < MCP_FETCH_MAX_ATTEMPTS)
+        await new Promise((r) => setTimeout(r, MCP_FETCH_BASE_BACKOFF_MS * 2 ** (attempt - 1)));
+    }
+  }
+
+  throw new ClaudeMcpFetchError(
+    `Failed to fetch installed MCP servers from ${url} after ${MCP_FETCH_MAX_ATTEMPTS} attempts`,
+    lastError,
+  );
+}
+
+// Exported for unit tests.
+export const __test = { fetchInstalledMcpServersForClaude, ClaudeMcpFetchError };
 
 function getTaskFilePath(pid: number): string {
   return `/tmp/agent-swarm-task-${pid}.json`;
@@ -526,22 +646,42 @@ export class ClaudeAdapter implements ProviderAdapter {
 
     console.log(`\x1b[2m[${config.role}]\x1b[0m Task file written: ${taskFilePath}`);
 
-    // Fetch installed MCP servers from API for this agent
-    const installedServers =
-      config.apiUrl && config.apiKey && config.agentId
-        ? await fetchInstalledMcpServers(config.apiUrl, config.apiKey, config.agentId, "claude")
-        : null;
-    if (installedServers) {
+    // Fetch installed MCP servers from API for this agent.
+    // If the fetch fails (network / 5xx after retries) we refuse to spawn —
+    // a session without swarm tools (join-swarm, store-progress, send-task, …)
+    // can't actually report progress, so it would auto-complete with no output.
+    let installedServers: Record<string, Record<string, unknown>> | null = null;
+    if (config.apiUrl && config.apiKey && config.agentId) {
+      try {
+        installedServers = await fetchInstalledMcpServersForClaude(
+          config.apiUrl,
+          config.apiKey,
+          config.agentId,
+        );
+      } catch (err) {
+        if (err instanceof ClaudeMcpFetchError) {
+          await cleanupTaskFile(taskFilePid);
+          throw new Error(
+            `[claude] Refusing to spawn session for task ${config.taskId.slice(0, 8)} — MCP server fetch failed: ${err.message}. Worker would have no swarm tools.`,
+          );
+        }
+        throw err;
+      }
+      const count = Object.keys(installedServers).length;
       console.log(
-        `\x1b[2m[${config.role}]\x1b[0m Merging ${Object.keys(installedServers).length} installed MCP server(s) into session config`,
+        `\x1b[2m[${config.role}]\x1b[0m Merging ${count} installed MCP server(s) into session config`,
       );
     }
 
     // Create per-session MCP config with X-Source-Task-Id header + installed servers (no shared-file race condition)
+    // Pass null (not {}) when no installed servers exist — keeps the existing
+    // "no .mcp.json + no installed servers → skip --mcp-config" behavior.
+    const installedForMerge =
+      installedServers && Object.keys(installedServers).length > 0 ? installedServers : null;
     const sessionMcpConfig = await createSessionMcpConfig(
       config.cwd,
       config.taskId,
-      installedServers,
+      installedForMerge,
     );
 
     return new ClaudeSession(

--- a/src/providers/claude-adapter.ts
+++ b/src/providers/claude-adapter.ts
@@ -25,12 +25,12 @@ interface TaskFileData {
 }
 
 /**
- * Thrown when the installed-MCP-servers API call fails after all retries.
- * Caller is expected to refuse spawning the session — a Claude session without
- * swarm tools cannot call store-progress and ends up auto-completed by the
- * runner with "no output captured", wasting tokens and losing task work.
+ * Thrown when the installed-MCP-servers fetch fails after retries.
+ * `createSession` catches this and refuses to spawn — a Claude session without
+ * swarm tools (join-swarm, store-progress, …) silently auto-completes with
+ * no output, wasting tokens.
  */
-class ClaudeMcpFetchError extends Error {
+export class ClaudeMcpFetchError extends Error {
   constructor(
     message: string,
     readonly cause: { status?: number; statusText?: string; error?: unknown },
@@ -49,18 +49,12 @@ function isRetriableMcpStatus(status: number): boolean {
 
 /**
  * Fetch the agent's installed MCP servers with retry + logging.
+ * Returns `{}` when the API succeeds with no active servers (valid state).
+ * Throws `ClaudeMcpFetchError` after retries on 5xx / network / non-retriable 4xx.
  *
- * Returns a (possibly empty) record on success — empty means the agent has
- * no active MCP servers configured, which is a valid steady state.
- * Throws `ClaudeMcpFetchError` after `MCP_FETCH_MAX_ATTEMPTS` on transient
- * failures (5xx, network) or immediately on non-retriable 4xx.
- *
- * Inlined here (rather than in `src/utils/mcp-server-fetcher.ts`) because the
- * Claude adapter is the only caller that needs the strict throw-on-failure
- * semantics — opencode adds the swarm endpoint explicitly and tolerates an
- * empty installed set.
+ * Exported for unit testing.
  */
-async function fetchInstalledMcpServersForClaude(
+export async function fetchInstalledMcpServersForClaude(
   apiUrl: string,
   apiKey: string,
   agentId: string,
@@ -141,9 +135,6 @@ async function fetchInstalledMcpServersForClaude(
     lastError,
   );
 }
-
-// Exported for unit tests.
-export const __test = { fetchInstalledMcpServersForClaude, ClaudeMcpFetchError };
 
 function getTaskFilePath(pid: number): string {
   return `/tmp/agent-swarm-task-${pid}.json`;
@@ -646,10 +637,6 @@ export class ClaudeAdapter implements ProviderAdapter {
 
     console.log(`\x1b[2m[${config.role}]\x1b[0m Task file written: ${taskFilePath}`);
 
-    // Fetch installed MCP servers from API for this agent.
-    // If the fetch fails (network / 5xx after retries) we refuse to spawn —
-    // a session without swarm tools (join-swarm, store-progress, send-task, …)
-    // can't actually report progress, so it would auto-complete with no output.
     let installedServers: Record<string, Record<string, unknown>> | null = null;
     if (config.apiUrl && config.apiKey && config.agentId) {
       try {
@@ -660,22 +647,21 @@ export class ClaudeAdapter implements ProviderAdapter {
         );
       } catch (err) {
         if (err instanceof ClaudeMcpFetchError) {
+          // Refuse to spawn: a session without swarm tools auto-completes silently.
           await cleanupTaskFile(taskFilePid);
           throw new Error(
-            `[claude] Refusing to spawn session for task ${config.taskId.slice(0, 8)} — MCP server fetch failed: ${err.message}. Worker would have no swarm tools.`,
+            `[claude] Refusing to spawn session for task ${config.taskId.slice(0, 8)} — MCP server fetch failed: ${err.message}`,
           );
         }
         throw err;
       }
-      const count = Object.keys(installedServers).length;
       console.log(
-        `\x1b[2m[${config.role}]\x1b[0m Merging ${count} installed MCP server(s) into session config`,
+        `\x1b[2m[${config.role}]\x1b[0m Merging ${Object.keys(installedServers).length} installed MCP server(s) into session config`,
       );
     }
 
     // Create per-session MCP config with X-Source-Task-Id header + installed servers (no shared-file race condition)
-    // Pass null (not {}) when no installed servers exist — keeps the existing
-    // "no .mcp.json + no installed servers → skip --mcp-config" behavior.
+    // Normalize {} → null so createSessionMcpConfig keeps its no-op short-circuit.
     const installedForMerge =
       installedServers && Object.keys(installedServers).length > 0 ? installedServers : null;
     const sessionMcpConfig = await createSessionMcpConfig(

--- a/src/tests/claude-adapter-mcp-fetch.test.ts
+++ b/src/tests/claude-adapter-mcp-fetch.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { __test } from "../providers/claude-adapter";
+
+const { fetchInstalledMcpServersForClaude, ClaudeMcpFetchError } = __test;
+
+const realFetch = globalThis.fetch;
+
+interface FetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+function installMockFetch(
+  responder: (call: FetchCall, attempt: number) => Response | Promise<Response>,
+): { calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, init });
+    return responder({ url, init }, calls.length);
+  }) as typeof fetch;
+  return { calls };
+}
+
+describe("claude-adapter fetchInstalledMcpServersForClaude", () => {
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test("returns mapped entries on 200 with active servers", async () => {
+    installMockFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            servers: [
+              {
+                name: "agent-swarm",
+                transport: "http",
+                isActive: true,
+                isEnabled: true,
+                url: "http://api:3013/mcp",
+                headers: JSON.stringify({ Authorization: "Bearer x" }),
+                resolvedHeaders: { "X-Agent-ID": "agent-1" },
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+    );
+
+    const result = await fetchInstalledMcpServersForClaude("http://api:3013", "k", "agent-1");
+    expect(result["agent-swarm"]).toBeDefined();
+    expect(result["agent-swarm"].url).toBe("http://api:3013/mcp");
+    expect((result["agent-swarm"].headers as Record<string, string>)["X-Agent-ID"]).toBe("agent-1");
+    expect(result["agent-swarm"].type).toBe("http");
+  });
+
+  test("returns empty object when API has zero active servers (success, not failure)", async () => {
+    installMockFetch(() => new Response(JSON.stringify({ servers: [] }), { status: 200 }));
+    const result = await fetchInstalledMcpServersForClaude("http://api:3013", "k", "agent-1");
+    expect(result).toEqual({});
+  });
+
+  test("filters out inactive or disabled servers", async () => {
+    installMockFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            servers: [
+              { name: "a", transport: "http", isActive: false, isEnabled: true, url: "http://a" },
+              { name: "b", transport: "http", isActive: true, isEnabled: false, url: "http://b" },
+              { name: "c", transport: "http", isActive: true, isEnabled: true, url: "http://c" },
+            ],
+          }),
+          { status: 200 },
+        ),
+    );
+    const result = await fetchInstalledMcpServersForClaude("http://api:3013", "k", "agent-1");
+    expect(Object.keys(result)).toEqual(["c"]);
+  });
+
+  test("retries on 5xx and succeeds on a later attempt", async () => {
+    const { calls } = installMockFetch((_call, attempt) => {
+      if (attempt < 3) return new Response("upstream error", { status: 502 });
+      return new Response(JSON.stringify({ servers: [] }), { status: 200 });
+    });
+    const result = await fetchInstalledMcpServersForClaude("http://api:3013", "k", "agent-1");
+    expect(result).toEqual({});
+    expect(calls.length).toBe(3);
+  });
+
+  test("throws ClaudeMcpFetchError after exhausting retries on persistent 5xx", async () => {
+    const { calls } = installMockFetch(() => new Response("down", { status: 503 }));
+    let thrown: unknown;
+    try {
+      await fetchInstalledMcpServersForClaude("http://api:3013", "k", "agent-1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ClaudeMcpFetchError);
+    expect((thrown as InstanceType<typeof ClaudeMcpFetchError>).cause.status).toBe(503);
+    expect(calls.length).toBe(3);
+  });
+
+  test("throws immediately on 4xx without retrying", async () => {
+    const { calls } = installMockFetch(() => new Response("forbidden", { status: 403 }));
+    let thrown: unknown;
+    try {
+      await fetchInstalledMcpServersForClaude("http://api:3013", "k", "agent-1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ClaudeMcpFetchError);
+    expect(calls.length).toBe(1);
+  });
+
+  test("throws ClaudeMcpFetchError when fetch itself rejects", async () => {
+    const { calls } = installMockFetch(() => {
+      throw new Error("ECONNREFUSED");
+    });
+    let thrown: unknown;
+    try {
+      await fetchInstalledMcpServersForClaude("http://api:3013", "k", "agent-1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ClaudeMcpFetchError);
+    expect(calls.length).toBe(3);
+  });
+
+  test("sends Authorization and X-Agent-ID headers", async () => {
+    let capturedHeaders: Record<string, string> = {};
+    installMockFetch((call) => {
+      const headers = call.init?.headers as Record<string, string> | undefined;
+      if (headers) capturedHeaders = headers;
+      return new Response(JSON.stringify({ servers: [] }), { status: 200 });
+    });
+    await fetchInstalledMcpServersForClaude("http://api:3013", "secret-key", "agent-42");
+    expect(capturedHeaders.Authorization).toBe("Bearer secret-key");
+    expect(capturedHeaders["X-Agent-ID"]).toBe("agent-42");
+  });
+});

--- a/src/tests/claude-adapter-mcp-fetch.test.ts
+++ b/src/tests/claude-adapter-mcp-fetch.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { __test } from "../providers/claude-adapter";
-
-const { fetchInstalledMcpServersForClaude, ClaudeMcpFetchError } = __test;
+import {
+  ClaudeMcpFetchError,
+  fetchInstalledMcpServersForClaude,
+} from "../providers/claude-adapter";
 
 const realFetch = globalThis.fetch;
 
@@ -98,7 +99,7 @@ describe("claude-adapter fetchInstalledMcpServersForClaude", () => {
       thrown = err;
     }
     expect(thrown).toBeInstanceOf(ClaudeMcpFetchError);
-    expect((thrown as InstanceType<typeof ClaudeMcpFetchError>).cause.status).toBe(503);
+    expect((thrown as ClaudeMcpFetchError).cause.status).toBe(503);
     expect(calls.length).toBe(3);
   });
 


### PR DESCRIPTION
## Summary

Workers were silently spawning Claude Code sessions with **zero swarm tools** when the per-session MCP-servers fetch hit a transient error. Sessions then lived ~50s, called nothing, and the runner auto-completed them with `Process completed successfully (no output captured)`.

### Root cause

A silent-null ladder:

1. `fetchInstalledMcpServers()` in `src/utils/mcp-server-fetcher.ts` returned `null` on **any** non-2xx, thrown error, or empty result — with no logging.
2. `claude-adapter.ts createSession()` accepted that `null` and proceeded to `createSessionMcpConfig()`.
3. With no installed servers and (in the failure path) no usable `.mcp.json`, the session spawned without `--mcp-config`. Even when `.mcp.json` existed, the per-task `X-Source-Task-Id` header injection requires the API-fetched entries — so the swarm tools were silently degraded or missing.

The MCP API (`/api/agents/{id}/mcp-servers`) is healthy in steady state, but transient blips (5xx, brief network hiccups) had no signal and no recovery.

### Fix (scoped to claude-adapter only)

`src/providers/claude-adapter.ts`
- Adds an inline `fetchInstalledMcpServersForClaude()` with 3-attempt retry and exponential backoff (250ms → 500ms) on 5xx / 408 / 425 / 429 / network errors.
- Logs each failed attempt with status + URL path (no auth headers).
- Distinguishes \"no MCP servers configured\" (returns `{}`) from \"fetch failed\" (throws `ClaudeMcpFetchError`).
- `createSession()` catches the typed error and **refuses to spawn** the session, with a clear message naming the task ID. Better to fail visibly than spawn a session that can't `store-progress`.
- Cleans up the task file before throwing so the next attempt starts clean.

The shared `src/utils/mcp-server-fetcher.ts` and the opencode adapter are intentionally untouched — opencode wires the swarm endpoint explicitly and tolerates a missing installed-set, so its behavior is unchanged.

### Tests

New `src/tests/claude-adapter-mcp-fetch.test.ts` covers:
- Successful fetch with active servers
- Empty server list (success, not failure)
- Filter on `isActive` / `isEnabled`
- Retry on 5xx then succeed
- Persistent 5xx → throws after 3 attempts
- 4xx → throws immediately (no retry)
- Network rejection → throws after retries
- Auth headers sent correctly

### Behavior change

Before: a transient API error → silent degraded session → wasted Claude tokens, lost task work.
After: same error → spawn aborted with a loud message → runner can mark the task failed cleanly and retry.