### PR TITLE
fix(config): skip non-identifier keys in env-var export

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -376,7 +376,17 @@ if [ -n "$AGENT_ID" ]; then
             #   - HARNESS_PROVIDER: live-reconciled by runner.ts poll loop;
             #     baking it would also defeat the precedence invariant
             #     (swarm_config > env > "claude")
-            jq -r '.configs[] | select(.key != "codex_oauth" and .key != "HARNESS_PROVIDER") | "\(.key)=" + (.value | @sh)' /tmp/swarm_config.json > /tmp/swarm_config.env 2>/dev/null || true
+            # Also skip keys that are not valid POSIX shell identifiers
+            # (e.g. CF-Access-Client-Id). Sourcing such a key causes the shell
+            # to parse "CF-Access-Client-Id=value" as a command invocation →
+            # "command not found", aborting the rest of the export. These keys
+            # are still available to the runner via headerConfigKeys (resolved
+            # per-request), so skipping them here is safe.
+            SKIPPED_NONIDENT=$(jq -r '.configs[] | select(.key != "codex_oauth" and .key != "HARNESS_PROVIDER") | select(.key | test("^[A-Za-z_][A-Za-z0-9_]*$") | not) | .key' /tmp/swarm_config.json 2>/dev/null || true)
+            if [ -n "$SKIPPED_NONIDENT" ]; then
+                echo "[entrypoint] debug: skipping non-identifier config keys (not valid POSIX shell variable names, still available via headerConfigKeys): $(echo "$SKIPPED_NONIDENT" | tr '\n' ' ')"
+            fi
+            jq -r '.configs[] | select(.key != "codex_oauth" and .key != "HARNESS_PROVIDER") | select(.key | test("^[A-Za-z_][A-Za-z0-9_]*$")) | "\(.key)=" + (.value | @sh)' /tmp/swarm_config.json > /tmp/swarm_config.env 2>/dev/null || true
             if [ -f /tmp/swarm_config.env ]; then
                 set -a
                 . /tmp/swarm_config.env

--- a/src/tests/entrypoint-config-env-export.test.ts
+++ b/src/tests/entrypoint-config-env-export.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Tests for the config→env-var export filter in docker-entrypoint.sh.
+ *
+ * The entrypoint fetches swarm config and writes valid POSIX identifier keys
+ * to /tmp/swarm_config.env for sourcing. Keys containing hyphens or other
+ * non-identifier characters must be skipped — otherwise `source` interprets
+ * them as commands:
+ *
+ *   CF-Access-Client-Id=84853443... → "command not found"
+ *
+ * This filter mirrors the jq expression in docker-entrypoint.sh so the
+ * logic can be verified without a Docker environment.
+ */
+
+const POSIX_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const DYNAMIC_KEYS = new Set(["codex_oauth", "HARNESS_PROVIDER"]);
+
+/** Mirrors the jq filter in docker-entrypoint.sh. */
+function filterForEnvExport(
+  configs: Array<{ key: string; value: string }>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const { key, value } of configs) {
+    if (DYNAMIC_KEYS.has(key)) continue;
+    if (!POSIX_IDENTIFIER.test(key)) continue;
+    result[key] = value;
+  }
+  return result;
+}
+
+describe("entrypoint config env export: POSIX identifier filter", () => {
+  test("includes valid POSIX identifier keys", () => {
+    const result = filterForEnvExport([
+      { key: "FOO", value: "bar" },
+      { key: "MY_VAR_123", value: "val" },
+      { key: "_UNDERSCORE_START", value: "ok" },
+    ]);
+    expect(result.FOO).toBe("bar");
+    expect(result.MY_VAR_123).toBe("val");
+    expect(result._UNDERSCORE_START).toBe("ok");
+  });
+
+  test("excludes hyphenated keys (CF-Access-Client-Id pattern)", () => {
+    const result = filterForEnvExport([
+      { key: "FOO", value: "keep" },
+      { key: "CF-Access-Client-Id", value: "secret1" },
+      { key: "CF-Access-Client-Secret", value: "secret2" },
+      { key: "BAR", value: "keep" },
+    ]);
+    expect(result.FOO).toBe("keep");
+    expect(result.BAR).toBe("keep");
+    expect("CF-Access-Client-Id" in result).toBe(false);
+    expect("CF-Access-Client-Secret" in result).toBe(false);
+  });
+
+  test("excludes keys starting with a digit", () => {
+    const result = filterForEnvExport([
+      { key: "VALID", value: "yes" },
+      { key: "123_INVALID", value: "no" },
+    ]);
+    expect(result.VALID).toBe("yes");
+    expect("123_INVALID" in result).toBe(false);
+  });
+
+  test("excludes codex_oauth and HARNESS_PROVIDER (existing behaviour)", () => {
+    const result = filterForEnvExport([
+      { key: "NORMAL", value: "val" },
+      { key: "codex_oauth", value: "secret" },
+      { key: "HARNESS_PROVIDER", value: "claude" },
+    ]);
+    expect(result.NORMAL).toBe("val");
+    expect("codex_oauth" in result).toBe(false);
+    expect("HARNESS_PROVIDER" in result).toBe(false);
+  });
+
+  test("returns empty object for empty configs array", () => {
+    expect(filterForEnvExport([])).toEqual({});
+  });
+});


### PR DESCRIPTION
## Problem

Some pods fail at startup when loading swarm config. Symptom from logs:

```
Fetching swarm config from API...
Found 24 config entries, exporting as env vars...
/tmp/swarm_config.env: line 4: CF-Access-Client-Id=84853443d57d164d3d624a79662401f1.access: command not found
```

**Root cause:** `docker-entrypoint.sh` fetches swarm config and writes `KEY=value` lines to `/tmp/swarm_config.env`, then sources it. Shell variable names may only contain letters, digits, and underscores (POSIX: `^[A-Za-z_][A-Za-z0-9_]*$`). Keys like `CF-Access-Client-Id` / `CF-Access-Client-Secret` — which exist because they're used as MCP HTTP header names via `headerConfigKeys` — are not valid shell identifiers. The shell parses `CF-Access-Client-Id=...` as a command invocation → "command not found", and the source call aborts. All subsequent config entries silently don't load.

## Fix

In `docker-entrypoint.sh`, the `jq` pipeline that generates `/tmp/swarm_config.env` now includes an additional `select` that filters out any key that does not match `^[A-Za-z_][A-Za-z0-9_]*$`. Skipped keys are logged at debug level. The keys are **not** removed from swarm config — they remain available for `headerConfigKeys` per-request resolution from the API.

## Test

Added `src/tests/entrypoint-config-env-export.test.ts` with 5 unit tests covering:
- Valid POSIX identifier keys (`FOO`, `MY_VAR_123`, `_UNDERSCORE_START`) are exported
- Hyphenated keys (`CF-Access-Client-Id`, `CF-Access-Client-Secret`) are excluded
- Keys starting with a digit are excluded
- Existing exclusions (`codex_oauth`, `HARNESS_PROVIDER`) still apply
- Empty config array returns empty result

## Manual Test Plan

1. Add a config entry with a hyphenated key (e.g. `CF-Access-Client-Id`) via the swarm API.
2. Restart a worker container.
3. Check entrypoint logs — the key should appear in `[entrypoint] debug: skipping non-identifier config keys...` rather than causing "command not found".
4. Verify that valid keys (e.g. `ANTHROPIC_API_KEY`) are still exported inside the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)