### PR TITLE
fix(codex): parse wall-clock reset time + preserve terminalError for usage-limit failures

### DIFF
--- a/src/http/schedules.ts
+++ b/src/http/schedules.ts
@@ -466,11 +466,11 @@ export async function handleSchedules(
         const mergedTimezone =
           parsed.body.timezone !== undefined ? parsed.body.timezone : existing.timezone;
         if (timing.mergedCron || timing.mergedInterval) {
-          // biome-ignore lint/suspicious/noExplicitAny: need partial ScheduledTask for calculateNextRun
           body.nextRunAt = calculateNextRun({
             cronExpression: timing.mergedCron,
             intervalMs: timing.mergedInterval,
             timezone: mergedTimezone,
+            // biome-ignore lint/suspicious/noExplicitAny: need partial ScheduledTask for calculateNextRun
           } as any);
         }
       }

--- a/src/providers/codex-adapter.ts
+++ b/src/providers/codex-adapter.ts
@@ -66,12 +66,12 @@ import {
   type WebSearchItem,
 } from "@openai/codex-sdk";
 import { buildRatingsFromLlm, fetchRetrievalsForTask, postRatings } from "../be/memory/raters/llm";
-import { SessionErrorTracker } from "../utils/error-tracker";
 import {
   CONTEXT_FORMULA,
   clampContextPercent,
   computeContextUsedUnified,
 } from "../utils/context-window";
+import { SessionErrorTracker } from "../utils/error-tracker";
 import { summarizeSession as runSummarize } from "../utils/internal-ai";
 import { scrubSecrets } from "../utils/secret-scrubber";
 import { type CodexAgentsMdHandle, writeCodexAgentsMd } from "./codex-agents-md";

--- a/src/providers/codex-adapter.ts
+++ b/src/providers/codex-adapter.ts
@@ -66,6 +66,7 @@ import {
   type WebSearchItem,
 } from "@openai/codex-sdk";
 import { buildRatingsFromLlm, fetchRetrievalsForTask, postRatings } from "../be/memory/raters/llm";
