### PR TITLE
feat(send-task,resolve-user): inherit requestedByUserId and expose externalIds

### DIFF
--- a/src/tests/mcp-tools-user.test.ts
+++ b/src/tests/mcp-tools-user.test.ts
@@ -158,6 +158,53 @@ describe("resolve-user MCP tool (new {kind, externalId, email} shape)", () => {
     const parsed = resolveUserInputSchema.safeParse({ email: "x@example.com" });
     expect(parsed.success).toBe(true);
   });
+
+  test("valid {userId} input passes the schema", () => {
+    const parsed = resolveUserInputSchema.safeParse({ userId: "some-user-id" });
+    expect(parsed.success).toBe(true);
+  });
+
+  test("response includes externalIds populated from user_external_ids rows", async () => {
+    const user = createUser({ name: "External ID User", email: "extid@example.com" });
+    linkIdentity(user.id, "github", "extid-gh-handle", SYSTEM_ACTOR);
+    linkIdentity(user.id, "slack", "U_EXTID", SYSTEM_ACTOR);
+
+    const result = await callTool(server, "resolve-user", {
+      kind: "github",
+      externalId: "extid-gh-handle",
+    });
+    const parsed = JSON.parse(textOf(result));
+    expect(parsed.id).toBe(user.id);
+    expect(Array.isArray(parsed.externalIds)).toBe(true);
+    const kinds = parsed.externalIds.map((e: { kind: string }) => e.kind).sort();
+    expect(kinds).toEqual(["github", "slack"]);
+  });
+
+  test("externalIds is empty array when user has no identities", async () => {
+    const user = createUser({ name: "No Identities User", email: "noid@example.com" });
+
+    const result = await callTool(server, "resolve-user", { email: "noid@example.com" });
+    const parsed = JSON.parse(textOf(result));
+    expect(parsed.id).toBe(user.id);
+    expect(parsed.externalIds).toEqual([]);
+  });
+
+  test("userId lookup returns user profile with externalIds", async () => {
+    const user = createUser({ name: "User ID Lookup", email: "uidlookup@example.com" });
+    linkIdentity(user.id, "linear", "L_UIDLOOKUP", SYSTEM_ACTOR);
+
+    const result = await callTool(server, "resolve-user", { userId: user.id });
+    const parsed = JSON.parse(textOf(result));
+    expect(parsed.id).toBe(user.id);
+    expect(parsed.name).toBe("User ID Lookup");
+    expect(parsed.externalIds).toHaveLength(1);
+    expect(parsed.externalIds[0]).toMatchObject({ kind: "linear", externalId: "L_UIDLOOKUP" });
+  });
+
+  test("userId lookup returns 'No user found' for unknown ID", async () => {
+    const result = await callTool(server, "resolve-user", { userId: "nonexistent-user-id-xyz" });
+    expect(textOf(result)).toContain("No user found");
+  });
 });
 
 describe("manage-user MCP tool (identities array)", () => {

--- a/src/tests/mcp-tools-user.test.ts
+++ b/src/tests/mcp-tools-user.test.ts
@@ -132,7 +132,7 @@ describe("resolve-user MCP tool (new {kind, externalId, email} shape)", () => {
     expect(parsed.success).toBe(false);
     if (!parsed.success) {
       const msg = JSON.stringify(parsed.error.issues);
-      expect(msg).toMatch(/Provide either \(kind \+ externalId\) or email/);
+      expect(msg).toMatch(/Provide either \(kind \+ externalId\), email, or userId/);
     }
   });
 

--- a/src/tests/send-task-requested-by.test.ts
+++ b/src/tests/send-task-requested-by.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { unlink } from "node:fs/promises";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import {
+  closeDb,
+  createAgent,
+  createTaskExtended,
+  createUser,
+  getTaskById,
+  initDb,
+} from "../be/db";
+import { registerSendTaskTool } from "../tools/send-task";
+
+const TEST_DB_PATH = "./test-send-task-requested-by.sqlite";
+
+const LEAD_ID = "11111111-1111-4111-a111-111111111111";
+const WORKER_ID = "22222222-2222-4222-a222-222222222222";
+
+let userAId: string;
+let userBId: string;
+
+type RegisteredTool = {
+  handler: (args: unknown, extra: unknown) => Promise<CallToolResult>;
+};
+
+function callSendTask(
+  server: McpServer,
+  args: Record<string, unknown>,
+  callerAgentId: string,
+  sourceTaskId?: string,
+): Promise<CallToolResult> {
+  const tools = (server as unknown as { _registeredTools: Record<string, RegisteredTool> })
+    ._registeredTools;
+  const tool = tools["send-task"];
+  if (!tool) throw new Error("send-task not registered");
+  const headers: Record<string, string> = { "x-agent-id": callerAgentId };
+  if (sourceTaskId) headers["x-source-task-id"] = sourceTaskId;
+  const extra = {
+    sessionId: "test-session",
+    requestInfo: { headers },
+  };
+  return tool.handler(args, extra);
+}
+
+function structuredOf(result: CallToolResult) {
+  return result.structuredContent as {
+    success: boolean;
+    task?: { id: string; requestedByUserId?: string };
+    message: string;
+  };
+}
+
+beforeAll(async () => {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      await unlink(TEST_DB_PATH + suffix);
+    } catch {}
+  }
+  closeDb();
+  initDb(TEST_DB_PATH);
+  createAgent({ id: LEAD_ID, name: "Test Lead", isLead: true, status: "idle" });
+  createAgent({ id: WORKER_ID, name: "Test Worker", isLead: false, status: "idle" });
+  userAId = createUser({ name: "User A", email: "user-a@example.com" }).id;
+  userBId = createUser({ name: "User B", email: "user-b@example.com" }).id;
+});
+
+afterAll(async () => {
+  closeDb();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      await unlink(TEST_DB_PATH + suffix);
+    } catch {}
+  }
+});
+
+describe("send-task: requestedByUserId inheritance", () => {
+  const server = new McpServer({ name: "test-send-task", version: "1.0.0" });
+  registerSendTaskTool(server);
+
+  test("child pool task inherits requestedByUserId from caller's sourceTaskId", async () => {
+    // Parent task has no agentId so the auto-route won't force a lead assignment.
+    const parentTask = createTaskExtended("parent pool task", {
+      requestedByUserId: userAId,
+    });
+
+    const result = await callSendTask(
+      server,
+      { task: "child pool task — inherit", allowDuplicate: true },
+      LEAD_ID,
+      parentTask.id,
+    );
+
+    const s = structuredOf(result);
+    expect(s.success).toBe(true);
+    expect(s.task).toBeDefined();
+    const created = getTaskById(s.task!.id);
+    expect(created?.requestedByUserId).toBe(userAId);
+  });
+
+  test("explicit requestedByUserId in args wins over inherited value", async () => {
+    const parentTask = createTaskExtended("parent with user A", {
+      requestedByUserId: userAId,
+    });
+
+    const result = await callSendTask(
+      server,
+      { task: "child with override user B", requestedByUserId: userBId, allowDuplicate: true },
+      LEAD_ID,
+      parentTask.id,
+    );
+
+    const s = structuredOf(result);
+    expect(s.success).toBe(true);
+    const created = getTaskById(s.task!.id);
+    expect(created?.requestedByUserId).toBe(userBId);
+  });
+
+  test("no crash when caller has no sourceTaskId and no requestedByUserId arg", async () => {
+    const result = await callSendTask(
+      server,
+      { task: "anonymous task — no requester", allowDuplicate: true },
+      LEAD_ID,
+    );
+
+    const s = structuredOf(result);
+    expect(s.success).toBe(true);
+    const created = getTaskById(s.task!.id);
+    expect(created?.requestedByUserId).toBeFalsy();
+  });
+
+  test("direct assignment to worker inherits requestedByUserId from caller's sourceTaskId", async () => {
+    // Parent assigned to WORKER so auto-route would pick WORKER, but we pass agentId explicitly.
+    const parentTask = createTaskExtended("parent for direct assign", {
+      requestedByUserId: userAId,
+    });
+
+    const result = await callSendTask(
+      server,
+      {
+        task: "worker direct assign — inherit user",
+        agentId: WORKER_ID,
+        allowDuplicate: true,
+      },
+      LEAD_ID,
+      parentTask.id,
+    );
+
+    const s = structuredOf(result);
+    expect(s.success).toBe(true);
+    const created = getTaskById(s.task!.id);
+    expect(created?.requestedByUserId).toBe(userAId);
+  });
+});

