### PR TITLE
fix(runner): capture `rate_limit_event` for resilient 5h cooldown

### DIFF
--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -2677,15 +2677,35 @@ async function checkCompletedProcesses(
           credentialInfo &&
           /rate.?limit|hit your limit|usage[ _-]?limit|too many requests/i.test(failureReason)
         ) {
-          // Try to extract reset time from the error message (e.g. "resets 3pm (UTC)")
-          const parsedResetTime = parseRateLimitResetTime(failureReason);
-          const defaultCooldownMs = 5 * 60 * 1000;
-          const rateLimitedUntil =
-            parsedResetTime ?? new Date(Date.now() + defaultCooldownMs).toISOString();
-          if (parsedResetTime) {
+          // Three-tier reset-time resolver (most to least precise):
+          // Tier 1: structured rate_limit_event from Claude CLI (resetsAt epoch sec)
+          // Tier 2: regex on the error message (e.g. "resets 3pm (UTC)")
+          // Tier 3: 5-min hard fallback — only when both structured and regex fail
+          // Tiers 1 & 2 are clamped to [now+60s, now+6h] at their source.
+          const clampResetTime = (isoString: string): string => {
+            const nowMs = Date.now();
+            const minMs = nowMs + 60_000;
+            const maxMs = nowMs + 6 * 60 * 60 * 1000;
+            const candidateMs = new Date(isoString).getTime();
+            return new Date(Math.min(Math.max(candidateMs, minMs), maxMs)).toISOString();
+          };
+
+          let rateLimitedUntil: string;
+          if (result.rateLimitResetAt) {
+            rateLimitedUntil = clampResetTime(result.rateLimitResetAt);
             console.log(
-              `[credentials] Parsed rate limit reset time from error: ${parsedResetTime}`,
+              `[credentials] Rate limit reset from rate_limit_event: ${rateLimitedUntil}`,
             );
+          } else {
+            const parsedResetTime = parseRateLimitResetTime(failureReason);
+            if (parsedResetTime) {
+              rateLimitedUntil = clampResetTime(parsedResetTime);
+              console.log(
+                `[credentials] Parsed rate limit reset time from error: ${rateLimitedUntil}`,
+              );
+            } else {
+              rateLimitedUntil = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+            }
           }
           reportKeyRateLimit(
             apiConfig.apiUrl,

--- a/src/providers/claude-adapter.ts
+++ b/src/providers/claude-adapter.ts
@@ -458,6 +458,7 @@ class ClaudeSession implements ProviderSession {
       cost: lastCost,
       isError: (exitCode ?? 1) !== 0,
       failureReason,
+      rateLimitResetAt: this.errorTracker.getRateLimitResetAt(),
     };
   }
 

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -116,6 +116,14 @@ export interface ProviderResult {
   errorCategory?: string;
   /** Human-readable failure reason built from error tracking. */
   failureReason?: string;
+  /**
+   * ISO timestamp of the rate limit reset time, parsed from a structured
+   * `rate_limit_event` line in the Claude CLI stream. Only set by the Claude
+   * adapter when a `status: "rejected"` event is present. Already clamped to
+   * [now+60s, now+6h] at the source. The runner uses this as tier-1 of the
+   * three-tier cooldown resolver.
+   */
+  rateLimitResetAt?: string;
 }
 
 /** Behavioral traits that govern prompt assembly and feature gating. */

--- a/src/tests/error-tracker.test.ts
+++ b/src/tests/error-tracker.test.ts
@@ -6,6 +6,38 @@ import {
   trackErrorFromJson,
 } from "../utils/error-tracker";
 
+describe("SessionErrorTracker — getRateLimitResetAt", () => {
+  test("returns undefined when no rate_limit_event was processed", () => {
+    const tracker = new SessionErrorTracker();
+    expect(tracker.getRateLimitResetAt()).toBeUndefined();
+  });
+
+  test("returns ISO string after a rejected rate_limit_event", () => {
+    const tracker = new SessionErrorTracker();
+    const futureResetsAtSec = Math.floor(Date.now() / 1000) + 3600;
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "rejected", resetsAt: futureResetsAtSec },
+    });
+    const result = tracker.getRateLimitResetAt();
+    expect(result).toBeDefined();
+    expect(() => new Date(result!).toISOString()).not.toThrow();
+  });
+
+  test("returns undefined after only allowed/allowed_warning events", () => {
+    const tracker = new SessionErrorTracker();
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "allowed", resetsAt: 1779202200 },
+    });
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "allowed_warning", resetsAt: 1779202200 },
+    });
+    expect(tracker.getRateLimitResetAt()).toBeUndefined();
+  });
+});
+
 describe("SessionErrorTracker", () => {
   test("hasErrors returns false when no errors tracked", () => {
     const tracker = new SessionErrorTracker();
@@ -261,6 +293,18 @@ describe("trackErrorFromJson", () => {
   test("ignores unrelated event types", () => {
     const tracker = new SessionErrorTracker();
     trackErrorFromJson({ type: "content_block_delta", delta: {} }, tracker);
+    expect(tracker.hasErrors()).toBe(false);
+  });
+
+  test("rate_limit_event is not treated as an error signal", () => {
+    const tracker = new SessionErrorTracker();
+    trackErrorFromJson(
+      {
+        type: "rate_limit_event",
+        rate_limit_info: { status: "rejected", resetsAt: 1779202200 },
+      },
+      tracker,
+    );
     expect(tracker.hasErrors()).toBe(false);
   });
 });

--- a/src/tests/rate-limit-event.test.ts
+++ b/src/tests/rate-limit-event.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test } from "bun:test";
+import { SessionErrorTracker, trackErrorFromJson } from "../utils/error-tracker";
+
+// Verbatim fixture from Linear CAI-1279 (session logs for task b7fbbdb9-4922-41d9-88ec-21febd6c4fec)
+const FIXTURE_REJECTED = {
+  type: "rate_limit_event",
+  rate_limit_info: {
+    status: "rejected",
+    resetsAt: 1779202200, // seconds since epoch — 2026-05-19T14:50:00Z
+    rateLimitType: "five_hour",
+    overageStatus: "rejected",
+    overageDisabledReason: "group_zero_credit_limit",
+    isUsingOverage: false,
+  },
+  uuid: "ff6e5299-429c-4fcb-ab34-0ce4e8fa6202",
+  session_id: "69dbe5a1-1130-45eb-983f-58a7a13c9c3c",
+};
+
+describe("SessionErrorTracker — rate_limit_event processing", () => {
+  test("stashes resetsAt (seconds) correctly as ms — verbatim CAI-1279 fixture", () => {
+    const tracker = new SessionErrorTracker();
+    tracker.processRateLimitEvent(FIXTURE_REJECTED);
+
+    const result = tracker.getRateLimitResetAt();
+    expect(result).toBeDefined();
+
+    // resetsAt: 1779202200 sec → 2026-05-19T14:50:00.000Z
+    // But since we clamp to [now+60s, now+6h] and this is a past timestamp,
+    // the value will be clamped to now+60s. What matters is the sec→ms conversion works.
+    // We verify the unit is correct by checking that 1779202200 * 1000 = ms,
+    // which is NOT the same as treating it as ms (would be 1970-01-21).
+    const parsedMs = new Date(result!).getTime();
+    const nowMs = Date.now();
+    expect(parsedMs).toBeGreaterThanOrEqual(nowMs + 59_000); // clamped to at least now+60s
+    expect(parsedMs).toBeLessThanOrEqual(nowMs + 7 * 60 * 60 * 1000); // not absurdly far
+  });
+
+  test("resetsAt treated as seconds, not milliseconds (unit conversion boundary)", () => {
+    const tracker = new SessionErrorTracker();
+    // A future resetsAt value (in seconds) — 1 hour from now
+    const oneHourFromNowSec = Math.floor(Date.now() / 1000) + 3600;
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: {
+        status: "rejected",
+        resetsAt: oneHourFromNowSec,
+      },
+    });
+
+    const result = tracker.getRateLimitResetAt();
+    expect(result).toBeDefined();
+
+    const parsedMs = new Date(result!).getTime();
+    const nowMs = Date.now();
+    // Should be ~1h from now (not 1970 if treated as ms, not year 57,000 if multiplied wrong)
+    expect(parsedMs).toBeGreaterThanOrEqual(nowMs + 50 * 60_000); // at least 50 min from now
+    expect(parsedMs).toBeLessThanOrEqual(nowMs + 70 * 60_000); // at most 70 min from now
+  });
+
+  test("status: rejected → stashes resetsAt", () => {
+    const tracker = new SessionErrorTracker();
+    const futureResetsAtSec = Math.floor(Date.now() / 1000) + 3600;
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "rejected", resetsAt: futureResetsAtSec },
+    });
+    expect(tracker.getRateLimitResetAt()).toBeDefined();
+  });
+
+  test("status: allowed → does NOT stash (no cooldown needed)", () => {
+    const tracker = new SessionErrorTracker();
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "allowed", resetsAt: 1779202200 },
+    });
+    expect(tracker.getRateLimitResetAt()).toBeUndefined();
+  });
+
+  test("status: allowed_warning → does NOT stash", () => {
+    const tracker = new SessionErrorTracker();
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "allowed_warning", resetsAt: 1779202200 },
+    });
+    expect(tracker.getRateLimitResetAt()).toBeUndefined();
+  });
+
+  test("malformed event (missing rate_limit_info) → does NOT stash, no throw", () => {
+    const tracker = new SessionErrorTracker();
+    tracker.processRateLimitEvent({ type: "rate_limit_event" });
+    expect(tracker.getRateLimitResetAt()).toBeUndefined();
+  });
+
+  test("malformed event (resetsAt is string) → does NOT stash, no throw", () => {
+    const tracker = new SessionErrorTracker();
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "rejected", resetsAt: "not-a-number" },
+    });
+    expect(tracker.getRateLimitResetAt()).toBeUndefined();
+  });
+
+  test("malformed event (resetsAt is negative) → does NOT stash", () => {
+    const tracker = new SessionErrorTracker();
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "rejected", resetsAt: -1 },
+    });
+    expect(tracker.getRateLimitResetAt()).toBeUndefined();
+  });
+
+  test("resetsAt already in the past → clamped to now+60s (clock skew defense)", () => {
+    const tracker = new SessionErrorTracker();
+    // Use a known-past timestamp (year 2020)
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "rejected", resetsAt: 1577836800 }, // 2020-01-01T00:00:00Z
+    });
+
+    const result = tracker.getRateLimitResetAt();
+    expect(result).toBeDefined();
+    const parsedMs = new Date(result!).getTime();
+    const nowMs = Date.now();
+    expect(parsedMs).toBeGreaterThanOrEqual(nowMs + 59_000);
+    expect(parsedMs).toBeLessThanOrEqual(nowMs + 65_000);
+  });
+
+  test("resetsAt absurdly far in future → clamped to now+6h (malformed defense)", () => {
+    const tracker = new SessionErrorTracker();
+    // Year 2099 in seconds
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "rejected", resetsAt: 4102444800 }, // 2100-01-01 in seconds
+    });
+
+    const result = tracker.getRateLimitResetAt();
+    expect(result).toBeDefined();
+    const parsedMs = new Date(result!).getTime();
+    const nowMs = Date.now();
+    const sixHoursMs = 6 * 60 * 60 * 1000;
+    expect(parsedMs).toBeLessThanOrEqual(nowMs + sixHoursMs + 1000); // within 6h (+1s tolerance)
+  });
+
+  test("multiple rate_limit_event lines → last rejected one wins", () => {
+    const tracker = new SessionErrorTracker();
+    const firstResetsAtSec = Math.floor(Date.now() / 1000) + 1800; // 30 min from now
+    const secondResetsAtSec = Math.floor(Date.now() / 1000) + 3600; // 60 min from now
+
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "rejected", resetsAt: firstResetsAtSec },
+    });
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "rejected", resetsAt: secondResetsAtSec },
+    });
+
+    const result = tracker.getRateLimitResetAt();
+    expect(result).toBeDefined();
+    const parsedMs = new Date(result!).getTime();
+    const nowMs = Date.now();
+    // Should reflect the SECOND event (~60 min), not the first (~30 min)
+    expect(parsedMs).toBeGreaterThanOrEqual(nowMs + 55 * 60_000);
+    expect(parsedMs).toBeLessThanOrEqual(nowMs + 65 * 60_000);
+  });
+
+  test("allowed event between two rejected events → last rejected wins", () => {
+    const tracker = new SessionErrorTracker();
+    const firstSec = Math.floor(Date.now() / 1000) + 1800;
+    const secondSec = Math.floor(Date.now() / 1000) + 3600;
+
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "rejected", resetsAt: firstSec },
+    });
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "allowed", resetsAt: 9999999999 }, // should be ignored
+    });
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "rejected", resetsAt: secondSec },
+    });
+
+    const result = tracker.getRateLimitResetAt();
+    expect(result).toBeDefined();
+    const parsedMs = new Date(result!).getTime();
+    const nowMs = Date.now();
+    // Should reflect the third (second rejected) event (~60 min)
+    expect(parsedMs).toBeGreaterThanOrEqual(nowMs + 55 * 60_000);
+    expect(parsedMs).toBeLessThanOrEqual(nowMs + 65 * 60_000);
+  });
+
+  test("no rate_limit_event at all → getRateLimitResetAt returns undefined", () => {
+    const tracker = new SessionErrorTracker();
+    expect(tracker.getRateLimitResetAt()).toBeUndefined();
+  });
+});
+
+describe("trackErrorFromJson — rate_limit_event routing", () => {
+  test("routes rate_limit_event to processRateLimitEvent, stashes reset time", () => {
+    const tracker = new SessionErrorTracker();
+    const futureResetsAtSec = Math.floor(Date.now() / 1000) + 3600;
+
+    trackErrorFromJson(
+      {
+        type: "rate_limit_event",
+        rate_limit_info: { status: "rejected", resetsAt: futureResetsAtSec },
+      },
+      tracker,
+    );
+
+    expect(tracker.getRateLimitResetAt()).toBeDefined();
+    // rate_limit_event itself is NOT an error signal — it's informational
+    expect(tracker.hasErrors()).toBe(false);
+  });
+
+  test("rate_limit_event with allowed status → no reset stashed, no errors", () => {
+    const tracker = new SessionErrorTracker();
+    trackErrorFromJson(
+      {
+        type: "rate_limit_event",
+        rate_limit_info: { status: "allowed", resetsAt: 1779202200 },
+      },
+      tracker,
+    );
+
+    expect(tracker.getRateLimitResetAt()).toBeUndefined();
+    expect(tracker.hasErrors()).toBe(false);
+  });
+
+  test("rate_limit_event does not block subsequent event processing", () => {
+    const tracker = new SessionErrorTracker();
+    const futureResetsAtSec = Math.floor(Date.now() / 1000) + 3600;
+
+    trackErrorFromJson(
+      {
+        type: "rate_limit_event",
+        rate_limit_info: { status: "rejected", resetsAt: futureResetsAtSec },
+      },
+      tracker,
+    );
+    trackErrorFromJson(
+      { type: "result", is_error: true, result: "Your group's usage limit is set to $0" },
+      tracker,
+    );
+
+    expect(tracker.getRateLimitResetAt()).toBeDefined();
+    expect(tracker.hasErrors()).toBe(true);
+  });
+});
+
+describe("three-tier resolver logic (unit test via clamp helper)", () => {
+  // Mirrors the clampResetTime inline helper in runner.ts
+  function clampResetTime(isoString: string): string {
+    const nowMs = Date.now();
+    const minMs = nowMs + 60_000;
+    const maxMs = nowMs + 6 * 60 * 60 * 1000;
+    const candidateMs = new Date(isoString).getTime();
+    return new Date(Math.min(Math.max(candidateMs, minMs), maxMs)).toISOString();
+  }
+
+  test("tier 1: rateLimitResetAt from structured event → used directly (after clamp)", () => {
+    const futureResetsAtSec = Math.floor(Date.now() / 1000) + 3600;
+    const tracker = new SessionErrorTracker();
+    tracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "rejected", resetsAt: futureResetsAtSec },
+    });
+
+    const rateLimitResetAt = tracker.getRateLimitResetAt();
+    expect(rateLimitResetAt).toBeDefined();
+
+    // Simulate tier-1 branch: result.rateLimitResetAt is set
+    const rateLimitedUntil = clampResetTime(rateLimitResetAt!);
+    expect(rateLimitedUntil).toBeDefined();
+    const resolvedMs = new Date(rateLimitedUntil).getTime();
+    const nowMs = Date.now();
+    expect(resolvedMs).toBeGreaterThanOrEqual(nowMs + 59_000);
+  });
+
+  test("tier 3 fallback: no structured event, no parseable message → 5-min default", () => {
+    // Simulate: rateLimitResetAt is undefined, parseRateLimitResetTime returns undefined
+    const defaultCooldownMs = 5 * 60 * 1000;
+    const rateLimitedUntil = new Date(Date.now() + defaultCooldownMs).toISOString();
+
+    const resolvedMs = new Date(rateLimitedUntil).getTime();
+    const nowMs = Date.now();
+    expect(resolvedMs).toBeGreaterThanOrEqual(nowMs + 4 * 60_000);
+    expect(resolvedMs).toBeLessThanOrEqual(nowMs + 6 * 60_000);
+  });
+});

