### PR TITLE
fix(utils): opus 4.7 context window size report

### DIFF
--- a/src/tests/context-window.test.ts
+++ b/src/tests/context-window.test.ts
@@ -3,6 +3,7 @@ import { computeContextUsed, getContextWindowSize } from "../utils/context-windo
 
 describe("getContextWindowSize", () => {
   test("returns 1M for opus models", () => {
+    expect(getContextWindowSize("claude-opus-4-7")).toBe(1_000_000);
     expect(getContextWindowSize("claude-opus-4-6")).toBe(1_000_000);
     expect(getContextWindowSize("opus")).toBe(1_000_000);
   });

--- a/src/utils/context-window.ts
+++ b/src/utils/context-window.ts
@@ -5,6 +5,7 @@
  */
 
 const CONTEXT_WINDOW_DEFAULTS: Record<string, number> = {
+  "claude-opus-4-7": 1_000_000,
   "claude-opus-4-6": 1_000_000,
   "claude-sonnet-4-6": 1_000_000,
   "claude-haiku-4-5": 200_000,


### PR DESCRIPTION
## Summary
- Adds `claude-opus-4-7` to the `CONTEXT_WINDOW_DEFAULTS` map with a 1M-token context window, matching the existing Opus 4.6 entry.
- Extends the existing context-window unit test to cover the new model ID.

## Why
Without this entry, `getContextWindowSize("claude-opus-4-7")` falls back to the default and misreports usage for Opus 4.7 agents. Causes:
- Incorrect/unnecessary context warning stop hook
- Misleading context usage display in the UI

### Before
<img width="366" height="612" alt="Screenshot 2026-05-14 at 18 34 35" src="https://github.com/user-attachments/assets/02895809-4a3c-42f1-9ad9-4e0ea5d1be87" />

<img width="1354" height="496" alt="Screenshot 2026-05-14 at 20 46 59" src="https://github.com/user-attachments/assets/e7e655c2-2df4-4956-9dfa-17ee948b560a" />

### After (built locally)
#### In-progress
<img width="821" height="549" alt="Screenshot 2026-05-14 at 22 20 39" src="https://github.com/user-attachments/assets/1748a48c-ba4a-4a9e-bd5e-930634f9e37c" />

#### Completed
<img width="565" height="909" alt="Screenshot 2026-05-14 at 22 24 16" src="https://github.com/user-attachments/assets/b9f1497b-dde2-41a8-9e31-168f12abb335" />
