### PR TITLE
feat(workers): wire context-mode ctx_* tools into Claude/Codex/OpenCode harnesses

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -126,8 +126,18 @@ RUN mkdir -p /home/worker/.codex && \
       'sandbox_mode = "danger-full-access"' \
       'skip_git_repo_check = true' \
       'show_raw_agent_reasoning = false' \
+      '' \
+      '[features]' \
+      'hooks = true' \
+      'plugin_hooks = true' \
       > /home/worker/.codex/config.toml && \
     chown -R worker:worker /home/worker/.codex
+
+# Install the context-mode Codex plugin (provides the ctx_* hooks for the Codex
+# harness). The [features] block above enables hooks + plugin-provided hooks.
+# Guarded with || true so a marketplace/registry hiccup can't fail the build.
+RUN codex plugin marketplace add mksglu/context-mode || true \
+    && codex plugin install context-mode@context-mode || true
 
 # Install opencode CLI + SDK (alternative harness, selected via HARNESS_PROVIDER=opencode)
 # CLI version must match SDK version — the SDK spawns `opencode serve` and parses
@@ -141,6 +151,15 @@ ENV PATH="/home/worker/.opencode/bin:$PATH"
 ARG OPENCODE_SDK_VERSION=1.15.12
 RUN sudo npm install -g @opencode-ai/sdk@${OPENCODE_SDK_VERSION}
 
+# Install context-mode CLI globally (context-window compression tools for all
+# harnesses). The global install puts `context-mode` on PATH (for Claude/Codex
+# stdio MCP) AND makes the package importable (for the OpenCode in-process
+# plugin). The Claude/Codex plugin installs provide the hooks; this provides
+# the CLI binary + package importability. Disable per-worker via
+# CONTEXT_MODE_DISABLED=true (read by the adapters at runtime).
+ARG CONTEXT_MODE_VERSION=1.0.151
+RUN sudo npm install -g context-mode@${CONTEXT_MODE_VERSION}
+
 # Install Claude marketplace plugins (build-time cache)
 RUN mkdir -p /home/worker/.claude \
     # Main desplega toolbox plugin
@@ -151,8 +170,12 @@ RUN mkdir -p /home/worker/.claude \
     # desplega.ai qa-use CLI
     && claude plugin marketplace add desplega-ai/qa-use || true \
     && claude plugin install qa-use@desplega.ai --scope user || true \
-    # context-mode to improve the
+    # context-mode to improve context-window usage. Pin the marketplace clone
+    # to the tag matching CONTEXT_MODE_VERSION so the installed plugin tracks the
+    # globally-installed CLI. The marketplace repo tags releases as v<version>;
+    # the checkout is guarded so an unexpected tag scheme can't fail the build.
     && claude plugin marketplace add mksglu/claude-context-mode || true \
+    && (cd /home/worker/.claude/plugins/marketplaces/context-mode && git checkout "v${CONTEXT_MODE_VERSION}" 2>/dev/null || true) \
     && claude plugin install context-mode@context-mode --scope user || true \
     # agent-fs goodies
     && claude plugin marketplace add desplega-ai/agent-fs || true \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -170,12 +170,15 @@ RUN mkdir -p /home/worker/.claude \
     # desplega.ai qa-use CLI
     && claude plugin marketplace add desplega-ai/qa-use || true \
     && claude plugin install qa-use@desplega.ai --scope user || true \
-    # context-mode to improve context-window usage. Pin the marketplace clone
-    # to the tag matching CONTEXT_MODE_VERSION so the installed plugin tracks the
-    # globally-installed CLI. The marketplace repo tags releases as v<version>;
-    # the checkout is guarded so an unexpected tag scheme can't fail the build.
+    # context-mode to improve context-window usage. NOTE: this plugin (which
+    # provides the ctx_* HOOKS) tracks the marketplace HEAD and is NOT version-
+    # pinned. A build-time `git checkout v${CONTEXT_MODE_VERSION}` in the
+    # marketplace clone does not work (git rejects it with "dubious ownership"
+    # and the clone is shallow without tags), so we don't attempt it. The ctx_*
+    # TOOLS are served by the globally-installed CLI (npm i -g
+    # context-mode@${CONTEXT_MODE_VERSION} above), which IS pinned; only the
+    # hook bundle floats — acceptable since the hooks are backward-compatible.
     && claude plugin marketplace add mksglu/claude-context-mode || true \
-    && (cd /home/worker/.claude/plugins/marketplaces/context-mode && git checkout "v${CONTEXT_MODE_VERSION}" 2>/dev/null || true) \
     && claude plugin install context-mode@context-mode --scope user || true \
     # agent-fs goodies
     && claude plugin marketplace add desplega-ai/agent-fs || true \

--- a/runbooks/local-development.md
+++ b/runbooks/local-development.md
@@ -20,6 +20,7 @@ Bun auto-loads `.env`. Don't use `dotenv`.
 | `MCP_BASE_URL` | `http://localhost:3013` | Public URL the workers/UI hit |
 | `APP_URL` | `http://localhost:5274` | Dashboard URL |
 | `SLACK_DISABLE` / `GITHUB_DISABLE` / `JIRA_DISABLE` / `LINEAR_DISABLE` | unset | Set `=true` to disable each integration |
+| `CONTEXT_MODE_DISABLED` | unset (enabled) | Set `=true` to opt a worker out of context-mode. Default-enabled — the worker image bakes in context-mode, and the Claude/Codex/OpenCode adapters wire it in unless this is `true`. |
 | `HARNESS_PROVIDER` | `claude` | `claude`, `pi`, `codex`, `devin`, or `claude-managed` |
 | `TEMPLATE_ID` | unset | e.g. `official/coder` |
 | `TEMPLATE_REGISTRY_URL` | `https://templates.agent-swarm.dev` | |

--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -3295,6 +3295,7 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
       swarmUrl,
       capabilities,
       traits,
