### PR TITLE
feat(pi-mono): delegate Amazon Bedrock auth to the AWS SDK

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,10 +20,22 @@ set -e
 HARNESS_PROVIDER="${HARNESS_PROVIDER:-claude}"
 
 if [ "$HARNESS_PROVIDER" = "pi" ]; then
-    # Pi-mono auth: ANTHROPIC_API_KEY, OPENROUTER_API_KEY, or auth.json must exist
-    if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$OPENROUTER_API_KEY" ] && [ ! -f "$HOME/.pi/agent/auth.json" ]; then
-        echo "Warning: pi provider has no credentials yet (ANTHROPIC_API_KEY / OPENROUTER_API_KEY / ~/.pi/agent/auth.json). Worker will park in credential-wait until creds appear in swarm_config."
-    fi
+    # Pi-mono auth: ANTHROPIC_API_KEY, OPENROUTER_API_KEY, or auth.json must
+    # exist — UNLESS MODEL_OVERRIDE selects amazon-bedrock, in which case
+    # credential resolution is delegated to the AWS SDK at first inference
+    # call (env vars, ~/.aws/*, SSO, IMDS, assume-role, etc.). The boot gate
+    # in checkPiMonoCredentials short-circuits to satisfiedBy=sdk-delegated
+    # for that case, so don't emit a misleading warning here.
+    case "$(echo "${MODEL_OVERRIDE:-}" | tr '[:upper:]' '[:lower:]')" in
+        amazon-bedrock/*)
+            echo "pi provider: MODEL_OVERRIDE=${MODEL_OVERRIDE} — AWS SDK will resolve Bedrock credentials at runtime (env, ~/.aws/*, SSO, IMDS)."
+            ;;
+        *)
+            if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$OPENROUTER_API_KEY" ] && [ ! -f "$HOME/.pi/agent/auth.json" ]; then
+                echo "Warning: pi provider has no credentials yet (ANTHROPIC_API_KEY / OPENROUTER_API_KEY / ~/.pi/agent/auth.json). Worker will park in credential-wait until creds appear in swarm_config."
+            fi
+            ;;
+    esac
 elif [ "$HARNESS_PROVIDER" = "opencode" ]; then
     # opencode auth: OPENROUTER_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY, or auth.json must exist
     OPENCODE_AUTH_FILE="${HOME}/.local/share/opencode/auth.json"

--- a/docs-site/content/docs/(documentation)/guides/harness-providers.mdx
+++ b/docs-site/content/docs/(documentation)/guides/harness-providers.mdx
@@ -99,9 +99,28 @@ The runner consumes these events (not the provider's native ones) to post progre
 | File | Transport | Auth |
 |---|---|---|
 | [`src/providers/claude-adapter.ts`](https://github.com/desplega-ai/agent-swarm/blob/main/src/providers/claude-adapter.ts) | `Bun.spawn` of `claude` CLI with `--output-format stream-json`, JSONL stdout parsing | `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` |
-| [`src/providers/pi-mono-adapter.ts`](https://github.com/desplega-ai/agent-swarm/blob/main/src/providers/pi-mono-adapter.ts) | In-process via `createAgentSession` from `@earendil-works/pi-coding-agent`; no subprocess | `ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY` / `~/.pi/agent/auth.json` |
+| [`src/providers/pi-mono-adapter.ts`](https://github.com/desplega-ai/agent-swarm/blob/main/src/providers/pi-mono-adapter.ts) | In-process via `createAgentSession` from `@earendil-works/pi-coding-agent`; no subprocess | `ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY` / `~/.pi/agent/auth.json` — or, when `MODEL_OVERRIDE=amazon-bedrock/*`, anything the AWS SDK default chain accepts (see [pi-mono + Amazon Bedrock](#pi-mono--amazon-bedrock-auth) below) |
 | [`src/providers/codex-adapter.ts`](https://github.com/desplega-ai/agent-swarm/blob/main/src/providers/codex-adapter.ts) | Wraps `@openai/codex-sdk` `Codex` / `Thread`; `thread.runStreamed()` yields `ThreadEvent` async iterator | `OPENAI_API_KEY` or ChatGPT OAuth stored in `swarm_config.codex_oauth` (see §6) |
 | [`src/providers/claude-managed-adapter.ts`](https://github.com/desplega-ai/agent-swarm/blob/main/src/providers/claude-managed-adapter.ts) | Anthropic SDK `client.beta.sessions.events.stream` (SSE); session executes in Anthropic's managed cloud sandbox, worker is a thin relay | `ANTHROPIC_API_KEY` plus pre-existing `MANAGED_AGENT_ID` + `MANAGED_ENVIRONMENT_ID` from one-time `claude-managed-setup` CLI (see §13) |
+
+### pi-mono + Amazon Bedrock auth
+
+pi-mono routes to Amazon Bedrock when `MODEL_OVERRIDE=amazon-bedrock/<model-id>` (e.g. `amazon-bedrock/anthropic.claude-sonnet-4-20250514-v1:0`). Bedrock authenticates through the AWS SDK's default credential chain — not a single API key — so agent-swarm **delegates credential resolution to the SDK**. The boot credential gate detects the `amazon-bedrock/` prefix and short-circuits to `satisfiedBy: "sdk-delegated"` without inspecting any AWS env var or file.
+
+**Accepted credential sources** — anything the AWS SDK accepts:
+
+- `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (+ optional `AWS_SESSION_TOKEN`)
+- `AWS_PROFILE` resolved against `~/.aws/credentials` and `~/.aws/config`
+- AWS SSO sessions configured in `~/.aws/config`
+- EC2 IMDS instance role / ECS task role
+- Web-identity / OIDC (`AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_ARN`)
+- `credential_process` and assume-role chains
+
+`AWS_REGION` (or `AWS_DEFAULT_REGION`) is required by the SDK and must be a Bedrock-enabled region.
+
+**Failure mode.** No `credential-wait` parking — the worker claims tasks immediately. If creds are missing, the first Bedrock inference call fails with the AWS SDK's own error (e.g. `CredentialsProviderError: Could not load credentials from any providers`), which surfaces in the session log via the existing error path (scrubbed through `scrubSecrets`). Treat this the same way you treat a stale codex `auth.json`: the underlying SDK is the source of truth.
+
+This is intentionally the same pattern codex uses for OAuth credentials (`codexAuthFileExists` → `presenceCheckOk` in [`src/commands/provider-credentials.ts`](https://github.com/desplega-ai/agent-swarm/blob/main/src/commands/provider-credentials.ts)) — presence-only gate, runtime validation owned by the adapter/SDK, no upstream call from agent-swarm. pi-ai does not currently expose a Bedrock-specific credential check we could call; if it does in the future, the live-test branch can be upgraded without touching the boot gate.
 
 ### Cost & context tracking
 

--- a/runbooks/harness-providers.md
+++ b/runbooks/harness-providers.md
@@ -9,7 +9,7 @@ Operational rules for editing or adding harness providers (claude, codex, openco
 | Claude Code | `claude` | `ClaudeAdapter` | Default; spawns `claude` CLI |
 | Codex | `codex` | `CodexAdapter` | Spawns `codex` CLI; OpenAI/ChatGPT OAuth |
 | opencode | `opencode` | `OpencodeAdapter` | Spawns `opencode` CLI; OpenRouter primary; agent-swarm plugin auto-injected. See [harness-configuration § Opencode](/docs/guides/harness-configuration#opencode) |
-| pi-mono | `pi` | `PiMonoAdapter` | In-process library; OpenRouter or Anthropic |
+| pi-mono | `pi` | `PiMonoAdapter` | In-process library; OpenRouter, Anthropic, or Amazon Bedrock (via `MODEL_OVERRIDE=amazon-bedrock/*` — see Bedrock auth below) |
 | Devin | `devin` | `DevinAdapter` | Cloud-managed via Cognition `/sessions` API |
 | Claude Managed | `claude-managed` | `ClaudeManagedAdapter` | Anthropic managed sandbox; SSE relay |
 
@@ -50,6 +50,16 @@ Tasks may carry an optional JSON Schema on `outputSchema` (see `CreateTaskOption
 When supported, validation happens in the `store-progress` MCP tool (see `src/tools/store-progress.ts:159-190`). When the schema is missing or violated, the tool call fails and the agent is asked to retry.
 
 **Caveat for default-mode Devin:** `ensureTaskFinished` in `src/commands/runner.ts` writes Devin's `providerOutput` directly into `task.output` without schema validation. Callers consuming a schema'd task's output should not assume `JSON.parse(task.output)` will succeed when the task ran on default-mode Devin.
+
+## pi-mono + Amazon Bedrock auth
+
+When `MODEL_OVERRIDE=amazon-bedrock/<model-id>` (e.g. `amazon-bedrock/anthropic.claude-sonnet-4-20250514-v1:0`), credential resolution is delegated to the AWS SDK's default chain — agent-swarm does no presence check beyond detecting the `amazon-bedrock/` prefix.
+
+- Any source the AWS SDK accepts works: `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (+ optional `AWS_SESSION_TOKEN`), `AWS_PROFILE` + `~/.aws/credentials`, SSO sessions in `~/.aws/config`, EC2 IMDS / ECS task role, web-identity / OIDC, `credential_process`, assume-role chains.
+- `AWS_REGION` (or `AWS_DEFAULT_REGION`) is required by the SDK and must be a Bedrock-enabled region.
+- The boot credential gate (`checkPiMonoCredentials`) short-circuits to `satisfiedBy: "sdk-delegated"` without inspecting any AWS env var or file. The worker does **not** park in `credential-wait` for Bedrock — even with no creds visible to agent-swarm, it claims tasks.
+- Credential errors surface at the first Bedrock inference call as an AWS SDK error in the session log (scrubbed via `scrubSecrets` at egress). Treat this the same as a codex `auth.json` failure: the adapter/SDK is the source of truth, not the boot gate.
+- This is the closest precedent to codex's "presence-only" pattern (`codexAuthFileExists` → `presenceCheckOk`). If pi-ai later exposes a `validateBedrockCredentials` helper, the live-test branch in `validateProviderCredentials` can be upgraded without touching the boot gate.
 
 ## Same-PR doc-update rule
 

--- a/src/commands/provider-credentials.ts
+++ b/src/commands/provider-credentials.ts
@@ -238,6 +238,7 @@ function parseCodexOAuthAccess(blob: string | undefined): string | null {
  * | `codex`          | `~/.codex/auth.json` (file) → `CODEX_OAUTH` (env OAuth) → `OPENAI_API_KEY` | OpenAI `/v1/models` (api-key path only) |
  * | `opencode`       | `OPENROUTER_API_KEY` → `ANTHROPIC_API_KEY` → `OPENAI_API_KEY` (pi-style) | matching provider's `/v1/models` |
  * | `pi`             | `OPENROUTER_API_KEY` → `ANTHROPIC_API_KEY` → `OPENAI_API_KEY`           | matching provider's `/v1/models` |
+ * | `pi` (bedrock)   | `MODEL_OVERRIDE=amazon-bedrock/*` → AWS SDK default credential chain    | presence-only (validated at first inference call) |
  * | `devin`          | `DEVIN_API_KEY` (+ `DEVIN_API_BASE_URL` override)                       | `${baseUrl}/v1/sessions?limit=1` |
  *
  * Returns `{ok: true, latency_ms}` on 2xx, `{ok: false, error, latency_ms}`
@@ -296,6 +297,16 @@ export async function validateProviderCredentials(provider: string): Promise<Liv
       }
       case "pi":
       case "opencode": {
+        // pi-mono with MODEL_OVERRIDE=amazon-bedrock/* delegates credential
+        // resolution to the AWS SDK default chain (env, ~/.aws/*, SSO, IMDS,
+        // assume-role, …). pi-ai exposes no Bedrock-specific check we could
+        // call here, and the SDK chain may issue slow IMDS network calls on
+        // non-EC2 hosts — so the live test is a presence check, mirroring the
+        // codex-OAuth pattern above. Real validation happens at the first
+        // Bedrock inference call.
+        if (provider === "pi" && env.MODEL_OVERRIDE?.toLowerCase().startsWith("amazon-bedrock/")) {
+          return presenceCheckOk();
+        }
         // Both pi-mono and opencode resolve credentials in the same order:
         // OPENROUTER → ANTHROPIC → OPENAI. Live-test against the matching
         // provider's models endpoint.

--- a/src/providers/pi-mono-adapter.ts
+++ b/src/providers/pi-mono-adapter.ts
@@ -72,17 +72,34 @@ function modelToCredKeys(modelStr: string | undefined): string[] | null {
 
 /**
  * Pi-mono is satisfied by ANY of:
- *   1. `~/.pi/agent/auth.json` exists.
- *   2. `MODEL_OVERRIDE` is set to a provider-prefixed model — only the
+ *   1. `MODEL_OVERRIDE` selects the `amazon-bedrock` provider — credential
+ *      resolution is delegated to the AWS SDK's default chain at first
+ *      inference call. agent-swarm does no presence check; if creds are
+ *      missing the SDK error surfaces in the session log.
+ *   2. `~/.pi/agent/auth.json` exists.
+ *   3. `MODEL_OVERRIDE` is set to a provider-prefixed model — only the
  *      matching provider's key is required.
- *   3. `MODEL_OVERRIDE` is empty / unprefixed — any one of the supported
+ *   4. `MODEL_OVERRIDE` is empty / unprefixed — any one of the supported
  *      keys (ANTHROPIC_API_KEY / OPENROUTER_API_KEY / OPENAI_API_KEY) is
  *      enough.
+ *
+ * Bedrock is checked first so a stale `auth.json` (Anthropic / OpenRouter
+ * creds from a previous login) doesn't get falsely reported as the
+ * satisfying source when the model is actually going to AWS.
  */
 export function checkPiMonoCredentials(
   env: Record<string, string | undefined>,
   opts: CredCheckOptions = {},
 ): CredStatus {
+  if (env.MODEL_OVERRIDE?.toLowerCase().startsWith("amazon-bedrock/")) {
+    return {
+      ready: true,
+      missing: [],
+      satisfiedBy: "sdk-delegated",
+      hint: "AWS SDK will resolve credentials at first Bedrock call (env, ~/.aws/*, SSO, IMDS, etc.).",
+    };
+  }
+
   const homeDir = opts.homeDir ?? env.HOME ?? "/root";
   const probe = opts.fs?.existsSync ?? existsSync;
   const authFile = `${homeDir}/.pi/agent/auth.json`;

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -163,11 +163,15 @@ export interface ProviderAdapter {
  *   (e.g. `codex login --with-api-key`) still needs to run before the
  *   adapter can use them. Workers should treat this as "ready" for the
  *   purposes of the boot loop — the side-effect is the entrypoint's job.
+ * - `'sdk-delegated'` — the harness's underlying SDK owns credential
+ *   resolution at runtime (e.g. AWS SDK default chain for pi-mono +
+ *   `MODEL_OVERRIDE=amazon-bedrock/...`); agent-swarm does no presence check
+ *   and any error surfaces from the first inference call.
  */
 export interface CredStatus {
   ready: boolean;
   missing: string[];
-  satisfiedBy?: "env" | "file" | "side-effect-pending";
+  satisfiedBy?: "env" | "file" | "side-effect-pending" | "sdk-delegated";
   hint?: string;
 }
 

--- a/src/tests/credential-check.test.ts
+++ b/src/tests/credential-check.test.ts
@@ -224,6 +224,53 @@ describe("checkPiMonoCredentials", () => {
       ).toBe(true);
     }
   });
