### PR TITLE
feat(ui): filter sessions list by active user

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7358,6 +7358,15 @@
             "required": false,
             "name": "q",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": false,
+            "name": "requestedByUserId",
+            "in": "query"
           }
         ],
         "responses": {

--- a/src/be/db.ts
+++ b/src/be/db.ts
@@ -9110,11 +9110,14 @@ export function listRecentSessions(opts?: {
   source?: string[];
   /** Case-insensitive substring match against `r.task`. */
   q?: string;
+  /** When set, restrict to root tasks where `requestedByUserId` equals this value. NULL rows are excluded. */
+  requestedByUserId?: string;
 }): SessionListItem[] {
   const limit = opts?.limit ?? 25;
   const offset = opts?.offset ?? 0;
   const sources = opts?.source?.filter((s) => s.length > 0) ?? [];
   const q = opts?.q?.trim();
+  const requestedByUserId = opts?.requestedByUserId?.trim() || undefined;
 
   const conditions: string[] = ["r.parentTaskId IS NULL"];
   const params: (string | number)[] = [];
@@ -9126,6 +9129,10 @@ export function listRecentSessions(opts?: {
   if (q && q.length > 0) {
     conditions.push("lower(r.task) LIKE ?");
     params.push(`%${q.toLowerCase()}%`);
+  }
+  if (requestedByUserId) {
+    conditions.push("r.requestedByUserId = ?");
+    params.push(requestedByUserId);
   }
   params.push(limit, offset);
 

--- a/src/http/sessions.ts
+++ b/src/http/sessions.ts
@@ -19,6 +19,12 @@ const listSessions = route({
     source: z.string().optional(),
     /** Case-insensitive substring match against the root task's text. */
     q: z.string().optional(),
+    /**
+     * When present, restrict results to root tasks where
+     * `agent_tasks.requestedByUserId` equals this value. NULL rows are
+     * excluded. Omit to return every session (legacy / non-UI callers).
+     */
+    requestedByUserId: z.string().min(1).optional(),
   }),
   responses: {
     200: { description: "Recent sessions ordered by chain-wide last activity" },
@@ -64,6 +70,7 @@ export async function handleSessions(
       offset: parsed.query.offset,
       source: sources,
       q: parsed.query.q,
+      requestedByUserId: parsed.query.requestedByUserId,
     });
     json(res, { sessions });
     return true;

--- a/src/tests/sessions.test.ts
+++ b/src/tests/sessions.test.ts
@@ -4,6 +4,7 @@ import {
   closeDb,
   createAgent,
   createTaskExtended,
+  createUser,
   getRootTaskChain,
   initDb,
   listRecentSessions,
@@ -137,5 +138,57 @@ describe("sessions — getRootTaskChain + listRecentSessions", () => {
     for (let i = 1; i < sessions.length; i++) {
       expect(sessions[i - 1].lastActivityAt >= sessions[i].lastActivityAt).toBe(true);
     }
+  });
+
+  test("listRecentSessions — requestedByUserId filter: positive / negative / NULL exclusion / compat", () => {
+    const userA = createUser({ name: "Test User A" });
+    const userB = createUser({ name: "Test User B" });
+
+    const agent = createAgent({
+      id: "sessions-test-agent-user-filter",
+      name: "Sessions Test Agent UserFilter",
+      isLead: false,
+      status: "idle",
+    });
+    createTaskExtended("user-a session 1", {
+      agentId: agent.id,
+      requestedByUserId: userA.id,
+    });
+    createTaskExtended("user-a session 2", {
+      agentId: agent.id,
+      requestedByUserId: userA.id,
+    });
+    createTaskExtended("user-b session 1", {
+      agentId: agent.id,
+      requestedByUserId: userB.id,
+    });
+
+    // Positive: user A sees only their own sessions
+    const aOnly = listRecentSessions({ limit: 50, requestedByUserId: userA.id });
+    const aTasks = aOnly.map((s) => s.root.task);
+    expect(aTasks).toContain("user-a session 1");
+    expect(aTasks).toContain("user-a session 2");
+    expect(aTasks).not.toContain("user-b session 1");
+    for (const s of aOnly) {
+      expect(s.root.requestedByUserId).toBe(userA.id);
+    }
+
+    // Negative: user A cannot see user B's sessions
+    const hasUserBInA = aOnly.some((s) => s.root.requestedByUserId === userB.id);
+    expect(hasUserBInA).toBe(false);
+
+    // NULL exclusion: NULL requestedByUserId rows excluded when filter is active
+    const hasNullInA = aOnly.some((s) => s.root.requestedByUserId == null);
+    expect(hasNullInA).toBe(false);
+
+    // Empty: unknown user ID returns empty list
+    const nobody = listRecentSessions({ limit: 50, requestedByUserId: "non-existent-user-id" });
+    expect(nobody).toHaveLength(0);
+
+    // Compat: no filter returns all sessions including NULL rows and both users
+    const all = listRecentSessions({ limit: 100 });
+    expect(all.some((s) => s.root.requestedByUserId == null)).toBe(true);
+    expect(all.some((s) => s.root.requestedByUserId === userA.id)).toBe(true);
+    expect(all.some((s) => s.root.requestedByUserId === userB.id)).toBe(true);
   });
 });

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -1727,12 +1727,15 @@ class ApiClient {
     source?: string[];
     /** Case-insensitive substring match against the root task's text. */
     q?: string;
+    /** When set, restrict results to sessions owned by this user. NULL rows are excluded. */
+    requestedByUserId?: string;
   }): Promise<SessionListItem[]> {
     const params = new URLSearchParams();
     if (opts?.limit != null) params.set("limit", String(opts.limit));
     if (opts?.offset != null) params.set("offset", String(opts.offset));
     if (opts?.source && opts.source.length > 0) params.set("source", opts.source.join(","));
     if (opts?.q && opts.q.length > 0) params.set("q", opts.q);
+    if (opts?.requestedByUserId) params.set("requestedByUserId", opts.requestedByUserId);
     const qs = params.toString();
     const url = `${this.getBaseUrl()}/api/sessions${qs ? `?${qs}` : ""}`;
     const res = await fetch(url, { headers: this.getHeaders() });

--- a/ui/src/api/hooks/use-sessions.ts
+++ b/ui/src/api/hooks/use-sessions.ts
@@ -22,6 +22,10 @@ export interface UseSessionsOptions {
   source?: string[];
   /** Case-insensitive substring search against the root task's text. */
   q?: string;
+  /** When set, restrict results to sessions owned by this user. */
+  requestedByUserId?: string;
+  /** Disable the query entirely (e.g. when user identity is not yet resolved). */
+  enabled?: boolean;
 }
 
 export function useSessions(options?: UseSessionsOptions) {
@@ -29,9 +33,12 @@ export function useSessions(options?: UseSessionsOptions) {
   const offset = options?.offset;
   const source = options?.source;
   const q = options?.q;
+  const requestedByUserId = options?.requestedByUserId;
+  const enabled = options?.enabled ?? true;
   return useQuery({
-    queryKey: ["sessions", { limit, offset, source, q }],
-    queryFn: () => api.listSessions({ limit, offset, source, q }),
+    queryKey: ["sessions", { limit, offset, source, q, requestedByUserId }],
+    queryFn: () => api.listSessions({ limit, offset, source, q, requestedByUserId }),
+    enabled,
   });
 }
 

--- a/ui/src/components/sessions/sessions-shell.tsx
+++ b/ui/src/components/sessions/sessions-shell.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useCurrentUser } from "@/contexts/current-user-context";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { cn, formatRelativeTime } from "@/lib/utils";
 
@@ -140,6 +141,7 @@ interface SessionsListProps {
   onShowSystemChange: (value: boolean) => void;
   onCollapse?: () => void;
   onNewSession: () => void;
+  identityState: "pending" | "needs-pick" | "ready";
 }
 
 function SessionsList({
@@ -152,6 +154,7 @@ function SessionsList({
   onShowSystemChange,
   onCollapse,
   onNewSession,
+  identityState,
 }: SessionsListProps) {
   const items = sessions ?? [];
 
@@ -244,7 +247,15 @@ function SessionsList({
       </div>
 
       <div className="flex-1 min-h-0 overflow-y-auto">
-        {isLoading ? (
+        {identityState === "needs-pick" ? (
+          <div className="px-3">
+            <EmptyState
+              icon={MessageSquare}
+              title="Identify yourself"
+              description="Select your identity to see your sessions."
+            />
+          </div>
+        ) : isLoading ? (
           <div className="flex flex-col gap-2 px-3">
             {Array.from({ length: 6 }).map((_, idx) => (
               <Skeleton key={`skeleton-${idx}`} className="h-12 w-full" />
@@ -253,7 +264,7 @@ function SessionsList({
         ) : items.length === 0 ? (
           query.trim().length > 0 ? (
             <div className="px-3 py-6 text-xs text-muted-foreground text-center">
-              No sessions match “{query}”.
+              No sessions match "{query}".
             </div>
           ) : (
             <div className="px-3">
@@ -343,6 +354,7 @@ export interface SessionsShellProps {
 
 export function SessionsShell({ activeRootTaskId, children }: SessionsShellProps) {
   const navigate = useNavigate();
+  const { userId, state: identityState } = useCurrentUser();
   const [collapsed, setCollapsed] = useState<boolean>(() => readBool(COLLAPSE_STORAGE_KEY, false));
   const [showSystem, setShowSystem] = useState<boolean>(() =>
     readBool(SHOW_SYSTEM_STORAGE_KEY, false),
@@ -367,6 +379,8 @@ export function SessionsShell({ activeRootTaskId, children }: SessionsShellProps
     limit: 50,
     source: sourceFilter,
     q: debouncedQuery.trim() || undefined,
+    requestedByUserId: userId ?? undefined,
+    enabled: identityState === "ready",
   });
 
   const openNew = useCallback(() => navigate("/sessions"), [navigate]);
@@ -400,6 +414,7 @@ export function SessionsShell({ activeRootTaskId, children }: SessionsShellProps
                 onShowSystemChange={setShowSystem}
                 onCollapse={() => setCollapsed(true)}
                 onNewSession={openNew}
+                identityState={identityState}
               />
             </aside>
           ) : null}


### PR DESCRIPTION
## Summary

- Adds an optional `requestedByUserId` query param to `GET /api/sessions` — when present, the backend restricts results to root tasks where `agent_tasks.requestedByUserId` equals the provided value (NULL rows excluded).
- The UI `SessionsShell` now reads `userId` from `useCurrentUser()`, passes it to `useSessions`, and disables the query until identity resolves to `"ready"`. A "Identify yourself" empty state is shown when identity is `"needs-pick"`.
- 5 new backend tests cover positive, negative, empty, NULL-exclusion, and backward-compat cases.
- `openapi.json` regenerated to include the new param.

## Planning artifacts

Research + implementation plan (Principal Researcher):
https://live.agent-fs.dev/file/~/4fdbb8e2-f63b-4977-95be-6e18019f0e86/99d03b30-1ffd-4ddd-b332-1244b511b230/thoughts/6557a439-15b8-4c55-a639-638626f4983e/plans/2026-05-21-cai-1282-filter-sessions-by-active-user.md

## Files changed

| File | Change |
|---|---|
| `src/http/sessions.ts` | Add `requestedByUserId` to route query schema; pass to DB |
| `src/be/db.ts` | Extend `listRecentSessions` opts + WHERE clause |
| `src/tests/sessions.test.ts` | 5 new user-filter test cases |
| `ui/src/api/client.ts` | Add `requestedByUserId` param to `listSessions` |
| `ui/src/api/hooks/use-sessions.ts` | Add `requestedByUserId` + `enabled` to `UseSessionsOptions` |
| `ui/src/components/sessions/sessions-shell.tsx` | Wire `useCurrentUser`, disable query until ready, add needs-pick empty state |
| `openapi.json` | Regenerated |

## Test plan

1. **API — positive**: `curl -H "Authorization: Bearer $KEY" "$API/api/sessions?requestedByUserId=<userA>"` — response contains only sessions where `root.requestedByUserId === userA`.
2. **API — negative**: repeat with `userB` — userA's sessions must NOT appear.
3. **API — NULL exclusion**: rows where `requestedByUserId IS NULL` must NOT appear in the filtered response.
4. **API — empty**: use a userId that has no sessions → `{ "sessions": [] }`.
5. **API — compat**: omit `requestedByUserId` entirely — all sessions returned (legacy / non-UI callers unaffected).
6. **UI — user A**: log in as user A (pick identity via the identity modal), navigate Home → Sessions. Only A's sessions should render.
7. **UI — user B**: switch to user B, navigate Sessions. Only B's sessions should render; A's sessions must not appear.
8. **UI — needs-pick**: clear identity (localStorage key `swarm:v1:...:current-user`), navigate Sessions. "Identify yourself" empty state should appear instead of a list.
9. **Unit tests**: `bun test src/tests/sessions.test.ts` — all 7 pass.

## Out of scope (follow-ups)

- `GET /api/sessions/{rootTaskId}` detail endpoint is **not** scoped — separate hardening pass needed.
- Admin / role-based override to see all sessions.

## Pre-existing test failures (unrelated to this PR)

`bun test` has 3 failures on `main` as well as this branch — all in `GITHUB_BOT_ALIASES support`. These are pre-existing and out of scope for this PR.