+      provider: adapter.name as ProviderName,
       name: agentProfileName,
       description: agentDescription,
       ...(traits.hasLocalEnvironment && {

--- a/src/prompts/base-prompt.ts
+++ b/src/prompts/base-prompt.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ProviderTraits } from "../providers/types";
+import type { ProviderName } from "../types";
 import { resolveTemplateAsync } from "./resolver";
 
 // Side-effect import: register all system + session templates
@@ -55,6 +56,12 @@ export type BasePromptArgs = {
   swarmUrl: string;
   capabilities?: string[];
   traits?: ProviderTraits;
+  /**
+   * Harness provider for this session. Gates provider-specific prompt blocks
+   * (e.g. the context-mode block is excluded for `pi`, which has no
+   * context-mode MCP wiring yet — deferred to DES-514).
+   */
+  provider?: ProviderName;
   name?: string;
   description?: string;
   soulMd?: string;
@@ -91,8 +98,16 @@ export const getBasePrompt = async (args: BasePromptArgs): Promise<string> => {
   if (!hasMcp) {
     // If no MCP, role cannot be lead
     compositeEventType = "system.session.worker.remote";
+  } else if (role === "lead") {
+    compositeEventType = "system.session.lead";
+  } else if (args.provider === "pi") {
+    // Pi has no context-mode MCP wiring yet (deferred to DES-514), so it uses a
+    // worker composite that omits the context_mode block to avoid advertising
+    // phantom `ctx_*` tools. All other local providers (claude, codex, opencode)
+    // keep the block via the standard worker composite.
+    compositeEventType = "system.session.worker.pi";
   } else {
-    compositeEventType = role === "lead" ? "system.session.lead" : "system.session.worker";
+    compositeEventType = "system.session.worker";
   }
   const compositeResult = await resolveTemplateAsync(compositeEventType, vars);
   let prompt = compositeResult.text;

--- a/src/prompts/session-templates.ts
+++ b/src/prompts/session-templates.ts
@@ -586,6 +586,32 @@ registerTemplate({
   category: "session",
 });
 
+// Pi-specific worker composite. Identical to `system.session.worker` except it
+// OMITS the `system.agent.context_mode` block — pi has no context-mode MCP
+// wiring yet (deferred to DES-514), so advertising the `ctx_*` tools to pi
+// workers would point at phantom tools. `getBasePrompt` selects this composite
+// when `provider === 'pi'`; all other local providers (claude, codex, opencode)
+// keep the context_mode block via `system.session.worker`.
+registerTemplate({
+  eventType: "system.session.worker.pi",
+  header: "",
+  defaultBody: `{{@template[system.agent.role]}}
+
+{{@template[system.agent.register]}}
+{{@template[system.agent.worker]}}
+{{@template[system.agent.filesystem]}}
+{{@template[system.agent.self_awareness]}}
+
+{{@template[system.agent.system]}}
+{{@template[system.agent.share_urls]}}
+{{@template[system.agent.code_quality]}}`,
+  variables: [
+    { name: "role", description: "The agent's role" },
+    { name: "agentId", description: "The agent's unique identifier" },
+  ],
+  category: "session",
+});
+
 // ============================================================================
 // Remote provider templates (no MCP, no Docker container)
 // ============================================================================

--- a/src/providers/claude-adapter.ts
+++ b/src/providers/claude-adapter.ts
@@ -256,6 +256,17 @@ export async function createSessionMcpConfig(
 
   if (Object.keys(mergedServers).length === 0 && !installedServers) return null;
 
+  // Inject the context-mode stdio MCP server so its `ctx_*` tools survive
+  // `--strict-mcp-config` (which restricts Claude to this file and structurally
+  // excludes plugin-provided MCP servers). The plugin's hooks still fire via the
+  // installed Claude plugin — strict-mcp-config only suppresses MCP servers, not
+  // hooks. Placed BEFORE mergeMcpConfig so an API-installed server can still
+  // override it (unlikely, but safe). Gated by CONTEXT_MODE_DISABLED so builds
+  // and deploys without context-mode don't break.
+  if (process.env.CONTEXT_MODE_DISABLED !== "true") {
+    mergedServers["context-mode"] = { command: "context-mode" };
+  }
+
   try {
     const config = mergeMcpConfig({ mcpServers: mergedServers }, installedServers ?? null, taskId);
     const sessionConfigPath = `/tmp/mcp-${taskId}.json`;

--- a/src/providers/codex-adapter.ts
+++ b/src/providers/codex-adapter.ts
@@ -351,15 +351,34 @@ export async function buildCodexConfig(
     }
   }
 
+  // (4) context-mode — pre-installed stdio MCP server providing the `ctx_*`
+  // context-compression tools. Gated by `CONTEXT_MODE_DISABLED` so builds /
+  // deploys without the `context-mode` binary on PATH don't break the session.
+  // Same entry shape as the swarm + installed-server stdio entries above.
+  if (process.env.CONTEXT_MODE_DISABLED !== "true") {
+    mcpServers["context-mode"] = {
+      command: "context-mode",
+      enabled: true,
+      startup_timeout_sec: 30,
+      tool_timeout_sec: 120,
+    };
+  }
+
   // (1) Baseline overrides. Keep these aligned with the Dockerfile baseline
   // at `~/.codex/config.toml` (Phase 6). Repeating them here makes local dev
   // (no baseline file) behave identically to the Docker worker.
+  //
+  // `features.hooks` / `features.plugin_hooks` enable Codex's hook system and
+  // the hooks contributed by installed Codex plugins (context-mode's plugin:
+  // routing injection, PreToolUse safety blocks, output capture). The SDK
+  // flattens these to `--config features.hooks=true` / `features.plugin_hooks=true`.
   return {
     model,
     approval_policy: "never",
     sandbox_mode: "danger-full-access",
     skip_git_repo_check: true,
     show_raw_agent_reasoning: false,
+    features: { hooks: true, plugin_hooks: true },
     mcp_servers: mcpServers as CodexConfig,
   };
 }

--- a/src/providers/opencode-adapter.ts
+++ b/src/providers/opencode-adapter.ts
@@ -588,6 +588,15 @@ export class OpencodeAdapter implements ProviderAdapter {
     // an accident, not a contract.
     const pluginPath = resolvePluginPath();
 
+    // context-mode ships as an in-process opencode plugin (NOT an MCP server).
+    // Adding it to the `plugin` array registers both its native ctx_* tools and
+    // its 5 hook surrogates. It must NOT also appear in the `mcp` block — dual
+    // registration yields zero tools. Gated so builds/deploys without it opt out.
+    const plugins = [pluginPath];
+    if (process.env.CONTEXT_MODE_DISABLED !== "true") {
+      plugins.push("context-mode");
+    }
+
     // Build per-task opencode config (plugin field carries the swarm plugin)
     const opencodeConfig: Config & { plugin?: string[] } = {
       $schema: "https://opencode.ai/config.json",
@@ -600,7 +609,7 @@ export class OpencodeAdapter implements ProviderAdapter {
         doom_loop: "allow",
         external_directory: "allow",
       },
-      plugin: [pluginPath],
+      plugin: plugins,
     };
 
     // Write per-task config file

--- a/src/providers/opencode-adapter.ts
+++ b/src/providers/opencode-adapter.ts
@@ -176,6 +176,32 @@ function resolvePluginPath(): string {
   return join(import.meta.dir, "../../plugin/opencode-plugins/agent-swarm.ts");
 }
 
+// context-mode is installed globally via `npm install -g` (Dockerfile.worker),
+// which places it under the npm global modules dir. opencode resolves bare
+// plugin names with `import(await Bun.resolve(name, ...))`, which does NOT walk
+// the npm global dir — a bare "context-mode" entry only resolves if Bun
+// auto-installs from the registry at runtime, which fails on network-sandboxed
+// workers. So we hand opencode the ABSOLUTE path to the package's built
+// opencode-plugin entry, which imports cleanly with no network.
+const CONTEXT_MODE_GLOBAL_ROOTS = ["/usr/lib/node_modules", "/usr/local/lib/node_modules"];
+const CONTEXT_MODE_PLUGIN_SUBPATH = "context-mode/build/adapters/opencode/plugin.js";
+
+/**
+ * Resolve the absolute path to context-mode's opencode plugin entry, or `null`
+ * if it can't be found on disk. `CONTEXT_MODE_OPENCODE_PLUGIN_PATH` overrides
+ * the lookup (and must itself exist). Returning `null` lets the caller skip the
+ * plugin gracefully instead of handing opencode an unresolvable entry.
+ */
+export function resolveContextModePluginPath(): string | null {
+  const override = process.env.CONTEXT_MODE_OPENCODE_PLUGIN_PATH;
+  if (override) return existsSync(override) ? override : null;
+  for (const root of CONTEXT_MODE_GLOBAL_ROOTS) {
+    const candidate = join(root, CONTEXT_MODE_PLUGIN_SUBPATH);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
 export class OpencodeSession implements ProviderSession {
   private _sessionId: string;
   private listeners: Array<(event: ProviderEvent) => void> = [];
@@ -589,12 +615,24 @@ export class OpencodeAdapter implements ProviderAdapter {
     const pluginPath = resolvePluginPath();
 
     // context-mode ships as an in-process opencode plugin (NOT an MCP server).
-    // Adding it to the `plugin` array registers both its native ctx_* tools and
-    // its 5 hook surrogates. It must NOT also appear in the `mcp` block — dual
-    // registration yields zero tools. Gated so builds/deploys without it opt out.
+    // Its built plugin entry registers both the native ctx_* tools and the 5
+    // hook surrogates. It must NOT also appear in the `mcp` block — dual
+    // registration yields zero tools. We push the ABSOLUTE path to the globally
+    // installed package's opencode plugin entry, not the bare name (see
+    // resolveContextModePluginPath for why a bare name fails to resolve offline).
+    // Gated by CONTEXT_MODE_DISABLED so builds/deploys without it opt out.
     const plugins = [pluginPath];
     if (process.env.CONTEXT_MODE_DISABLED !== "true") {
-      plugins.push("context-mode");
+      const contextModePluginPath = resolveContextModePluginPath();
+      if (contextModePluginPath) {
+        plugins.push(contextModePluginPath);
+      } else {
+        console.warn(
+          "[opencode] context-mode is enabled but its opencode plugin entry was not found on disk; " +
+            "skipping it for this session. Set CONTEXT_MODE_OPENCODE_PLUGIN_PATH to override, or " +
+            "CONTEXT_MODE_DISABLED=true to silence.",
+        );
+      }
     }
 
     // Build per-task opencode config (plugin field carries the swarm plugin)

--- a/src/tests/base-prompt.test.ts
+++ b/src/tests/base-prompt.test.ts
@@ -605,6 +605,47 @@ describe("getBasePrompt — local providers unaffected", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Context-mode block — provider gating
+//
+// The context_mode block advertises the `ctx_*` MCP tools. It is included for
+// local providers that have context-mode wired into their per-session config
+// (claude, codex, opencode) and excluded for `pi`, which has no context-mode
+// wiring yet (deferred to DES-514). Remote-provider exclusion is covered by the
+// "remote provider excluded sections" suite above.
+// ---------------------------------------------------------------------------
+const localTraits: ProviderTraits = { hasMcp: true, hasLocalEnvironment: true };
+
+describe("getBasePrompt — context-mode provider gating", () => {
+  test("excludes context-mode block for pi provider", async () => {
+    const result = await getBasePrompt({
+      ...minimalArgs,
+      traits: localTraits,
+      provider: "pi",
+    });
+    expect(result).not.toContain("Context Window Management");
+    expect(result).not.toContain("context-mode");
+  });
+
+  for (const provider of ["claude", "codex", "opencode"] as const) {
+    test(`includes context-mode block for ${provider} provider`, async () => {
+      const result = await getBasePrompt({
+        ...minimalArgs,
+        traits: localTraits,
+        provider,
+      });
+      expect(result).toContain("Context Window Management");
+      expect(result).toContain("context-mode");
+    });
+  }
+
+  test("includes context-mode block when provider is unspecified (local default)", async () => {
+    const result = await getBasePrompt({ ...minimalArgs, traits: localTraits });
+    expect(result).toContain("Context Window Management");
+    expect(result).toContain("context-mode");
+  });
+});
+
 describe("getBasePrompt — conditional Slack templates", () => {
   test("omits Slack tool templates when Slack is disabled", async () => {
     disableSlackPromptTools();

--- a/src/tests/claude-adapter.test.ts
+++ b/src/tests/claude-adapter.test.ts
@@ -246,6 +246,21 @@ describe("mergeMcpConfig (issue #369)", () => {
     const merged = mergeMcpConfig({ mcpServers: {} }, {}, TASK_ID);
     expect(Object.keys(merged.mcpServers)).toHaveLength(0);
   });
+
+  test("preserves a context-mode entry through the merge", () => {
+    const base = {
+      mcpServers: {
+        "agent-swarm": {
+          type: "http",
+          url: "http://localhost:3013/mcp",
+          headers: { Authorization: "Bearer KEY", "X-Agent-ID": "a1" },
+        },
+        "context-mode": { command: "context-mode" },
+      },
+    };
+    const merged = mergeMcpConfig(base, null, TASK_ID);
+    expect(merged.mcpServers["context-mode"]).toEqual({ command: "context-mode" });
+  });
 });
 
 describe("createSessionMcpConfig", () => {
@@ -323,7 +338,13 @@ describe("createSessionMcpConfig", () => {
     const written = await readWritten(path!);
     expect(written.mcpServers["agent-swarm"]).toBeDefined();
     expect(written.mcpServers.Datadog).toBeDefined();
-    expect(Object.keys(written.mcpServers).sort()).toEqual(["Datadog", "agent-swarm"]);
+    // context-mode is injected by default (see CONTEXT_MODE_DISABLED gate); the
+    // two differently-named .mcp.json servers still merge alongside it.
+    expect(Object.keys(written.mcpServers).sort()).toEqual([
+      "Datadog",
+      "agent-swarm",
+      "context-mode",
+    ]);
   });
 
   test("ancestor wins over repo-local on agent-swarm key conflict", async () => {
@@ -401,5 +422,65 @@ describe("createSessionMcpConfig", () => {
     expect(path).toBe("/tmp/mcp-task-installed.json");
     const written = await readWritten(path!);
     expect(written.mcpServers["from-api"]).toBeDefined();
+  });
+
+  test("includes context-mode entry when CONTEXT_MODE_DISABLED is unset", async () => {
+    const prev = process.env.CONTEXT_MODE_DISABLED;
+    delete process.env.CONTEXT_MODE_DISABLED;
+    try {
+      await writeFile(
+        join(sandbox, ".mcp.json"),
+        JSON.stringify({
+          mcpServers: {
+            "agent-swarm": {
+              type: "http",
+              url: "http://swarm/mcp",
+              headers: { Authorization: "Bearer SWARM", "X-Agent-ID": "a1" },
+            },
+          },
+        }),
+      );
+      const cwd = join(sandbox, "repos", "foo");
+      await mkdir(cwd, { recursive: true });
+
+      const path = await createSessionMcpConfig(cwd, "task-ctx-on");
+      const written = await readWritten(path!);
+      expect(written.mcpServers["context-mode"]).toEqual({ command: "context-mode" });
+      // Coexists with the swarm entry.
+      expect(written.mcpServers["agent-swarm"]).toBeDefined();
+    } finally {
+      if (prev === undefined) delete process.env.CONTEXT_MODE_DISABLED;
+      else process.env.CONTEXT_MODE_DISABLED = prev;
+    }
+  });
+
+  test("excludes context-mode entry when CONTEXT_MODE_DISABLED='true'", async () => {
+    const prev = process.env.CONTEXT_MODE_DISABLED;
+    process.env.CONTEXT_MODE_DISABLED = "true";
+    try {
+      await writeFile(
+        join(sandbox, ".mcp.json"),
+        JSON.stringify({
+          mcpServers: {
+            "agent-swarm": {
+              type: "http",
+              url: "http://swarm/mcp",
+              headers: { Authorization: "Bearer SWARM", "X-Agent-ID": "a1" },
+            },
+          },
+        }),
+      );
+      const cwd = join(sandbox, "repos", "foo");
+      await mkdir(cwd, { recursive: true });
+
+      const path = await createSessionMcpConfig(cwd, "task-ctx-off");
+      const written = await readWritten(path!);
+      expect(written.mcpServers["context-mode"]).toBeUndefined();
+      // The swarm entry is still present.
+      expect(written.mcpServers["agent-swarm"]).toBeDefined();
+    } finally {
+      if (prev === undefined) delete process.env.CONTEXT_MODE_DISABLED;
+      else process.env.CONTEXT_MODE_DISABLED = prev;
+    }
   });
 });

--- a/src/tests/codex-adapter.test.ts
+++ b/src/tests/codex-adapter.test.ts
@@ -872,9 +872,21 @@ describe("computeCodexCostUsd", () => {
 describe("buildCodexConfig", () => {
   // Save and restore the global fetch so we don't leak mocks between tests.
   const originalFetch = globalThis.fetch;
+  // These tests assert the EXACT set of mcp_servers keys, which is only the
+  // installed-server merge logic. Disable the always-on context-mode entry so
+  // those exact-key assertions stay valid; a dedicated block below verifies
+  // the context-mode + features behavior. Save/restore the env to avoid leaks.
+  let prevContextModeDisabled: string | undefined;
+
+  beforeEach(() => {
+    prevContextModeDisabled = process.env.CONTEXT_MODE_DISABLED;
+    process.env.CONTEXT_MODE_DISABLED = "true";
+  });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    if (prevContextModeDisabled === undefined) delete process.env.CONTEXT_MODE_DISABLED;
+    else process.env.CONTEXT_MODE_DISABLED = prevContextModeDisabled;
   });
 
   // Helper: build a ProviderSessionConfig pointed at a mock endpoint.
@@ -1095,6 +1107,83 @@ describe("buildCodexConfig", () => {
     globalThis.fetch = stubFetch({ servers: [] });
     const merged = await buildCodexConfig(cfg(), "gpt-5.3-codex", () => {});
     expect(merged.model).toBe("gpt-5.3-codex");
+  });
+});
+
+// ─── Phase 3: buildCodexConfig — context-mode MCP + hook feature flags ───────
+
+describe("buildCodexConfig — context-mode + features", () => {
+  const originalFetch = globalThis.fetch;
+  // Explicitly own CONTEXT_MODE_DISABLED here. Save the ambient value up front
+  // and restore it after every test so we never leak the mutation to siblings.
+  let prevContextModeDisabled: string | undefined;
+
+  beforeEach(() => {
+    prevContextModeDisabled = process.env.CONTEXT_MODE_DISABLED;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (prevContextModeDisabled === undefined) delete process.env.CONTEXT_MODE_DISABLED;
+    else process.env.CONTEXT_MODE_DISABLED = prevContextModeDisabled;
+  });
+
+  function cfg(overrides: Partial<ProviderSessionConfig> = {}): ProviderSessionConfig {
+    return {
+      prompt: "hello",
+      systemPrompt: "",
+      model: "gpt-5.4",
+      role: "worker",
+      agentId: "agent-mcp-test",
+      taskId: "task-mcp-test",
+      apiUrl: "http://test.invalid",
+      apiKey: "test-key",
+      cwd: "",
+      logFile: `/tmp/codex-ctx-test-${Date.now()}-${Math.random().toString(36).slice(2)}.log`,
+      ...overrides,
+    };
+  }
+
+  function stubFetch(body: unknown, status = 200): typeof globalThis.fetch {
+    return async (): Promise<Response> => {
+      return new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+  }
+
+  test("includes the 'context-mode' mcp_servers entry by default", async () => {
+    delete process.env.CONTEXT_MODE_DISABLED;
+    globalThis.fetch = stubFetch({ servers: [], total: 0 });
+    const merged = await buildCodexConfig(cfg(), "gpt-5.4", () => {});
+    const mcp = merged.mcp_servers as Record<string, Record<string, unknown>>;
+
+    expect(Object.keys(mcp).sort()).toEqual(["agent-swarm", "context-mode"]);
+    expect(mcp["context-mode"]?.command).toBe("context-mode");
+    expect(mcp["context-mode"]?.enabled).toBe(true);
+    expect(mcp["context-mode"]?.startup_timeout_sec).toBe(30);
+    expect(mcp["context-mode"]?.tool_timeout_sec).toBe(120);
+  });
+
+  test("excludes the 'context-mode' entry when CONTEXT_MODE_DISABLED=true", async () => {
+    process.env.CONTEXT_MODE_DISABLED = "true";
+    globalThis.fetch = stubFetch({ servers: [], total: 0 });
+    const merged = await buildCodexConfig(cfg(), "gpt-5.4", () => {});
+    const mcp = merged.mcp_servers as Record<string, Record<string, unknown>>;
+
+    expect(Object.keys(mcp)).toEqual(["agent-swarm"]);
+    expect(mcp["context-mode"]).toBeUndefined();
+  });
+
+  test("sets features.hooks and features.plugin_hooks to true", async () => {
+    delete process.env.CONTEXT_MODE_DISABLED;
+    globalThis.fetch = stubFetch({ servers: [], total: 0 });
+    const merged = await buildCodexConfig(cfg(), "gpt-5.4", () => {});
+
+    const features = merged.features as Record<string, unknown>;
+    expect(features.hooks).toBe(true);
+    expect(features.plugin_hooks).toBe(true);
   });
 });
 

--- a/src/tests/opencode-adapter.test.ts
+++ b/src/tests/opencode-adapter.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Event as OpencodeEvent } from "@opencode-ai/sdk";
 import type { ProviderEvent, ProviderResult, ProviderSessionConfig } from "../providers/types";
@@ -645,22 +646,28 @@ describe("OpencodeAdapter — per-task isolation (DES-300)", () => {
 
 describe("OpencodeAdapter — context-mode plugin wiring (phase 4)", () => {
   let prevContextModeDisabled: string | undefined;
+  let prevContextModePluginPath: string | undefined;
+  // The global npm install of context-mode is absent in the test env, so point
+  // the override at a real temp file to make resolution succeed deterministically.
+  const fakePluginPath = "/tmp/ctx-mode-opencode-plugin.test.js";
 
   beforeEach(() => {
     prevContextModeDisabled = process.env.CONTEXT_MODE_DISABLED;
+    prevContextModePluginPath = process.env.CONTEXT_MODE_OPENCODE_PLUGIN_PATH;
     lastCreateOpencodeConfig = undefined;
     mock.restore();
   });
 
   afterEach(() => {
-    // Never leak the env mutation across tests.
-    if (prevContextModeDisabled === undefined) {
-      delete process.env.CONTEXT_MODE_DISABLED;
-    } else {
-      process.env.CONTEXT_MODE_DISABLED = prevContextModeDisabled;
-    }
+    // Never leak the env mutations across tests.
+    if (prevContextModeDisabled === undefined) delete process.env.CONTEXT_MODE_DISABLED;
+    else process.env.CONTEXT_MODE_DISABLED = prevContextModeDisabled;
+    if (prevContextModePluginPath === undefined)
+      delete process.env.CONTEXT_MODE_OPENCODE_PLUGIN_PATH;
+    else process.env.CONTEXT_MODE_OPENCODE_PLUGIN_PATH = prevContextModePluginPath;
     Bun.$`rm -rf /tmp/opencode-task-1.json /tmp/opencode-data-task-1`.quiet().nothrow();
     Bun.$`rm -rf /tmp/test/.opencode`.quiet().nothrow();
+    Bun.$`rm -f ${fakePluginPath}`.quiet().nothrow();
   });
 
   /** Pull the opencode config object passed to createOpencode. */
@@ -672,30 +679,52 @@ describe("OpencodeAdapter — context-mode plugin wiring (phase 4)", () => {
     return opts.config as { plugin?: string[]; mcp?: Record<string, unknown> };
   }
 
-  test("plugin array includes context-mode by default", async () => {
+  test("resolveContextModePluginPath returns the override path when it exists", async () => {
+    writeFileSync(fakePluginPath, "// test plugin\n");
+    process.env.CONTEXT_MODE_OPENCODE_PLUGIN_PATH = fakePluginPath;
+    const { resolveContextModePluginPath } = await import("../providers/opencode-adapter");
+    expect(resolveContextModePluginPath()).toBe(fakePluginPath);
+  });
+
+  test("resolveContextModePluginPath returns null when the override path is missing", async () => {
+    process.env.CONTEXT_MODE_OPENCODE_PLUGIN_PATH = "/tmp/ctx-mode-does-not-exist.js";
+    const { resolveContextModePluginPath } = await import("../providers/opencode-adapter");
+    expect(resolveContextModePluginPath()).toBeNull();
+  });
+
+  test("plugin array includes the resolved context-mode plugin path when available", async () => {
     delete process.env.CONTEXT_MODE_DISABLED;
+    writeFileSync(fakePluginPath, "// test plugin\n");
+    process.env.CONTEXT_MODE_OPENCODE_PLUGIN_PATH = fakePluginPath;
     const events: OpencodeEvent[] = [
       { type: "session.idle", properties: { sessionID: "sess-abc-123" } },
     ];
     await driveSession(events, testConfig({ taskId: "task-1" }));
 
     const built = getBuiltConfig();
-    expect(built.plugin).toContain("context-mode");
+    expect(built.plugin).toContain(fakePluginPath);
+    // The bare package name must never be used — opencode can't resolve it offline.
+    expect(built.plugin).not.toContain("context-mode");
   });
 
   test("plugin array excludes context-mode when CONTEXT_MODE_DISABLED=true", async () => {
     process.env.CONTEXT_MODE_DISABLED = "true";
+    writeFileSync(fakePluginPath, "// test plugin\n");
+    process.env.CONTEXT_MODE_OPENCODE_PLUGIN_PATH = fakePluginPath;
     const events: OpencodeEvent[] = [
       { type: "session.idle", properties: { sessionID: "sess-abc-123" } },
     ];
     await driveSession(events, testConfig({ taskId: "task-1" }));
 
     const built = getBuiltConfig();
+    expect(built.plugin).not.toContain(fakePluginPath);
     expect(built.plugin).not.toContain("context-mode");
   });
 
   test("context-mode does NOT appear in the mcp block", async () => {
     delete process.env.CONTEXT_MODE_DISABLED;
+    writeFileSync(fakePluginPath, "// test plugin\n");
+    process.env.CONTEXT_MODE_OPENCODE_PLUGIN_PATH = fakePluginPath;
     const events: OpencodeEvent[] = [
       { type: "session.idle", properties: { sessionID: "sess-abc-123" } },
     ];

--- a/src/tests/opencode-adapter.test.ts
+++ b/src/tests/opencode-adapter.test.ts
@@ -640,3 +640,69 @@ describe("OpencodeAdapter — per-task isolation (DES-300)", () => {
     await Bun.$`rm -rf /tmp/opencode-data-task-cfg-json`.quiet().nothrow();
   });
 });
+
+// ── Phase 4: context-mode in-process plugin ────────────────────────────────────
+
+describe("OpencodeAdapter — context-mode plugin wiring (phase 4)", () => {
+  let prevContextModeDisabled: string | undefined;
+
+  beforeEach(() => {
+    prevContextModeDisabled = process.env.CONTEXT_MODE_DISABLED;
+    lastCreateOpencodeConfig = undefined;
+    mock.restore();
+  });
+
+  afterEach(() => {
+    // Never leak the env mutation across tests.
+    if (prevContextModeDisabled === undefined) {
+      delete process.env.CONTEXT_MODE_DISABLED;
+    } else {
+      process.env.CONTEXT_MODE_DISABLED = prevContextModeDisabled;
+    }
+    Bun.$`rm -rf /tmp/opencode-task-1.json /tmp/opencode-data-task-1`.quiet().nothrow();
+    Bun.$`rm -rf /tmp/test/.opencode`.quiet().nothrow();
+  });
+
+  /** Pull the opencode config object passed to createOpencode. */
+  function getBuiltConfig(): { plugin?: string[]; mcp?: Record<string, unknown> } {
+    const opts = lastCreateOpencodeConfig as {
+      config?: { plugin?: string[]; mcp?: Record<string, unknown> };
+    };
+    expect(opts.config).toBeDefined();
+    return opts.config as { plugin?: string[]; mcp?: Record<string, unknown> };
+  }
+
+  test("plugin array includes context-mode by default", async () => {
+    delete process.env.CONTEXT_MODE_DISABLED;
+    const events: OpencodeEvent[] = [
+      { type: "session.idle", properties: { sessionID: "sess-abc-123" } },
+    ];
+    await driveSession(events, testConfig({ taskId: "task-1" }));
+
+    const built = getBuiltConfig();
+    expect(built.plugin).toContain("context-mode");
+  });
+
+  test("plugin array excludes context-mode when CONTEXT_MODE_DISABLED=true", async () => {
+    process.env.CONTEXT_MODE_DISABLED = "true";
+    const events: OpencodeEvent[] = [
+      { type: "session.idle", properties: { sessionID: "sess-abc-123" } },
+    ];
+    await driveSession(events, testConfig({ taskId: "task-1" }));
+
+    const built = getBuiltConfig();
+    expect(built.plugin).not.toContain("context-mode");
+  });
+
+  test("context-mode does NOT appear in the mcp block", async () => {
+    delete process.env.CONTEXT_MODE_DISABLED;
+    const events: OpencodeEvent[] = [
+      { type: "session.idle", properties: { sessionID: "sess-abc-123" } },
+    ];
+    await driveSession(events, testConfig({ taskId: "task-1" }));
+
+    const built = getBuiltConfig();
+    expect(built.mcp).toBeDefined();
+    expect(built.mcp?.["context-mode"]).toBeUndefined();
+  });
+});

--- a/src/tests/prompt-template-session.test.ts
+++ b/src/tests/prompt-template-session.test.ts
@@ -90,10 +90,12 @@ describe("Session templates — registration", () => {
     }
   });
 
-  test("total of 19 session/system templates registered", () => {
+  test("total of 20 session/system templates registered", () => {
     const all = getAllTemplateDefinitions();
     const sessionSystem = all.filter((d) => d.category === "system" || d.category === "session");
-    expect(sessionSystem.length).toBe(19);
+    // 20 = the original 19 + `system.session.worker.pi` (a pi-specific worker
+    // composite that omits the context_mode block — see session-templates.ts).
+    expect(sessionSystem.length).toBe(20);
   });
 });
 

--- a/thoughts/taras/plans/2026-05-28-context-mode-worker-wiring.md
+++ b/thoughts/taras/plans/2026-05-28-context-mode-worker-wiring.md
@@ -389,6 +389,16 @@ bun run start:http
 
 ---
 
+## Implementation Deviations
+
+Captured during implementation (autopilot, 2026-05-29):
+
+1. **Phase 4 (OpenCode) — absolute path instead of bare name.** The plan assumed `npm install -g context-mode` makes the package importable for OpenCode's in-process plugin. It does not: OpenCode resolves bare plugin names via `import(await Bun.resolve(name, …))`, which does not walk the npm global modules dir. A bare `"context-mode"` entry only resolves if Bun auto-installs from the registry at runtime (fails on network-sandboxed workers — verified with `--network none`). Fix: `opencode-adapter` now pushes the **absolute path** to the global install's built opencode plugin entry (`<npm root -g>/context-mode/build/adapters/opencode/plugin.js`), confirmed to import offline. Override via `CONTEXT_MODE_OPENCODE_PLUGIN_PATH`; skipped gracefully (with a warning) when not found.
+
+2. **Phase 1 (Claude plugin) — left unpinned.** The build-time `git checkout v<version>` in the marketplace clone fails (`git` rejects it with "dubious ownership" and the clone is shallow without tags). The hooks-providing plugin therefore tracks marketplace HEAD; the ctx_* **tools** are served by the version-pinned global CLI, so only the (backward-compatible) hook bundle floats. Accepted as low-risk.
+
+3. **Phase 5 (pi exclusion) — wider than 2 files.** No provider exclusion *set* existed; remote providers are excluded via composite *selection* in `getBasePrompt`. Implemented by threading `provider` through `getBasePrompt`/`runner.ts` and registering a `system.session.worker.pi` composite without the `context_mode` reference.
+
 ## Appendix
 
 - **Research**: `thoughts/taras/research/2026-05-28-context-mode-mcp-setup-across-harnesses.md`

--- a/thoughts/taras/plans/2026-05-28-context-mode-worker-wiring.md
+++ b/thoughts/taras/plans/2026-05-28-context-mode-worker-wiring.md
@@ -145,14 +145,14 @@ Add `context-mode` as a globally-installed npm package (version-pinned), pin the
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Docker build succeeds: `docker build -f Dockerfile.worker .`
-- [ ] `context-mode` binary is on PATH in the image: `docker run --rm <img> which context-mode`
-- [ ] `context-mode` package is importable: `docker run --rm <img> node -e "require('context-mode')"`
+- [x] Docker build succeeds: `docker build -f Dockerfile.worker .`
+- [x] `context-mode` binary is on PATH in the image: `docker run --rm <img> which context-mode` → `/usr/bin/context-mode`
+- [x] `context-mode` package is importable <!-- NOTE: bare `require('context-mode')` is N/A — it's a global ESM package not resolvable by name from an arbitrary cwd. Verified `import()` of the absolute plugin entry works offline (`--network none`). -->
 - [x] Existing tests pass: `bun test`
 - [x] Type check passes: `bun run tsc:check`
 
 #### Automated QA:
-- [ ] Verify `context-mode --help` or `context-mode doctor` runs inside a fresh container
+- [x] Verify `context-mode --help` or `context-mode doctor` runs inside a fresh container
 
 #### Manual Verification:
 - [ ] Image size delta is acceptable (check `docker history` for the new layer)

--- a/thoughts/taras/plans/2026-05-28-context-mode-worker-wiring.md
+++ b/thoughts/taras/plans/2026-05-28-context-mode-worker-wiring.md
@@ -1,7 +1,7 @@
 ---
 date: 2026-05-28T12:00:00Z
 topic: "Context-Mode MCP Wiring for Swarm Workers"
-status: approved
+status: completed
 autonomy: critical
 commit_per_phase: true
 ---
@@ -148,8 +148,8 @@ Add `context-mode` as a globally-installed npm package (version-pinned), pin the
 - [ ] Docker build succeeds: `docker build -f Dockerfile.worker .`
 - [ ] `context-mode` binary is on PATH in the image: `docker run --rm <img> which context-mode`
 - [ ] `context-mode` package is importable: `docker run --rm <img> node -e "require('context-mode')"`
-- [ ] Existing tests pass: `bun test`
-- [ ] Type check passes: `bun run tsc:check`
+- [x] Existing tests pass: `bun test`
+- [x] Type check passes: `bun run tsc:check`
 
 #### Automated QA:
 - [ ] Verify `context-mode --help` or `context-mode doctor` runs inside a fresh container
@@ -189,13 +189,13 @@ Inject a `context-mode` stdio MCP server entry into the per-session config built
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Tests pass: `bun test src/tests/claude-adapter.test.ts`
-- [ ] All tests pass: `bun test`
-- [ ] Type check: `bun run tsc:check`
-- [ ] Lint: `bun run lint`
+- [x] Tests pass: `bun test src/tests/claude-adapter.test.ts`
+- [x] All tests pass: `bun test`
+- [x] Type check: `bun run tsc:check`
+- [x] Lint: `bun run lint`
 
 #### Automated QA:
-- [ ] `cat /tmp/mcp-<taskId>.json` in a test run shows the `context-mode` entry alongside `agent-swarm`
+- [x] `cat /tmp/mcp-<taskId>.json` in a test run shows the `context-mode` entry alongside `agent-swarm` <!-- covered by claude-adapter.test.ts unit assertions -->
 
 #### Manual Verification:
 - [ ] Start a Claude worker locally, verify `ctx stats` or `ctx doctor` tool is callable (requires Docker image from Phase 1)
@@ -255,13 +255,13 @@ Add a `context-mode` entry to the `mcp_servers` object built by `buildCodexConfi
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Tests pass: `bun test src/tests/codex-adapter.test.ts`
-- [ ] All tests pass: `bun test`
-- [ ] Type check: `bun run tsc:check`
-- [ ] Lint: `bun run lint`
+- [x] Tests pass: `bun test src/tests/codex-adapter.test.ts`
+- [x] All tests pass: `bun test`
+- [x] Type check: `bun run tsc:check`
+- [x] Lint: `bun run lint`
 
 #### Automated QA:
-- [ ] Log/print the built Codex config in a test run and verify `context-mode` appears in `mcp_servers` and `features.hooks` is `true`
+- [x] Log/print the built Codex config in a test run and verify `context-mode` appears in `mcp_servers` and `features.hooks` is `true` <!-- covered by codex-adapter.test.ts unit assertions -->
 
 #### Manual Verification:
 - [ ] Start a Codex worker locally with Docker, verify `ctx_*` tools are available and hooks fire (check for routing instruction injection at session start)
@@ -302,13 +302,13 @@ Add `"context-mode"` to the `plugin` array in the OpenCode config (NOT the `mcp`
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Tests pass: `bun test src/tests/opencode-adapter.test.ts`
-- [ ] All tests pass: `bun test`
-- [ ] Type check: `bun run tsc:check`
-- [ ] Lint: `bun run lint`
+- [x] Tests pass: `bun test src/tests/opencode-adapter.test.ts`
+- [x] All tests pass: `bun test`
+- [x] Type check: `bun run tsc:check`
+- [x] Lint: `bun run lint`
 
 #### Automated QA:
-- [ ] Print the written `/tmp/opencode-<taskId>.json` and verify `context-mode` is in `plugin` but not in `mcp`
+- [x] Print the written `/tmp/opencode-<taskId>.json` and verify `context-mode` is in `plugin` but not in `mcp` <!-- covered by opencode-adapter.test.ts unit assertions -->
 
 #### Manual Verification:
 - [ ] Start an OpenCode worker locally with Docker, verify `ctx_*` tools load
@@ -340,13 +340,13 @@ Stop advertising `ctx_*` tools to pi workers since they can't use them (deferred
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Tests pass: `bun test src/tests/base-prompt.test.ts`
-- [ ] All tests pass: `bun test`
-- [ ] Type check: `bun run tsc:check`
-- [ ] Lint: `bun run lint`
+- [x] Tests pass: `bun test src/tests/base-prompt.test.ts`
+- [x] All tests pass: `bun test`
+- [x] Type check: `bun run tsc:check`
+- [x] Lint: `bun run lint`
 
 #### Automated QA:
-- [ ] Diff the generated system prompts for each provider and confirm context_mode presence/absence is correct
+- [x] Diff the generated system prompts for each provider and confirm context_mode presence/absence is correct <!-- covered by base-prompt.test.ts unit assertions -->
 
 #### Manual Verification:
 - [ ] None — automated checks sufficient


### PR DESCRIPTION
## Summary

Wires context-mode's `ctx_*` tools into agent-swarm workers across all four local harnesses so they actually load at runtime. Previously context-mode was installed and advertised in worker prompts but never loaded — Claude's `--strict-mcp-config` filtered it out and the other three providers had no wiring.

Implements [`thoughts/taras/plans/2026-05-28-context-mode-worker-wiring.md`].

## Changes

- **Docker (Phase 1)** — global `npm i -g context-mode@1.0.151` (puts the CLI on PATH + package on disk), Codex plugin install + `[features] hooks/plugin_hooks` in `config.toml`, `CONTEXT_MODE_DISABLED` env gate documented.
- **Claude (Phase 2)** — inject a `context-mode` stdio MCP entry into the per-session config so it survives `--strict-mcp-config`.
- **Codex (Phase 3)** — `context-mode` `mcp_servers` entry + `features.hooks/plugin_hooks` flags.
- **OpenCode (Phase 4)** — load context-mode as an in-process plugin via the **absolute path** to the global install's built plugin entry (see deviation #1).
- **pi (Phase 5)** — exclude the `context_mode` prompt block (pi can't load the tools yet — deferred to DES-514) via a new `system.session.worker.pi` composite.

Gated everywhere by `CONTEXT_MODE_DISABLED=true` (default: enabled).

## Deviations from the plan (verified during implementation)

1. **OpenCode uses an absolute path, not the bare name.** The plan assumed `npm install -g` makes context-mode importable for OpenCode's in-process plugin. It doesn't: OpenCode resolves bare plugin names via `import(await Bun.resolve(name, …))`, which does **not** walk the npm global modules dir. A bare `"context-mode"` only resolves if Bun auto-installs from the registry at runtime — which fails on network-sandboxed workers (verified with `--network none`). Fix: push the absolute path to `<npm root -g>/context-mode/build/adapters/opencode/plugin.js` (imports cleanly offline). Override via `CONTEXT_MODE_OPENCODE_PLUGIN_PATH`; skipped gracefully when not found.
2. **Claude plugin left unpinned.** A build-time `git checkout v<version>` in the marketplace clone fails (git "dubious ownership" + shallow clone without tags). The hooks-providing plugin tracks marketplace HEAD; the ctx_* **tools** are served by the version-pinned global CLI, so only the (backward-compatible) hook bundle floats. Accepted as low-risk.
3. **Phase 5 touched 3 extra files.** No provider exclusion *set* existed — remote providers are excluded via composite *selection* in `getBasePrompt`. Implemented by threading `provider` through `getBasePrompt`/`runner.ts` and adding a `worker.pi` composite.

## Verification

- `bun run tsc:check` ✓ · `bun run lint` ✓ · `bun test` → **4805 pass / 0 fail** ✓
- `scripts/check-db-boundary.sh` ✓ · `scripts/check-api-key-boundary.sh` ✓
- `docker build -f Dockerfile.worker` ✓ — in-image: `context-mode` on PATH, `--help` works, Codex `[features]` present, Claude plugin installed
- OpenCode plugin entry imports **offline** (`--network none`): exports `ContextModePlugin, default, …`

## Manual E2E (not yet run — needs live workers + creds)

- [ ] Claude/Codex/OpenCode workers: confirm `ctx_*` tools load + hooks fire
- [ ] pi worker: confirm the system prompt omits the `context_mode` block
- [ ] `CONTEXT_MODE_DISABLED=true`: confirm no `ctx_*` tools load for Claude/Codex/OpenCode
