### PR TITLE
ci(merge-gate): trigger on merge_group for GitHub merge queue

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+  # Run the same gate when GitHub's merge queue forms a merge group, so the
+  # "Merge Gate" required check reports a status for queued PRs. Without this,
+  # a merge-queue-required check would never run and PRs would be stuck.
+  # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
+  merge_group:
 
 jobs:
   detect-changes:
@@ -23,14 +28,24 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.base_ref }}
+      - name: Determine base for diff
+        id: base
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            # merge_group events have no github.base_ref; diff against the
+            # merge group's base SHA (already reachable via fetch-depth: 0).
+            echo "ref=${{ github.event.merge_group.base_sha }}" >> "$GITHUB_OUTPUT"
+          else
+            git fetch origin "${{ github.base_ref }}"
+            echo "ref=origin/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Compute per-domain change flags
         id: check
         run: |
           set -euo pipefail
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          CHANGED=$(git diff --name-only ${{ steps.base.outputs.ref }}...HEAD)
           echo "Changed files:"
           echo "$CHANGED"
           echo "---"


### PR DESCRIPTION
## What

Adds the `merge_group` event trigger to the **Merge Gate** workflow (`.github/workflows/merge-gate.yml`), per GitHub's [Triggering merge group checks with GitHub Actions](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions).

## Why

The `gate` job (display name **"Merge Gate"**) is the required status check for merging. When a **merge queue** is enabled, GitHub forms a temporary *merge group* and the required checks must report a status on the `merge_group` event. Without this trigger, the required check would never run against a queued group and PRs would stall in the queue indefinitely.

## Changes

- `on:` now also fires on `merge_group:` (the existing `pull_request` → `main` trigger is unchanged).
- Made `detect-changes` event-aware: `github.base_ref` is empty on `merge_group` events, so a new step diffs against `github.event.merge_group.base_sha` (reachable via the job's existing `fetch-depth: 0`) for merge groups, and keeps the `origin/<base_ref>` diff for pull requests. The per-domain change-detection logic is otherwise untouched.

## Validation

- YAML parses cleanly (ruby + js-yaml).
- Pre-push hooks passed (lint, tsc, tests, boundary checks).
- On a PR (this one), behavior is identical to before — the `merge_group` branch is only exercised once a merge queue is enabled and this check is marked required.

> Note: a repo admin still needs to enable the merge queue + mark **"Merge Gate"** as required in branch protection for this to take effect.