--- a/src/utils/error-tracker.ts
+++ b/src/utils/error-tracker.ts
@@ -10,8 +10,21 @@ export interface ErrorSignal {
   timestamp: string;
 }
 
+/**
+ * Clamps a candidate reset timestamp (ms) to [now+60s, now+6h].
+ * Protects against past timestamps (clock skew) and absurdly far future values (malformed).
+ */
+function clampRateLimitResetMs(candidateMs: number): number {
+  const nowMs = Date.now();
+  const minMs = nowMs + 60_000;
+  const maxMs = nowMs + 6 * 60 * 60 * 1000;
+  return Math.min(Math.max(candidateMs, minMs), maxMs);
+}
+
 export class SessionErrorTracker {
   private errors: ErrorSignal[] = [];
+  /** Stashed reset time (ms) from the last rejected rate_limit_event in this session. */
+  private rateLimitResetAtMs: number | undefined;
 
   /** Record an error from an assistant message with message.error field */
   addApiError(errorCategory: string, message: string): void {
@@ -51,6 +64,45 @@ export class SessionErrorTracker {
       message,
       timestamp: new Date().toISOString(),
     });
+  }
+
+  /**
+   * Process a parsed rate_limit_event JSON object from the Claude CLI stream.
+   * Only stashes the reset time when status === "rejected"; ignores all others.
+   * Last call wins — if the CLI emits multiple events, the final rejected one is used.
+   *
+   * `resetsAt` is **seconds** since epoch (empirically verified; Linear description is wrong).
+   * Conversion to ms happens here at this single well-named boundary.
+   */
+  processRateLimitEvent(json: Record<string, unknown>): void {
+    try {
+      const info = json.rate_limit_info as Record<string, unknown> | undefined;
+      if (!info) return;
+
+      if (info.status !== "rejected") return;
+
+      const resetsAtSec = info.resetsAt;
+      if (typeof resetsAtSec !== "number" || !Number.isFinite(resetsAtSec) || resetsAtSec <= 0) {
+        console.warn(
+          `[rate_limit_event] Malformed resetsAt value: ${JSON.stringify(resetsAtSec)} — ignoring`,
+        );
+        return;
+      }
+
+      const resetsAtMs = resetsAtSec * 1000;
+      this.rateLimitResetAtMs = clampRateLimitResetMs(resetsAtMs);
+    } catch (err) {
+      console.warn(`[rate_limit_event] Failed to process event: ${err}`);
+    }
+  }
+
+  /**
+   * Returns the stashed rate limit reset time as an ISO string, or undefined
+   * if no rejected rate_limit_event was seen in this session.
+   */
+  getRateLimitResetAt(): string | undefined {
+    if (this.rateLimitResetAtMs === undefined) return undefined;
+    return new Date(this.rateLimitResetAtMs).toISOString();
   }
 
   hasErrors(): boolean {
@@ -137,6 +189,12 @@ export function trackErrorFromJson(
   json: Record<string, unknown>,
   tracker: SessionErrorTracker,
 ): void {
+  // 0. Structured rate limit event — stash resetsAt for the three-tier resolver in runner.ts
+  if (json.type === "rate_limit_event") {
+    tracker.processRateLimitEvent(json);
+    return;
+  }
+
   // 1. Assistant messages with API errors (rate_limit, auth, billing, etc.)
   if (json.type === "assistant") {
     const message = json.message as Record<string, unknown> | undefined;


### PR DESCRIPTION
The Claude CLI emits a structured `rate_limit_event` JSONL line with `resetsAt` (epoch seconds) before the failing `result` line. We were ignoring it, causing `parseRateLimitResetTime` to return undefined on "Your group's usage limit is set to $0" and falling back to a 5-min cooldown — too short for a 5-hour session-bucket exhaustion, creating a dispatch/instant-fail loop.

Three-tier resolver in runner.ts:
  1. Structured `rate_limit_event.resetsAt` (most precise — direct from CLI)
  2. Regex `parseRateLimitResetTime` (legacy: "resets 3pm UTC" pattern)
  3. 5-min hard fallback (only when both structured and regex fail)

Tiers 1 & 2 clamped to [now+60s, now+6h] to guard against clock skew and malformed future timestamps.

`resetsAt` is **seconds** since epoch (verified empirically across 20 historical session_logs rows — Linear description claiming ms is wrong). Conversion at one well-named boundary: `resetsAtSec * 1000 = resetsAtMs`.

Files touched:
- src/utils/error-tracker.ts: add processRateLimitEvent + getRateLimitResetAt
- src/providers/types.ts: add optional rateLimitResetAt to ProviderResult
- src/providers/claude-adapter.ts: wire errorTracker.getRateLimitResetAt()
- src/commands/runner.ts: three-tier resolver at rate-limit detection site
- src/tests/rate-limit-event.test.ts: 18 new tests with verbatim CAI-1279 fixture
- src/tests/error-tracker.test.ts: 4 additional tests for new methods