+import { SessionErrorTracker } from "../utils/error-tracker";
 import {
   CONTEXT_FORMULA,
   clampContextPercent,
@@ -413,6 +414,7 @@ class CodexSession implements ProviderSession {
   private lastUsage: Usage | null = null;
   private aborted = false;
   private settled = false;
+  private readonly errorTracker = new SessionErrorTracker();
   /**
    * Result captured by `settle` but held back from `resolveCompletion` until
    * `runSession`'s `finally` block has fully cleaned up (log writer flush,
@@ -951,9 +953,11 @@ class CodexSession implements ProviderSession {
           }
           if (event.type === "turn.failed" && !terminalError) {
             terminalError = this.formatTerminalError(event.error.message);
+            this.errorTracker.processCodexUsageLimitMessage(event.error.message);
           }
           if (event.type === "error" && !terminalError) {
             terminalError = this.formatTerminalError(event.message);
+            this.errorTracker.processCodexUsageLimitMessage(event.message);
           }
         }
       } catch (err) {
@@ -967,6 +971,30 @@ class CodexSession implements ProviderSession {
             cost,
             isError: true,
             failureReason: "cancelled",
+          });
+          return;
+        }
+        // The Codex CLI exits with code 1 after emitting a UsageLimitReached or
+        // other terminal error event. The SDK then throws "Codex Exec exited with
+        // code 1: Reading prompt from stdin" AFTER the event loop ends, which
+        // would overwrite the structured terminalError we already captured above.
+        // Preserve the structured error so the [usage-limit] prefix survives to
+        // the runner's rate-limit resolver.
+        if (terminalError) {
+          const cost = this.buildCostData(this.lastUsage, true);
+          this.emit({
+            type: "result",
+            cost,
+            isError: true,
+            errorCategory: terminalError.category ?? "turn_failed",
+          });
+          this.settle({
+            exitCode: 1,
+            sessionId: this._sessionId,
+            cost,
+            isError: true,
+            failureReason: terminalError.message,
+            rateLimitResetAt: this.errorTracker.getRateLimitResetAt(),
           });
           return;
         }
@@ -987,6 +1015,7 @@ class CodexSession implements ProviderSession {
         cost,
         isError,
         failureReason: terminalError?.message,
+        rateLimitResetAt: this.errorTracker.getRateLimitResetAt(),
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -1000,6 +1029,7 @@ class CodexSession implements ProviderSession {
         cost,
         isError: true,
         failureReason: message,
+        rateLimitResetAt: this.errorTracker.getRateLimitResetAt(),
       });
     } finally {
       // Session-end summarization. Pure addition for codex — no behavior to

--- a/src/tests/codex-adapter.test.ts
+++ b/src/tests/codex-adapter.test.ts
@@ -1619,10 +1619,11 @@ describe("CodexSession — rate-limit error preservation", () => {
       },
     };
 
-    (sdk.Codex.prototype as unknown as { startThread: (...args: unknown[]) => unknown }).startThread =
-      function startThread(): unknown {
-        return fakeThread as unknown;
-      };
+    (
+      sdk.Codex.prototype as unknown as { startThread: (...args: unknown[]) => unknown }
+    ).startThread = function startThread(): unknown {
+      return fakeThread as unknown;
+    };
 
     try {
       const adapter = new CodexAdapter();

--- a/src/tests/codex-adapter.test.ts
+++ b/src/tests/codex-adapter.test.ts
@@ -53,6 +53,63 @@ function makeFakeThread(events: ThreadEvent[]): {
 }
 
 /**
+ * Like `makeFakeThread` but throws the given error after all events have been
+ * yielded. Simulates the SDK's "Codex Exec exited with code 1: Reading prompt
+ * from stdin" throw that fires after the event stream closes.
+ */
+function makeFakeThreadWithThrow(
+  events: ThreadEvent[],
+  throwAfterStream: Error,
+): ReturnType<typeof makeFakeThread> {
+  return {
+    id: null,
+    async runStreamed(_input, _opts) {
+      async function* generate(): AsyncGenerator<ThreadEvent> {
+        for (const event of events) {
+          yield event;
+        }
+        throw throwAfterStream;
+      }
+      return { events: generate() };
+    },
+  };
+}
+
+/**
+ * Like `runSessionWithFakeThread` but injects a thread that throws after its
+ * event stream ends (simulating the SDK exit-code throw).
+ */
+async function runSessionWithThrowingThread(
+  events: ThreadEvent[],
+  throwAfterStream: Error,
+  config: ProviderSessionConfig,
+): Promise<{ emitted: ProviderEvent[]; result: ProviderResult }> {
+  const sdk = await import("@openai/codex-sdk");
+  const originalStartThread = (
+    sdk.Codex.prototype as unknown as { startThread: (...args: unknown[]) => unknown }
+  ).startThread;
+
+  const fakeThread = makeFakeThreadWithThrow(events, throwAfterStream);
+  (sdk.Codex.prototype as unknown as { startThread: (...args: unknown[]) => unknown }).startThread =
+    function startThread(): unknown {
+      return fakeThread as unknown;
+    };
+
+  try {
+    const adapter = new CodexAdapter();
+    const session = await adapter.createSession(config);
+    const emitted: ProviderEvent[] = [];
+    session.onEvent((e) => emitted.push(e));
+    const result = await session.waitForCompletion();
+    return { emitted, result };
+  } finally {
+    (
+      sdk.Codex.prototype as unknown as { startThread: (...args: unknown[]) => unknown }
+    ).startThread = originalStartThread;
+  }
+}
+
+/**
  * Drive a CodexSession manually by constructing the private class via the
  * adapter's own factory path. We can't import the class directly because it
  * is not exported, so we use a runtime trick: import the module object and
@@ -1476,5 +1533,139 @@ describe("CodexSession session-end summarization", () => {
     );
     expect(matching.length).toBe(1);
     expect(matching[0]![1]).toBe(500);
+  });
+});
+
+describe("CodexSession — rate-limit error preservation", () => {
+  const tmpLogDir = `/tmp/codex-rate-limit-test-${Date.now()}`;
+  let prevSkipEnv: string | undefined;
+
+  beforeAll(() => {
+    mkdirSync(tmpLogDir, { recursive: true });
+    prevSkipEnv = process.env.SKIP_SESSION_SUMMARY;
+    process.env.SKIP_SESSION_SUMMARY = "1";
+  });
+
+  afterAll(() => {
+    rmSync(tmpLogDir, { recursive: true, force: true });
+    if (prevSkipEnv === undefined) delete process.env.SKIP_SESSION_SUMMARY;
+    else process.env.SKIP_SESSION_SUMMARY = prevSkipEnv;
+  });
+
+  afterEach(() => {
+    // Keep afterEach from the test runner clean
+  });
+
+  test("terminalError survives SDK post-stream throw and surfaces as [usage-limit] failureReason", async () => {
+    const usageLimitMsg =
+      "You've hit your usage limit. To get more access now, send a request to your admin or try again at 8:35 PM.";
+    const events: ThreadEvent[] = [
+      { type: "thread.started", thread_id: "thread-ratelimit-1" },
+      { type: "turn.started" },
+      { type: "error", message: usageLimitMsg },
+      { type: "turn.failed", error: { message: usageLimitMsg } },
+    ];
+    const sdkThrow = new Error("Codex Exec exited with code 1: Reading prompt from stdin");
+
+    const { result } = await runSessionWithThrowingThread(
+      events,
+      sdkThrow,
+      testConfig({ logFile: join(tmpLogDir, "ratelimit-preserve.log"), cwd: "" }),
+    );
+
+    // Bug #1 fix: structured failureReason must survive the SDK throw
+    expect(result.failureReason).toMatch(/\[usage-limit\]/);
+    expect(result.failureReason).not.toContain("Reading prompt from stdin");
+    expect(result.isError).toBe(true);
+    // Parser must have extracted a reset time
+    expect(result.rateLimitResetAt).toBeDefined();
+    const resetMs = new Date(result.rateLimitResetAt!).getTime();
+    expect(resetMs).toBeGreaterThan(Date.now());
+  });
+
+  test("AbortError still settles as cancelled even when terminalError is absent (regression guard)", async () => {
+    // If the session is aborted before any error event, the AbortError path
+    // must still win over the terminalError preservation branch.
+    const sdk = await import("@openai/codex-sdk");
+    const originalStartThread = (
+      sdk.Codex.prototype as unknown as { startThread: (...args: unknown[]) => unknown }
+    ).startThread;
+
+    const fakeThread = {
+      id: null,
+      runStreamed: async (_input: string, opts?: { signal?: AbortSignal }) => {
+        async function* generate(): AsyncGenerator<ThreadEvent> {
+          yield { type: "thread.started", thread_id: "thread-abort-guard" };
+          yield { type: "turn.started" };
+          await new Promise<void>((resolve) => {
+            const onAbort = () => {
+              opts?.signal?.removeEventListener("abort", onAbort);
+              resolve();
+            };
+            if (opts?.signal?.aborted) {
+              resolve();
+              return;
+            }
+            opts?.signal?.addEventListener("abort", onAbort);
+            setTimeout(resolve, 5000);
+          });
+          if (opts?.signal?.aborted) {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            throw err;
+          }
+        }
+        return { events: generate() };
+      },
+    };
+
+    (sdk.Codex.prototype as unknown as { startThread: (...args: unknown[]) => unknown }).startThread =
+      function startThread(): unknown {
+        return fakeThread as unknown;
+      };
+
+    try {
+      const adapter = new CodexAdapter();
+      const config = testConfig({
+        logFile: join(tmpLogDir, "abort-guard.log"),
+        cwd: "",
+        taskId: "",
+        apiUrl: "",
+        apiKey: "",
+      });
+      const session = await adapter.createSession(config);
+      const emitted: ProviderEvent[] = [];
+      session.onEvent((e) => emitted.push(e));
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      await session.abort();
+      const result = await session.waitForCompletion();
+
+      expect(result.failureReason).toBe("cancelled");
+      expect(result.exitCode).toBe(130);
+    } finally {
+      (
+        sdk.Codex.prototype as unknown as { startThread: (...args: unknown[]) => unknown }
+      ).startThread = originalStartThread;
+    }
+  });
+
+  test("real unexpected exception (no terminalError) still falls through to outer catch", async () => {
+    // When the SDK throws before any error event, the outer catch must fire normally.
+    const events: ThreadEvent[] = [
+      { type: "thread.started", thread_id: "thread-unexpected" },
+      { type: "turn.started" },
+    ];
+    const unexpectedErr = new Error("unexpected network failure");
+
+    const { result } = await runSessionWithThrowingThread(
+      events,
+      unexpectedErr,
+      testConfig({ logFile: join(tmpLogDir, "unexpected-err.log"), cwd: "" }),
+    );
+
+    // No terminalError → outer catch fires → failureReason is the raw exception message
+    expect(result.failureReason).toBe("unexpected network failure");
+    expect(result.isError).toBe(true);
+    expect(result.rateLimitResetAt).toBeUndefined();
   });
 });

--- a/src/tests/codex-rate-limit-parse.test.ts
+++ b/src/tests/codex-rate-limit-parse.test.ts
@@ -151,9 +151,7 @@ describe("parseCodexRateLimitResetTime — invalid component rejection (CAI-1284
   });
 
   test("'Try again at 0:30 PM.' → undefined (hour 0 is not 1–12)", () => {
-    expect(
-      parseCodexRateLimitResetTime("usage limit. Try again at 0:30 PM.", now),
-    ).toBeUndefined();
+    expect(parseCodexRateLimitResetTime("usage limit. Try again at 0:30 PM.", now)).toBeUndefined();
   });
 
   test("'Try again at 12:60 PM.' → undefined (minute 60 out of range)", () => {

--- a/src/tests/codex-rate-limit-parse.test.ts
+++ b/src/tests/codex-rate-limit-parse.test.ts
@@ -135,6 +135,52 @@ describe("parseCodexRateLimitResetTime — negative cases", () => {
   });
 });
 
+describe("parseCodexRateLimitResetTime — invalid component rejection (CAI-1284 review)", () => {
+  const now = new Date("2026-05-25T18:00:00Z");
+
+  test("'Try again at 99:99 PM.' → undefined (hour and minute out of range)", () => {
+    expect(
+      parseCodexRateLimitResetTime("usage limit. Try again at 99:99 PM.", now),
+    ).toBeUndefined();
+  });
+
+  test("'Try again at 13:99 PM.' → undefined (hour out of range)", () => {
+    expect(
+      parseCodexRateLimitResetTime("usage limit. Try again at 13:99 PM.", now),
+    ).toBeUndefined();
+  });
+
+  test("'Try again at 0:30 PM.' → undefined (hour 0 is not 1–12)", () => {
+    expect(
+      parseCodexRateLimitResetTime("usage limit. Try again at 0:30 PM.", now),
+    ).toBeUndefined();
+  });
+
+  test("'Try again at 12:60 PM.' → undefined (minute 60 out of range)", () => {
+    expect(
+      parseCodexRateLimitResetTime("usage limit. Try again at 12:60 PM.", now),
+    ).toBeUndefined();
+  });
+
+  test("'Try again at May 32nd, 2026 8:35 PM.' → undefined (day overflow)", () => {
+    expect(
+      parseCodexRateLimitResetTime("usage limit. Try again at May 32nd, 2026 8:35 PM.", now),
+    ).toBeUndefined();
+  });
+
+  test("'Try again at Feb 30th, 2026 8:35 PM.' → undefined (Feb has ≤29 days)", () => {
+    expect(
+      parseCodexRateLimitResetTime("usage limit. Try again at Feb 30th, 2026 8:35 PM.", now),
+    ).toBeUndefined();
+  });
+
+  test("'Try again at May 26th, 2026 8:35 PM.' → valid (positive control)", () => {
+    expect(
+      parseCodexRateLimitResetTime("usage limit. Try again at May 26th, 2026 8:35 PM.", now),
+    ).toBe("2026-05-26T20:35:00.000Z");
+  });
+});
+
 describe("parseCodexRateLimitResetTime — case-insensitive", () => {
   test("'TRY AGAIN AT 8:35 PM' (all caps) parses", () => {
     const now = new Date("2026-05-25T00:00:00Z");

--- a/src/tests/codex-rate-limit-parse.test.ts
+++ b/src/tests/codex-rate-limit-parse.test.ts
@@ -18,17 +18,26 @@ describe("parseCodexRateLimitResetTime — verbatim CAI-1284 fixture", () => {
     expect(result).toBe("2026-05-26T20:35:00.000Z");
   });
 
-  test("rolls to next day when 'now' equals the parsed wall-clock exactly", () => {
+  test("keeps same day when 'now' equals the parsed wall-clock exactly (clock-skew window)", () => {
     const now = new Date("2026-05-25T20:35:00Z");
     const result = parseCodexRateLimitResetTime(VERBATIM_ERROR_MESSAGE, now);
-    expect(result).toBe("2026-05-26T20:35:00.000Z");
+    // Within 2-min skew window → same day; clampRateLimitResetMs applies now+60s floor.
+    expect(result).toBe("2026-05-25T20:35:00.000Z");
+  });
+
+  test("clock-skew regression: 30s past 8:35 PM does NOT roll to tomorrow (CAI-1284)", () => {
+    // Worker receives the usage-limit event 30 seconds after the wall-clock reset time.
+    // Should stay same-day; clampRateLimitResetMs applies now+60s floor instead.
+    const now = new Date("2026-05-25T20:35:30Z");
+    const result = parseCodexRateLimitResetTime(VERBATIM_ERROR_MESSAGE, now);
+    expect(result).toBe("2026-05-25T20:35:00.000Z");
   });
 });
 
 describe("parseCodexRateLimitResetTime — same-day format variants", () => {
   test.each([
     // [time string, expected ISO, now ISO]
-    ["12:00 AM", "2026-05-26T00:00:00.000Z", "2026-05-25T00:00:00Z"], // midnight: past, rolls
+    ["12:00 AM", "2026-05-25T00:00:00.000Z", "2026-05-25T00:00:00Z"], // midnight == now: within skew, stays same day
     ["12:00 PM", "2026-05-25T12:00:00.000Z", "2026-05-25T00:00:00Z"], // noon: future
     ["1:00 PM", "2026-05-25T13:00:00.000Z", "2026-05-25T00:00:00Z"],
     ["11:59 PM", "2026-05-25T23:59:00.000Z", "2026-05-25T00:00:00Z"],

--- a/src/tests/codex-rate-limit-parse.test.ts
+++ b/src/tests/codex-rate-limit-parse.test.ts
@@ -172,9 +172,7 @@ describe("SessionErrorTracker — Codex usage-limit integration", () => {
   test("last call wins on multiple usage-limit events", () => {
     const tracker = new SessionErrorTracker();
     // First: a past-sounding time that would be clamped to now+60s
-    tracker.processCodexUsageLimitMessage(
-      "You've hit your usage limit. Try again at 1:00 AM.",
-    );
+    tracker.processCodexUsageLimitMessage("You've hit your usage limit. Try again at 1:00 AM.");
     const firstIso = tracker.getRateLimitResetAt();
     expect(firstIso).toBeDefined();
 

--- a/src/tests/codex-rate-limit-parse.test.ts
+++ b/src/tests/codex-rate-limit-parse.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "bun:test";
+import { parseCodexRateLimitResetTime, SessionErrorTracker } from "../utils/error-tracker";
+
+// Verbatim from Linear CAI-1284 issue body (Team/Business plan fixture)
+const VERBATIM_ERROR_MESSAGE =
+  "You've hit your usage limit. To get more access now, send a request to your admin or try again at 8:35 PM.";
+
+describe("parseCodexRateLimitResetTime — verbatim CAI-1284 fixture", () => {
+  test("parses '8:35 PM' as 20:35 UTC same day when now is 18:00 UTC", () => {
+    const now = new Date("2026-05-25T18:00:00Z");
+    const result = parseCodexRateLimitResetTime(VERBATIM_ERROR_MESSAGE, now);
+    expect(result).toBe("2026-05-25T20:35:00.000Z");
+  });
+
+  test("rolls to next day when 'now' is past the parsed wall-clock", () => {
+    const now = new Date("2026-05-25T21:00:00Z"); // 9:00 PM UTC — past 8:35 PM
+    const result = parseCodexRateLimitResetTime(VERBATIM_ERROR_MESSAGE, now);
+    expect(result).toBe("2026-05-26T20:35:00.000Z");
+  });
+
+  test("rolls to next day when 'now' equals the parsed wall-clock exactly", () => {
+    const now = new Date("2026-05-25T20:35:00Z");
+    const result = parseCodexRateLimitResetTime(VERBATIM_ERROR_MESSAGE, now);
+    expect(result).toBe("2026-05-26T20:35:00.000Z");
+  });
+});
+
+describe("parseCodexRateLimitResetTime — same-day format variants", () => {
+  test.each([
+    // [time string, expected ISO, now ISO]
+    ["12:00 AM", "2026-05-26T00:00:00.000Z", "2026-05-25T00:00:00Z"], // midnight: past, rolls
+    ["12:00 PM", "2026-05-25T12:00:00.000Z", "2026-05-25T00:00:00Z"], // noon: future
+    ["1:00 PM", "2026-05-25T13:00:00.000Z", "2026-05-25T00:00:00Z"],
+    ["11:59 PM", "2026-05-25T23:59:00.000Z", "2026-05-25T00:00:00Z"],
+  ])("'Try again at %s.' → %s", (time, expected, nowISO) => {
+    const now = new Date(nowISO);
+    const msg = `You've hit your usage limit. Try again at ${time}.`;
+    expect(parseCodexRateLimitResetTime(msg, now)).toBe(expected);
+  });
+
+  test("'or try again at' prefix (lowercase) also parses", () => {
+    const now = new Date("2026-05-25T18:00:00Z");
+    const msg =
+      "You've hit your usage limit. To get more access now, send a request to your admin or try again at 8:35 PM.";
+    expect(parseCodexRateLimitResetTime(msg, now)).toBe("2026-05-25T20:35:00.000Z");
+  });
+});
+
+describe("parseCodexRateLimitResetTime — different-day format", () => {
+  test("'May 26th, 2026 8:35 PM' parses with ordinal suffix", () => {
+    const now = new Date("2026-05-25T22:00:00Z");
+    const msg =
+      "You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), " +
+      "visit https://chatgpt.com/codex/settings/usage to purchase more credits or " +
+      "try again at May 26th, 2026 8:35 PM.";
+    expect(parseCodexRateLimitResetTime(msg, now)).toBe("2026-05-26T20:35:00.000Z");
+  });
+
+  test("ordinal-less form 'May 26, 2026 8:35 PM' also parses (defensive)", () => {
+    const now = new Date("2026-05-25T22:00:00Z");
+    const msg = "You've hit your usage limit. Try again at May 26, 2026 8:35 PM.";
+    expect(parseCodexRateLimitResetTime(msg, now)).toBe("2026-05-26T20:35:00.000Z");
+  });
+
+  test.each([
+    ["1st", 1],
+    ["2nd", 2],
+    ["3rd", 3],
+    ["4th", 4],
+    ["11th", 11],
+    ["21st", 21],
+    ["22nd", 22],
+    ["23rd", 23],
+  ])("ordinal suffix %s parses", (ord, day) => {
+    const now = new Date("2026-04-01T00:00:00Z");
+    const msg = `You've hit your usage limit. Try again at May ${day}${ord.replace(/\d+/, "")}, 2026 8:35 PM.`;
+    const result = parseCodexRateLimitResetTime(msg, now);
+    expect(result).toBe(`2026-05-${String(day).padStart(2, "0")}T20:35:00.000Z`);
+  });
+
+  test("12-hour edge: midnight cross-day 'Jan 1st, 2027 12:00 AM'", () => {
+    const now = new Date("2026-12-31T23:00:00Z");
+    const msg = "You've hit your usage limit. Try again at Jan 1st, 2027 12:00 AM.";
+    expect(parseCodexRateLimitResetTime(msg, now)).toBe("2027-01-01T00:00:00.000Z");
+  });
+
+  test("12-hour edge: noon cross-day 'Jan 2nd, 2027 12:00 PM'", () => {
+    const now = new Date("2026-12-31T23:00:00Z");
+    const msg = "You've hit your usage limit. Try again at Jan 2nd, 2027 12:00 PM.";
+    expect(parseCodexRateLimitResetTime(msg, now)).toBe("2027-01-02T12:00:00.000Z");
+  });
+});
+
+describe("parseCodexRateLimitResetTime — negative cases", () => {
+  test("'Try again later.' (no time) → undefined", () => {
+    const msg = "You've hit your usage limit. Try again later.";
+    expect(parseCodexRateLimitResetTime(msg)).toBeUndefined();
+  });
+
+  test("'or try again later.' (no time) → undefined", () => {
+    const msg =
+      "You've hit your usage limit. To get more access now, send a request to your admin or try again later.";
+    expect(parseCodexRateLimitResetTime(msg)).toBeUndefined();
+  });
+
+  test("workspace-credit-depleted (no retry suffix at all) → undefined", () => {
+    expect(
+      parseCodexRateLimitResetTime("Your workspace is out of credits. Add credits to continue."),
+    ).toBeUndefined();
+  });
+
+  test("workspace member out of credits → undefined", () => {
+    expect(
+      parseCodexRateLimitResetTime(
+        "Your workspace is out of credits. Ask your workspace owner to refill in order to continue.",
+      ),
+    ).toBeUndefined();
+  });
+
+  test("non-codex error message → undefined", () => {
+    expect(parseCodexRateLimitResetTime("Connection failed: ECONNREFUSED")).toBeUndefined();
+  });
+
+  test("empty string → undefined", () => {
+    expect(parseCodexRateLimitResetTime("")).toBeUndefined();
+  });
+});
+
+describe("parseCodexRateLimitResetTime — case-insensitive", () => {
+  test("'TRY AGAIN AT 8:35 PM' (all caps) parses", () => {
+    const now = new Date("2026-05-25T00:00:00Z");
+    const result = parseCodexRateLimitResetTime("usage limit. TRY AGAIN AT 8:35 PM.", now);
+    expect(result).toBe("2026-05-25T20:35:00.000Z");
+  });
+});
+
+describe("SessionErrorTracker — Codex usage-limit integration", () => {
+  test("stashes clamped reset time from verbatim CAI-1284 fixture", () => {
+    const tracker = new SessionErrorTracker();
+    tracker.processCodexUsageLimitMessage(VERBATIM_ERROR_MESSAGE);
+    const iso = tracker.getRateLimitResetAt();
+    expect(iso).toBeDefined();
+    const ms = new Date(iso!).getTime();
+    const nowMs = Date.now();
+    // Clamped to [now+60s, now+6h]
+    expect(ms).toBeGreaterThanOrEqual(nowMs + 59_000);
+    expect(ms).toBeLessThanOrEqual(nowMs + 6 * 60 * 60 * 1000 + 1000);
+  });
+
+  test("non-usage-limit error does not stash", () => {
+    const tracker = new SessionErrorTracker();
+    tracker.processCodexUsageLimitMessage("Connection failed.");
+    expect(tracker.getRateLimitResetAt()).toBeUndefined();
+  });
+
+  test("workspace-credit message does not stash (no parseable time)", () => {
+    const tracker = new SessionErrorTracker();
+    tracker.processCodexUsageLimitMessage(
+      "Your workspace is out of credits. Add credits to continue.",
+    );
+    expect(tracker.getRateLimitResetAt()).toBeUndefined();
+  });
+
+  test("'try again later' variant does not stash (no parseable time)", () => {
+    const tracker = new SessionErrorTracker();
+    tracker.processCodexUsageLimitMessage(
+      "You've hit your usage limit. To get more access now, send a request to your admin or try again later.",
+    );
+    expect(tracker.getRateLimitResetAt()).toBeUndefined();
+  });
+
+  test("last call wins on multiple usage-limit events", () => {
+    const tracker = new SessionErrorTracker();
+    // First: a past-sounding time that would be clamped to now+60s
+    tracker.processCodexUsageLimitMessage(
+      "You've hit your usage limit. Try again at 1:00 AM.",
+    );
+    const firstIso = tracker.getRateLimitResetAt();
+    expect(firstIso).toBeDefined();
+
+    // Second: clear future time
+    const future = new Date(Date.now() + 3 * 60 * 60 * 1000); // +3h
+    const h = future.getUTCHours();
+    const m = future.getUTCMinutes();
+    const hh = h % 12 || 12;
+    const ampm = h >= 12 ? "PM" : "AM";
+    const mm = String(m).padStart(2, "0");
+    tracker.processCodexUsageLimitMessage(
+      `You've hit your usage limit. Try again at ${hh}:${mm} ${ampm}.`,
+    );
+    const secondIso = tracker.getRateLimitResetAt();
+    expect(secondIso).toBeDefined();
+    // Last call wins — value changed (may be same or different after clamp, but defined)
+  });
+
+  test("empty string does not stash", () => {
+    const tracker = new SessionErrorTracker();
+    tracker.processCodexUsageLimitMessage("");
+    expect(tracker.getRateLimitResetAt()).toBeUndefined();
+  });
+});

--- a/src/tests/error-tracker.test.ts
+++ b/src/tests/error-tracker.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  parseCodexRateLimitResetTime,
   parseRateLimitResetTime,
   parseStderrForErrors,
   SessionErrorTracker,
@@ -546,5 +547,39 @@ describe("parseRateLimitResetTime", () => {
     expect(parseRateLimitResetTime("retry after 100000 seconds")).toBeUndefined();
     // More than 24 hours in minutes
     expect(parseRateLimitResetTime("wait 2000 minutes")).toBeUndefined();
+  });
+});
+
+describe("Codex/Claude coexistence — single tracker handles both providers", () => {
+  test("processRateLimitEvent (Claude) and processCodexUsageLimitMessage (Codex) both stash into getRateLimitResetAt", () => {
+    // Claude path: processRateLimitEvent
+    const claudeTracker = new SessionErrorTracker();
+    const futureResetsAtSec = Math.floor(Date.now() / 1000) + 3600;
+    claudeTracker.processRateLimitEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "rejected", resetsAt: futureResetsAtSec },
+    });
+    expect(claudeTracker.getRateLimitResetAt()).toBeDefined();
+
+    // Codex path: processCodexUsageLimitMessage
+    const codexTracker = new SessionErrorTracker();
+    codexTracker.processCodexUsageLimitMessage(
+      "You've hit your usage limit. To get more access now, send a request to your admin or try again at 8:35 PM.",
+    );
+    expect(codexTracker.getRateLimitResetAt()).toBeDefined();
+
+    // A tracker that received a Claude event does NOT get cross-contaminated by
+    // an independent Codex call on a different instance.
+    const iso = claudeTracker.getRateLimitResetAt();
+    expect(iso).toBeDefined();
+    const ms = new Date(iso!).getTime();
+    expect(ms).toBeCloseTo(futureResetsAtSec * 1000, -2); // within 100ms tolerance
+  });
+
+  test("parseCodexRateLimitResetTime does not interfere with parseRateLimitResetTime fixtures", () => {
+    // Claude format: "resets 3pm (UTC)" — must NOT be matched by Codex parser
+    expect(parseCodexRateLimitResetTime("resets 3pm (UTC)")).toBeUndefined();
+    // Codex format: "try again at 8:35 PM" — must NOT be matched by Claude parser
+    expect(parseRateLimitResetTime("try again at 8:35 PM.")).toBeUndefined();
   });
 });

--- a/src/utils/error-tracker.ts
+++ b/src/utils/error-tracker.ts
@@ -318,10 +318,11 @@ export function parseCodexRateLimitResetTime(
     const candidate = new Date(
       Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), hours, minutes, 0),
     );
-    // Rollover: if the parsed wall-clock is at-or-before "now", assume tomorrow.
-    // Codex uses same-day format only when the reset is on the current calendar day,
-    // so a past time almost certainly means tomorrow (the next quota bucket).
-    if (candidate.getTime() <= now.getTime()) {
+    // Rollover: if the parsed wall-clock is more than SKEW_MS before "now", assume tomorrow.
+    // At-or-just-before-now candidates (clock skew, second truncation) stay same-day and
+    // flow to clampRateLimitResetMs which applies the now+60s floor.
+    const SKEW_MS = 2 * 60 * 1000;
+    if (candidate.getTime() < now.getTime() - SKEW_MS) {
       candidate.setUTCDate(candidate.getUTCDate() + 1);
     }
     return candidate.toISOString();

--- a/src/utils/error-tracker.ts
+++ b/src/utils/error-tracker.ts
@@ -97,6 +97,26 @@ export class SessionErrorTracker {
   }
 
   /**
+   * Process a Codex-style usage-limit error message (from a `{type:"error"}`
+   * or `{type:"turn.failed"}` SDK event). Only stashes when the message
+   * contains the usage-limit signature AND carries a parseable wall-clock
+   * reset time. "Try again later." and workspace-credit branches fall through
+   * to the runner's tier-3 fallback instead.
+   * Last call wins — multiple events per session are deduped to the latest.
+   */
+  processCodexUsageLimitMessage(message: string): void {
+    if (!message) return;
+    if (!/usage limit|hit your usage/i.test(message)) return;
+
+    const iso = parseCodexRateLimitResetTime(message);
+    if (!iso) return;
+
+    const candidateMs = new Date(iso).getTime();
+    if (!Number.isFinite(candidateMs)) return;
+    this.rateLimitResetAtMs = clampRateLimitResetMs(candidateMs);
+  }
+
+  /**
    * Returns the stashed rate limit reset time as an ISO string, or undefined
    * if no rejected rate_limit_event was seen in this session.
    */
@@ -249,6 +269,66 @@ const MONTH_NAMES: Record<string, number> = {
   dec: 11,
   december: 11,
 };
+
+/**
+ * Parse the reset time embedded in a Codex `UsageLimitReached` error message.
+ * Codex emits one of these formats via chrono's `%-I:%M %p` (same day) or
+ * `%b %-d{th/st/nd/rd}, %Y %-I:%M %p` (different day):
+ *   "Try again at 8:35 PM."
+ *   "or try again at 8:35 PM."
+ *   "Try again at May 26th, 2026 8:35 PM."
+ *   "or try again at May 26th, 2026 8:35 PM."
+ * Wall-clock times are UTC because the agent-swarm Docker worker has TZ=Etc/UTC;
+ * chrono::Local resolves to UTC in that container.
+ */
+export function parseCodexRateLimitResetTime(
+  message: string,
+  now: Date = new Date(),
+): string | undefined {
+  if (!message) return undefined;
+
+  // Different-day format (more specific — try first):
+  // "Month Day{st/nd/rd/th}, Year HH:MM AM/PM"
+  const datedMatch = message.match(
+    /\btry again at\s+([A-Za-z]+)\s+(\d{1,2})(?:st|nd|rd|th)?,\s+(\d{4})\s+(\d{1,2}):(\d{2})\s*(AM|PM|am|pm)\b/i,
+  );
+  if (datedMatch) {
+    const monthIdx = MONTH_NAMES[datedMatch[1]!.toLowerCase()];
+    if (monthIdx !== undefined) {
+      const day = Number.parseInt(datedMatch[2]!, 10);
+      const year = Number.parseInt(datedMatch[3]!, 10);
+      let hours = Number.parseInt(datedMatch[4]!, 10);
+      const minutes = Number.parseInt(datedMatch[5]!, 10);
+      const ampm = datedMatch[6]!.toLowerCase();
+      if (ampm === "pm" && hours !== 12) hours += 12;
+      if (ampm === "am" && hours === 12) hours = 0;
+      return new Date(Date.UTC(year, monthIdx, day, hours, minutes, 0)).toISOString();
+    }
+  }
+
+  // Same-day format: "HH:MM AM/PM"
+  // Anchored on "try again at" so we don't match times elsewhere in the message.
+  const timeMatch = message.match(/\btry again at\s+(\d{1,2}):(\d{2})\s*(AM|PM|am|pm)\b/i);
+  if (timeMatch) {
+    let hours = Number.parseInt(timeMatch[1]!, 10);
+    const minutes = Number.parseInt(timeMatch[2]!, 10);
+    const ampm = timeMatch[3]!.toLowerCase();
+    if (ampm === "pm" && hours !== 12) hours += 12;
+    if (ampm === "am" && hours === 12) hours = 0;
+    const candidate = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), hours, minutes, 0),
+    );
+    // Rollover: if the parsed wall-clock is at-or-before "now", assume tomorrow.
+    // Codex uses same-day format only when the reset is on the current calendar day,
+    // so a past time almost certainly means tomorrow (the next quota bucket).
+    if (candidate.getTime() <= now.getTime()) {
+      candidate.setUTCDate(candidate.getUTCDate() + 1);
+    }
+    return candidate.toISOString();
+  }
+
+  return undefined;
+}
 
 /**
  * Parse a rate limit error message to extract a reset time, returning an ISO datetime string.

--- a/src/utils/error-tracker.ts
+++ b/src/utils/error-tracker.ts
@@ -297,12 +297,19 @@ export function parseCodexRateLimitResetTime(
     if (monthIdx !== undefined) {
       const day = Number.parseInt(datedMatch[2]!, 10);
       const year = Number.parseInt(datedMatch[3]!, 10);
-      let hours = Number.parseInt(datedMatch[4]!, 10);
+      const rawHours = Number.parseInt(datedMatch[4]!, 10);
       const minutes = Number.parseInt(datedMatch[5]!, 10);
       const ampm = datedMatch[6]!.toLowerCase();
+      if (rawHours < 1 || rawHours > 12 || minutes < 0 || minutes > 59) return undefined;
+      let hours = rawHours;
       if (ampm === "pm" && hours !== 12) hours += 12;
       if (ampm === "am" && hours === 12) hours = 0;
-      return new Date(Date.UTC(year, monthIdx, day, hours, minutes, 0)).toISOString();
+      const d = new Date(Date.UTC(year, monthIdx, day, hours, minutes, 0));
+      // Round-trip guard: Date.UTC silently normalises out-of-range days (e.g. May 32 → June 1).
+      if (d.getUTCFullYear() !== year || d.getUTCMonth() !== monthIdx || d.getUTCDate() !== day) {
+        return undefined;
+      }
+      return d.toISOString();
     }
   }
 
@@ -310,9 +317,11 @@ export function parseCodexRateLimitResetTime(
   // Anchored on "try again at" so we don't match times elsewhere in the message.
   const timeMatch = message.match(/\btry again at\s+(\d{1,2}):(\d{2})\s*(AM|PM|am|pm)\b/i);
   if (timeMatch) {
-    let hours = Number.parseInt(timeMatch[1]!, 10);
+    const rawHours = Number.parseInt(timeMatch[1]!, 10);
     const minutes = Number.parseInt(timeMatch[2]!, 10);
     const ampm = timeMatch[3]!.toLowerCase();
+    if (rawHours < 1 || rawHours > 12 || minutes < 0 || minutes > 59) return undefined;
+    let hours = rawHours;
     if (ampm === "pm" && hours !== 12) hours += 12;
     if (ampm === "am" && hours === 12) hours = 0;
     const candidate = new Date(


### PR DESCRIPTION
## Summary

- **Bug #1 (outer-catch overwrite):** `CodexSession.runSession`'s inner catch re-throws the SDK's post-stream `"Codex Exec exited with code 1: Reading prompt from stdin"` error, which was being caught by the outer `catch` and overwriting the structured `[usage-limit]` `terminalError` already captured from the event stream. Fixed by checking for `terminalError` in the inner catch and settling with the structured error before the outer catch fires.

- **Bug #2 (no Codex reset-time parsing):** Even with bug #1 fixed, the runner's three-tier resolver had no way to parse Codex's wall-clock format (`"Try again at 8:35 PM."` / `"Try again at May 26th, 2026 8:35 PM."`). Added `parseCodexRateLimitResetTime` to `error-tracker.ts` and `SessionErrorTracker.processCodexUsageLimitMessage` to stash the parsed reset time, mirroring the existing Claude `processRateLimitEvent` API. The runner's tier-1 path (`result.rateLimitResetAt`) picks this up with zero changes to `runner.ts`.

**Result:** After a `CODEX_OAUTH` credential hits its usage limit, the correct `rateLimitResetAt` is reported to `POST /api/keys/report-rate-limit`, the pool excludes that slot, and subsequent tasks route to a healthy credential instead of immediately re-failing.

## Files changed

- `src/utils/error-tracker.ts` — `+parseCodexRateLimitResetTime`, `+SessionErrorTracker.processCodexUsageLimitMessage`; 2-min skew window in same-day rollover (review fix)
- `src/providers/codex-adapter.ts` — `+errorTracker` field, inner-catch terminalError preservation, `rateLimitResetAt` piped into all 3 `settle()` calls
- `src/tests/codex-rate-limit-parse.test.ts` — NEW (34 tests: verbatim CAI-1284 fixture, same-day/different-day formats, all ordinal suffixes, midnight/noon edges, negative cases, clock-skew regression)
- `src/tests/codex-adapter.test.ts` — +3 tests for rate-limit error preservation (SDK throw-after-stream, AbortError regression guard, unexpected-exception fallthrough)
- `src/tests/error-tracker.test.ts` — +2 tests for Codex/Claude coexistence

## Planning artifacts

- **Research:** [CAI-1280 Codex credential-pool research](https://live.agent-fs.dev/file/~/4fdbb8e2-f63b-4977-95be-6e18019f0e86/99d03b30-1ffd-4ddd-b332-1244b511b230/thoughts/6557a439-15b8-4c55-a639-638626f4983e/research/2026-05-20-cai-1280-codex-credential-pool.md) (upstream Codex OAuth background that led to CAI-1284)
- **Plan:** [CAI-1284 implementation plan](https://live.agent-fs.dev/file/~/4fdbb8e2-f63b-4977-95be-6e18019f0e86/99d03b30-1ffd-4ddd-b332-1244b511b230/thoughts/6557a439-15b8-4c55-a639-638626f4983e/plans/2026-05-25-cai-1284-codex-rate-limit-tracking.md)

## Test plan

```bash
# 1. Parser unit tests (34 cases — verbatim fixture + format variants + clock-skew regression)
bun test src/tests/codex-rate-limit-parse.test.ts

# 2. Adapter integration tests (3 new + 55 pre-existing)
bun test src/tests/codex-adapter.test.ts

# 3. Error-tracker coexistence tests (68 total, 2 new)
bun test src/tests/error-tracker.test.ts

# 4. Full suite
bun test

# 5. Boundary checks
bash scripts/check-db-boundary.sh
bash scripts/check-api-key-boundary.sh
```

Key reviewer tests:
- "terminalError survives SDK post-stream throw" → `result.failureReason` contains `[usage-limit]`, NOT `Reading prompt from stdin`; `result.rateLimitResetAt` is defined
- "real unexpected exception (no terminalError) still falls through to outer catch" → `result.failureReason` is the raw exception message (regression guard)
- "AbortError still settles as cancelled" → `result.failureReason === 'cancelled'`; `exitCode === 130`
- **Clock-skew regression (review fix):** "30s past 8:35 PM does NOT roll to tomorrow" → returns `2026-05-25T20:35:00.000Z`, not tomorrow; `clampRateLimitResetMs` applies `now+60s` floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)