+
+  // ─── amazon-bedrock: AWS SDK delegates credential resolution ───────────────
+  // When MODEL_OVERRIDE selects amazon-bedrock, pi-mono routes through the AWS
+  // SDK's default credential chain (env, ~/.aws/*, SSO, IMDS, assume-role,
+  // web-identity, …). agent-swarm does no presence check beyond detecting the
+  // `amazon-bedrock/` prefix — the SDK validates at first inference call.
+  // Mirrors the codex auth.json "presence-only" pattern.
+
+  test("amazon-bedrock: ready (sdk-delegated) with no env vars and no auth.json", () => {
+    const env = { MODEL_OVERRIDE: "amazon-bedrock/anthropic.claude-sonnet-4-20250514-v1:0" };
+    const status = checkPiMonoCredentials(env, { homeDir: HOME, fs: noFiles });
+    expect(status.ready).toBe(true);
+    expect(status.satisfiedBy).toBe("sdk-delegated");
+    expect(status.missing).toEqual([]);
+  });
+
+  test("amazon-bedrock: stays sdk-delegated even when ANTHROPIC_API_KEY is also set", () => {
+    // The Anthropic-shape key is irrelevant here — the model is routed through
+    // AWS Bedrock, not Anthropic. Reporting satisfiedBy="env" would mislead.
+    const env = {
+      MODEL_OVERRIDE: "amazon-bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
+      ANTHROPIC_API_KEY: "x",
+    };
+    const status = checkPiMonoCredentials(env, { homeDir: HOME, fs: noFiles });
+    expect(status.ready).toBe(true);
+    expect(status.satisfiedBy).toBe("sdk-delegated");
+  });
+
+  test("amazon-bedrock: stays sdk-delegated even when auth.json exists", () => {
+    // auth.json holds Anthropic/OpenRouter/OpenAI creds — none used by Bedrock.
+    // Bedrock branch must win over the file probe.
+    const env = { MODEL_OVERRIDE: "amazon-bedrock/anthropic.claude-sonnet-4-20250514-v1:0" };
+    const status = checkPiMonoCredentials(env, {
+      homeDir: HOME,
+      fs: fsWith(new Set([AUTH])),
+    });
+    expect(status.ready).toBe(true);
+    expect(status.satisfiedBy).toBe("sdk-delegated");
+  });
+
+  test("amazon-bedrock: provider-prefix match is case-insensitive", () => {
+    // Mirrors modelToCredKeys' .toLowerCase() at line 54 of pi-mono-adapter.
+    const env = { MODEL_OVERRIDE: "Amazon-Bedrock/anthropic.claude-sonnet-4-20250514-v1:0" };
+    const status = checkPiMonoCredentials(env, { homeDir: HOME, fs: noFiles });
+    expect(status.ready).toBe(true);
+    expect(status.satisfiedBy).toBe("sdk-delegated");
+  });
 });
 
 // ─── opencode ────────────────────────────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -491,7 +491,10 @@ export type AgentLatestModel = z.infer<typeof AgentLatestModelSchema>;
 export const AgentCredStatusSchema = z.object({
   ready: z.boolean(),
   missing: z.array(z.string()).default([]),
-  satisfiedBy: z.enum(["env", "file", "side-effect-pending"]).nullable().default(null),
+  satisfiedBy: z
+    .enum(["env", "file", "side-effect-pending", "sdk-delegated"])
+    .nullable()
+    .default(null),
   hint: z.string().nullable().default(null),
   liveTest: AgentCredStatusLiveTestSchema.nullable().default(null),
   latestModel: AgentLatestModelSchema.nullable().default(null),


### PR DESCRIPTION
When MODEL_OVERRIDE selects an amazon-bedrock model, credentials are resolved by the AWS SDK's default chain (env vars, ~/.aws/*, SSO, IMDS, ECS task role, web-identity, assume-role) — not a single API key. The existing pi-mono credential gate only knows about ANTHROPIC_API_KEY / OPENROUTER_API_KEY / OPENAI_API_KEY / ~/.pi/agent/auth.json, so a worker with valid AWS credentials but no Anthropic-shape key would park in credential-wait forever even though pi-ai + AWS SDK would authenticate fine.

Mirror the codex "presence-only" precedent: detect the `amazon-bedrock/` prefix on MODEL_OVERRIDE and short-circuit the boot gate to a new `satisfiedBy: "sdk-delegated"` state without inspecting any AWS env var or file. The AWS SDK validates at the first Bedrock inference call; missing-credential errors surface in the session log with the SDK's own message. This avoids replicating the AWS chain in agent-swarm — no new dependency, no IMDS probe, no SSO logic.

- `checkPiMonoCredentials`: amazon-bedrock branch runs before the auth.json check so a stale Anthropic auth.json isn't falsely reported as the satisfying source when the model is routing to AWS.
- `validateProviderCredentials` "pi" branch: presenceCheckOk() for amazon-bedrock — same shape codex uses when ~/.codex/auth.json is on disk.
- `CredStatus.satisfiedBy`: union and Zod enum gain "sdk-delegated".
- `docker-entrypoint.sh`: pi block case-matches MODEL_OVERRIDE; bedrock prints a positive note instead of the legacy "no credentials" warning.
- `runbooks/harness-providers.md` + docs-site guide: new section documenting accepted AWS credential sources, the AWS_REGION requirement, and the failure mode (errors surface at session-start, not in credential-wait).
- Tests: four new cases under `checkPiMonoCredentials` covering empty env, ANTHROPIC_API_KEY also set, auth.json present, and case-insensitive prefix matching.