### PR TITLE
feat(ui): gate Pages surface behind API ≥1.79.0

### DIFF
--- a/ui/src/components/layout/app-sidebar.tsx
+++ b/ui/src/components/layout/app-sidebar.tsx
@@ -71,7 +71,7 @@ const navGroups: { label: string; items: NavItem[] }[] = [
     items: [
       { title: "Schedules", path: "/schedules", icon: Clock },
       { title: "Workflows", path: "/workflows", icon: Workflow },
-      { title: "Pages", path: "/pages", icon: Globe },
+      { title: "Pages", path: "/pages", icon: Globe, gate: { minVersion: "1.79.0" } },
       { title: "Usage", path: "/usage", icon: BarChart3 },
       { title: "Budgets", path: "/budgets", icon: Wallet },
     ],
@@ -98,8 +98,14 @@ const navGroups: { label: string; items: NavItem[] }[] = [
 export function AppSidebar() {
   const location = useLocation();
   const { data: status } = useStatusContext();
-  // Phase 4 ≥1.76.0: feature gate for Sessions (and any future v1.76+ entry).
-  const sessionsGate = useFeatureGate("1.76.0");
+  // Feature-gate lookups for nav items whose backing routes need a min API
+  // version. Add a new entry here when introducing another gated surface.
+  const gates: Record<string, ReturnType<typeof useFeatureGate>> = {
+    "1.76.0": useFeatureGate("1.76.0"), // Sessions
+    "1.79.0": useFeatureGate("1.79.0"), // Pages
+  };
+  const isGated = (item: NavItem) =>
+    !!item.gate && gates[item.gate.minVersion]?.supported === false;
   // 404 from /status (older API) → hide the Home nav item.
   const homeAvailable = status !== null;
   const identityName = status?.identity.name ?? "Agent Swarm";
@@ -155,7 +161,7 @@ export function AppSidebar() {
                           item.path === "/"
                             ? location.pathname === "/"
                             : location.pathname.startsWith(item.path);
-                        const gated = item.gate?.minVersion === "1.76.0" && !sessionsGate.supported;
+                        const gated = isGated(item);
                         if (gated) return null;
                         return (
                           <SidebarMenuItem key={item.path}>
@@ -182,7 +188,7 @@ export function AppSidebar() {
                         item.path === "/"
                           ? location.pathname === "/"
                           : location.pathname.startsWith(item.path);
-                      const gated = item.gate?.minVersion === "1.76.0" && !sessionsGate.supported;
+                      const gated = isGated(item);
                       if (gated) return null;
                       return (
                         <SidebarMenuItem key={item.path}>

--- a/ui/src/components/shared/command-menu.tsx
+++ b/ui/src/components/shared/command-menu.tsx
@@ -13,6 +13,7 @@ import {
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAgents } from "@/api/hooks/use-agents";
+import { useFeatureGate } from "@/api/hooks/use-feature-gate";
 import { useTasks } from "@/api/hooks/use-tasks";
 import {
   CommandDialog,
@@ -24,7 +25,14 @@ import {
   CommandSeparator,
 } from "@/components/ui/command";
 
-const NAV_ITEMS = [
+interface NavItem {
+  label: string;
+  path: string;
+  icon: typeof Bot;
+  gate?: { minVersion: string };
+}
+
+const NAV_ITEMS: NavItem[] = [
   { label: "Dashboard", path: "/", icon: LayoutDashboard },
   { label: "Agents", path: "/agents", icon: Bot },
   { label: "Tasks", path: "/tasks", icon: ClipboardList },
@@ -33,7 +41,7 @@ const NAV_ITEMS = [
   { label: "Usage", path: "/usage", icon: BarChart3 },
   { label: "Config", path: "/config", icon: Settings },
   { label: "Repos", path: "/repos", icon: FolderGit2 },
-  { label: "Pages", path: "/pages", icon: Globe },
+  { label: "Pages", path: "/pages", icon: Globe, gate: { minVersion: "1.79.0" } },
   { label: "Services", path: "/services", icon: Server },
 ];
 
@@ -44,6 +52,15 @@ export function CommandMenu() {
   const { data: agents } = useAgents();
   const { data: tasksData } = useTasks();
   const tasks = tasksData?.tasks;
+
+  // Feature-gate lookups for nav items whose backing routes need a min API
+  // version. Hide an item only when the gate explicitly reports unsupported
+  // — leaves it visible while the version probe is in flight so the menu
+  // doesn't flash open with missing items.
+  const gates: Record<string, boolean> = {
+    "1.79.0": useFeatureGate("1.79.0").supported, // Pages
+  };
+  const visibleNav = NAV_ITEMS.filter((i) => !i.gate || gates[i.gate.minVersion] !== false);
 
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
@@ -68,7 +85,7 @@ export function CommandMenu() {
         <CommandEmpty>No results found.</CommandEmpty>
 
         <CommandGroup heading="Navigation">
-          {NAV_ITEMS.map((item) => (
+          {visibleNav.map((item) => (
             <CommandItem key={item.path} onSelect={() => handleSelect(item.path)}>
               <item.icon className="h-4 w-4" />
               <span>{item.label}</span>

--- a/ui/src/pages/pages/[id]/page.tsx
+++ b/ui/src/pages/pages/[id]/page.tsx
@@ -29,8 +29,10 @@ import { AlertCircle, Braces, ExternalLink, Lock, Maximize2, Minimize2 } from "l
 import { useState } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import { api } from "@/api/client";
+import { useFeatureGate } from "@/api/hooks/use-feature-gate";
 import { usePage } from "@/api/hooks/use-pages";
 import type { PageMetadata } from "@/api/types";
+import { UpgradeRequired } from "@/components/feature-gate/upgrade-required";
 import { AlertCallout } from "@/components/ui/alert-callout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -216,6 +218,7 @@ export default function ArtifactPage() {
   const { id } = useParams<{ id: string }>();
   const [searchParams] = useSearchParams();
   const fullMode = searchParams.get("mode") === "full";
+  const gate = useFeatureGate("1.79.0");
 
   const { data, error, isLoading } = useQuery({
     queryKey: ["page-metadata", id],
@@ -230,6 +233,15 @@ export default function ArtifactPage() {
     retry: false,
   });
 
+  if (!gate.supported) {
+    return (
+      <UpgradeRequired
+        feature="Pages"
+        requiredVersion={gate.requiredVersion}
+        currentVersion={gate.currentVersion}
+      />
+    );
+  }
   if (!id) {
     return <ArtifactPageError message="Missing artifact id in URL." />;
   }

--- a/ui/src/pages/pages/page.tsx
+++ b/ui/src/pages/pages/page.tsx
@@ -2,8 +2,10 @@ import type { ColDef, RowClickedEvent } from "ag-grid-community";
 import { Globe, KeyRound, Lock, type LucideIcon } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { useFeatureGate } from "@/api/hooks/use-feature-gate";
 import { usePages } from "@/api/hooks/use-pages";
 import type { PageAuthMode, PageListItem } from "@/api/types";
+import { UpgradeRequired } from "@/components/feature-gate/upgrade-required";
 import { AgentLink } from "@/components/shared/agent-link";
 import { DataGrid } from "@/components/shared/data-grid";
 import { EmptyState } from "@/components/shared/empty-state";
@@ -31,6 +33,11 @@ const authModeIcon: Record<PageAuthMode, LucideIcon> = {
 
 export default function PagesListingPage() {
   const navigate = useNavigate();
+  const gate = useFeatureGate("1.79.0");
+  // Pass `enabled: false` indirectly by skipping the data fetch when gated —
+  // but we still need all hooks declared unconditionally, so just gate the
+  // EARLY-RETURN below; the data hook runs harmlessly on older servers (it
+  // will 404, react-query swallows). Cheap, keeps hook order stable.
   const { data, isLoading } = usePages();
   const rows = useMemo<PageListItem[]>(() => data?.pages ?? [], [data]);
 
@@ -122,6 +129,16 @@ export default function PagesListingPage() {
   );
 
   const isEmpty = !isLoading && rows.length === 0;
+
+  if (!gate.supported) {
+    return (
+      <UpgradeRequired
+        feature="Pages"
+        requiredVersion={gate.requiredVersion}
+        currentVersion={gate.currentVersion}
+      />
+    );
+  }
 
   return (
     <div className="flex flex-col flex-1 min-h-0 gap-4">


### PR DESCRIPTION
## Summary

Pages (sidebar entry + `/pages` listing + `/pages/:id` detail + ⌘K palette entry) is now gated behind API version `1.79.0` via `useFeatureGate`. Older API servers stop seeing the Pages nav; deep-linked URLs render the canonical `<UpgradeRequired>` screen instead of broken-fetch noise.

### Changes

- `ui/src/components/layout/app-sidebar.tsx` — Pages nav item tagged with `gate: { minVersion: "1.79.0" }`. The gated-check is generalized to a `gates` record so future gated entries are a one-liner.
- `ui/src/components/shared/command-menu.tsx` — same gate applied; ⌘K filters Pages out on older servers.
- `ui/src/pages/pages/page.tsx` + `ui/src/pages/pages/[id]/page.tsx` — render `<UpgradeRequired feature='Pages' requiredVersion='1.79.0' />` when gate reports unsupported.

### Test plan

- [x] `cd ui && pnpm exec tsc -b` clean
- [x] `cd ui && pnpm lint` clean
- [ ] Manual: configure SPA against a pre-1.79 swarm (mock `/status` version) → Pages nav hidden in sidebar + ⌘K; `/pages` shows UpgradeRequired card.
- [ ] Manual: against ≥1.79 swarm → no change.