--- a/src/tools/resolve-user.ts
+++ b/src/tools/resolve-user.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod";
-import { findUserByEmail, findUserByExternalId } from "@/be/users";
+import { findUserByEmail, findUserByExternalId, findUserById, getUserIdentities } from "@/be/users";
 import { createToolRegistrar } from "@/tools/utils";
 
 /**
@@ -8,10 +8,10 @@ import { createToolRegistrar } from "@/tools/utils";
  *   - `{kind, externalId}` for platform-identity lookups (replaces the old
  *     `slackUserId` / `linearUserId` / `githubUsername` / `gitlabUsername` fields).
  *   - `email` for primary-email or alias lookup.
+ *   - `userId` for direct canonical-ID lookup (reverse-resolution: "give me
+ *     all external IDs for this swarm user").
  *
- * Validator requires either (kind + externalId) OR email. Old worker payloads
- * carrying `slackUserId`, `name`, etc. fail Zod validation at runtime — that
- * is the documented no-soak behaviour for this refactor.
+ * Validator requires either (kind + externalId) OR email OR userId.
  *
  * Exported for tests so the schema can be validated without spinning up an
  * MCP transport (the SDK only runs Zod at the transport layer).
@@ -31,11 +31,21 @@ export const resolveUserInputSchema = z
         "Platform-specific identifier for the given kind (e.g. Slack user ID 'U08NR6QD6CS', Linear user UUID, GitHub login).",
       ),
     email: z.string().email().optional().describe("Email address (primary or alias)."),
+    userId: z
+      .string()
+      .optional()
+      .describe(
+        "Canonical swarm user ID. Use this to reverse-look up all external identities for a known user (e.g. find their GitHub handle from a requestedByUserId).",
+      ),
   })
   .strict()
-  .refine((v) => (v.kind !== undefined && v.externalId !== undefined) || v.email !== undefined, {
-    message: "Provide either (kind + externalId) or email",
-  });
+  .refine(
+    (v) =>
+      (v.kind !== undefined && v.externalId !== undefined) ||
+      v.email !== undefined ||
+      v.userId !== undefined,
+    { message: "Provide either (kind + externalId), email, or userId" },
+  );
 
 export const registerResolveUserTool = (server: McpServer) => {
   createToolRegistrar(server)(
@@ -43,16 +53,18 @@ export const registerResolveUserTool = (server: McpServer) => {
     {
       title: "Resolve user identity",
       description:
-        "Look up a canonical user profile by an `(kind, externalId)` pair (e.g. {kind: 'slack', externalId: 'U_X'}) OR by email (primary or alias). Returns the user profile or 'No user found'.",
+        "Look up a canonical user profile by an `(kind, externalId)` pair (e.g. {kind: 'slack', externalId: 'U_X'}), by email (primary or alias), or by swarm `userId`. Returns the user profile including `externalIds` (all linked platform identities) or 'No user found'.",
       annotations: { readOnlyHint: true },
       inputSchema: resolveUserInputSchema,
     },
-    async ({ kind, externalId, email }) => {
+    async ({ kind, externalId, email, userId }) => {
       let user = null;
       if (kind && externalId) {
         user = findUserByExternalId(kind, externalId);
       } else if (email) {
         user = findUserByEmail(email);
+      } else if (userId) {
+        user = findUserById(userId);
       }
 
       if (!user) {
@@ -61,8 +73,11 @@ export const registerResolveUserTool = (server: McpServer) => {
         };
       }
 
+      const externalIds = getUserIdentities(user.id);
       return {
-        content: [{ type: "text" as const, text: JSON.stringify(user, null, 2) }],
+        content: [
+          { type: "text" as const, text: JSON.stringify({ ...user, externalIds }, null, 2) },
+        ],
       };
     },
   );

--- a/src/tools/send-task.ts
+++ b/src/tools/send-task.ts
@@ -93,6 +93,13 @@ export const registerSendTaskTool = (server: McpServer) => {
             "Slack thread timestamp. Required with slackChannelId for thread-level updates.",
           ),
         slackUserId: z.string().optional().describe("Slack user ID of the original requester."),
+        requestedByUserId: z
+          .string()
+          .uuid()
+          .optional()
+          .describe(
+            "ID of the human user who originally requested this task chain. When omitted, inherited from the caller's current task so the attribution flows through multi-hop delegation automatically.",
+          ),
       }),
       outputSchema: z.object({
         yourAgentId: z.string().uuid().optional(),
@@ -118,6 +125,7 @@ export const registerSendTaskTool = (server: McpServer) => {
         slackChannelId,
         slackThreadTs,
         slackUserId,
+        requestedByUserId,
       },
       requestInfo,
       _meta,
@@ -158,6 +166,10 @@ export const registerSendTaskTool = (server: McpServer) => {
 
       // Auto-default parentTaskId to caller's current task for tree tracking
       const effectiveParentTaskId = parentTaskId ?? requestInfo.sourceTaskId;
+
+      // Inherit requestedByUserId from the caller's current task when not explicitly provided
+      const callerTask = requestInfo.sourceTaskId ? getTaskById(requestInfo.sourceTaskId) : null;
+      const effectiveRequestedByUserId = requestedByUserId ?? callerTask?.requestedByUserId ?? undefined;
 
       // Auto-route to parent's worker if parentTaskId is set and no explicit agentId
       let effectiveAgentId = agentId;
@@ -237,6 +249,7 @@ export const registerSendTaskTool = (server: McpServer) => {
             slackChannelId,
             slackThreadTs,
             slackUserId,
+            requestedByUserId: effectiveRequestedByUserId,
           });
 
           return {
@@ -288,6 +301,7 @@ export const registerSendTaskTool = (server: McpServer) => {
             slackChannelId,
             slackThreadTs,
             slackUserId,
+            requestedByUserId: effectiveRequestedByUserId,
           });
 
           return {
@@ -313,6 +327,7 @@ export const registerSendTaskTool = (server: McpServer) => {
           slackChannelId,
           slackThreadTs,
           slackUserId,
+          requestedByUserId: effectiveRequestedByUserId,
         });
 
         return {

--- a/src/tools/send-task.ts
+++ b/src/tools/send-task.ts
@@ -169,7 +169,8 @@ export const registerSendTaskTool = (server: McpServer) => {
 
       // Inherit requestedByUserId from the caller's current task when not explicitly provided
       const callerTask = requestInfo.sourceTaskId ? getTaskById(requestInfo.sourceTaskId) : null;
-      const effectiveRequestedByUserId = requestedByUserId ?? callerTask?.requestedByUserId ?? undefined;
+      const effectiveRequestedByUserId =
+        requestedByUserId ?? callerTask?.requestedByUserId ?? undefined;
 
       // Auto-route to parent's worker if parentTaskId is set and no explicit agentId
       let effectiveAgentId = agentId;


### PR DESCRIPTION
## Summary

- **(A) `send-task` now inherits `requestedByUserId` through the task chain** — when a lead dispatches a child task without an explicit `requestedByUserId`, it is automatically inherited from the caller's current task (via `requestInfo.sourceTaskId`). This ensures child coder tasks (e.g. those running `gh pr create`) carry the original human requester's identity so the GitHub handle lookup succeeds and PRs ship with an assignee.
- **(B) `resolve-user` response now includes `externalIds`** — the tool returns `externalIds: Array<{kind, externalId}>` alongside the `User` shape by calling the existing `getUserIdentities(user.id)` helper. Callers can now reverse-look up any platform handle (GitHub, Slack, Linear…) from a canonical user ID without extra round-trips.
- **(B+) `resolve-user` also accepts `userId` as a lookup mode** — trivial addition that lets workers call `{userId: requestedByUserId}` directly instead of needing an email first.

These two changes form a complete attribution pipeline: (A) propagates the requester's ID through multi-hop delegation, (B) lets any agent resolve the GitHub handle from that ID.

## Changes

- `src/tools/send-task.ts` — add `requestedByUserId` to input schema; compute `effectiveRequestedByUserId` from caller's source task when not provided; pass it through all three `createTaskExtended` call sites.
- `src/tools/resolve-user.ts` — add `userId` to input schema; call `getUserIdentities(user.id)` and merge `externalIds` into every successful response.
- `src/tests/send-task-requested-by.test.ts` — new test file covering (A) acceptance criteria.
- `src/tests/mcp-tools-user.test.ts` — extended with (B) acceptance tests for `externalIds` and `userId` lookup.

## Test coverage

**(A) `send-task` inheritance:**
- Child pool task inherits `requestedByUserId` from caller's `sourceTaskId`
- Explicit `requestedByUserId` arg overrides the inherited value
- No crash when no parent / no requester is set
- Direct worker assignment also inherits correctly

**(B) `resolve-user` `externalIds`:**
- Response contains `externalIds` populated from `user_external_ids` rows
- `externalIds` is an empty array when user has no identities (no crash)
- `{userId}` lookup returns user profile with `externalIds`
- `{userId}` lookup returns "No user found" for unknown ID

## PR Checks

All pass locally:
- `bun run lint` ✅
- `bun run tsc:check` ✅
- `bun test src/tests/send-task-requested-by.test.ts src/tests/mcp-tools-user.test.ts` ✅ (23 pass)
- `bash scripts/check-db-boundary.sh` ✅

## Planning artifacts

- Plan doc: `thoughts/5fd166b4-7d41-40ce-852f-9a3c2ea191a3/plans/2026-05-22-send-task-requestedbyuserid-and-resolve-user-externalids.md` (agent-fs personal drive)

## Notes

- DO NOT MERGE — awaiting reviewer sign-off.
- The `requestedByUserId` field already had FK support in the DB (`src/be/migrations/031_user_registry.sql`) and inheritance logic in `createTaskExtended` for the `parentTaskId` case; this PR fills the gap at the `send-task` tool layer.