### PR TITLE
feat(ui): polish session-log code blocks, streaming, and auto-follow

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -28,6 +28,7 @@
     "cronstrue": "^3.14.0",
     "dagre": "^0.8.5",
     "lucide-react": "^0.575.0",
+    "prism-react-renderer": "^2.4.1",
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       lucide-react:
         specifier: ^0.575.0
         version: 0.575.0(react@19.2.4)
+      prism-react-renderer:
+        specifier: ^2.4.1
+        version: 2.4.1(react@19.2.4)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1570,6 +1573,9 @@ packages:
   '@types/node@24.10.13':
     resolution: {integrity: sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==}
 
+  '@types/prismjs@1.26.6':
+    resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -2383,6 +2389,11 @@ packages:
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  prism-react-renderer@2.4.1:
+    resolution: {integrity: sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==}
+    peerDependencies:
+      react: '>=16.0.0'
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -4160,6 +4171,8 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/prismjs@1.26.6': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -5237,6 +5250,12 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prism-react-renderer@2.4.1(react@19.2.4):
+    dependencies:
+      '@types/prismjs': 1.26.6
+      clsx: 2.1.1
+      react: 19.2.4
 
   prop-types@15.8.1:
     dependencies:

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -10,7 +10,8 @@ export type AgentTaskStatus =
   | "paused"
   | "completed"
   | "failed"
-  | "cancelled";
+  | "cancelled"
+  | "superseded";
 export type AgentTaskSource =
   | "mcp"
   | "slack"

--- a/ui/src/components/shared/session-log-viewer.tsx
+++ b/ui/src/components/shared/session-log-viewer.tsx
@@ -1,5 +1,6 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { ArrowDown, Brain, Check, ChevronRight, Copy, Scissors, Search } from "lucide-react";
+import { Highlight, themes } from "prism-react-renderer";
 import {
   type CSSProperties,
   memo,
@@ -18,6 +19,7 @@ import "streamdown/styles.css";
 import type { ContextSnapshot, SessionLog } from "@/api/types";
 import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useTheme } from "@/hooks/use-theme";
 import { formatTokens } from "@/lib/format-tokens";
 import { cn, normalizeNewlines } from "@/lib/utils";
 
@@ -670,9 +672,17 @@ function previewOf(body: string): string {
   return truncate(s.replace(/\s+/g, " "), 52) || "ok";
 }
 
-/** Normalize Unicode bullets at line-start to markdown lists, then paragraph-fix. */
+/** Normalize Unicode bullets at line-start to markdown lists, then paragraph-fix.
+ * Fenced code blocks are split out and passed through verbatim — running the
+ * single→double newline paragraph fix inside a ``` fence would double-space
+ * every code line. Handles unclosed fences (streaming) by matching to EOL. */
 function tidyMarkdown(text: string): string {
-  return normalizeNewlines(text.replace(/^([ \t]*)[•·▪]\s+/gm, "$1- "));
+  return text
+    .split(/(```[\s\S]*?(?:```|$))/g)
+    .map((part, i) =>
+      i % 2 === 1 ? part : normalizeNewlines(part.replace(/^([ \t]*)[•·▪]\s+/gm, "$1- ")),
+    )
+    .join("");
 }
 
 function buildStream(
@@ -907,6 +917,124 @@ function CopyIconButton({
   );
 }
 
+// --- Markdown code blocks -------------------------------------------------
+// Agent output frequently embeds fenced code (```bash, ```json, …). Streamdown's
+// built-in CodeBlock renders a heavy, double-bordered box whose copy/download
+// controls fight the surrounding .prose-* styles (and didn't reliably work). We
+// override `code`/`pre` — the same pattern as markdown-view.tsx's Monaco
+// override, but lightweight (no editor instances, safe inside the virtualized
+// log) — to render one clean terminal-style block with a single working Copy
+// button and no download.
+// Markdown fence label → Prism language id (Prism's bundled grammars use a few
+// different names; unknowns fall through and render as plain, uncolored code).
+const PRISM_LANG_ALIASES: Record<string, string> = {
+  sh: "bash",
+  shell: "bash",
+  zsh: "bash",
+  console: "bash",
+  ts: "typescript",
+  js: "javascript",
+  yml: "yaml",
+  py: "python",
+  rb: "ruby",
+  md: "markdown",
+  dockerfile: "docker",
+};
+
+const LogCodeBlock = memo(function LogCodeBlock({
+  language,
+  value,
+}: {
+  language: string;
+  value: string;
+}) {
+  const { theme } = useTheme();
+  const lang = language && language.toLowerCase() !== "text" ? language.toLowerCase() : null;
+  const prismLang = lang ? (PRISM_LANG_ALIASES[lang] ?? lang) : "text";
+  return (
+    <div className="sl-code group/code relative my-2 overflow-hidden rounded-lg border border-border/70 bg-muted/40">
+      {lang ? (
+        <div className="flex items-center justify-between gap-2 border-b border-border/50 bg-muted/50 py-1 pl-3 pr-1">
+          <span className="select-none font-mono text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            {lang}
+          </span>
+          <CopyIconButton text={value} label="Copy code" className="size-6" />
+        </div>
+      ) : (
+        <CopyIconButton
+          text={value}
+          label="Copy code"
+          className="absolute right-1.5 top-1.5 z-10 bg-muted/80 opacity-0 backdrop-blur transition-opacity group-hover/code:opacity-100 focus-visible:opacity-100"
+        />
+      )}
+      {/* Prism highlights synchronously (no async flash, safe in the virtualized
+          list). We drop the theme's own background so our container surface shows
+          through and only keep the per-token colors. */}
+      <Highlight
+        code={value}
+        language={prismLang}
+        theme={theme === "dark" ? themes.vsDark : themes.github}
+      >
+        {({ tokens, getLineProps, getTokenProps }) => (
+          <pre className="sl-code-pre">
+            {tokens.map((line, i) => (
+              <div key={i} {...getLineProps({ line })}>
+                {line.map((token, k) => (
+                  <span key={k} {...getTokenProps({ token })} />
+                ))}
+              </div>
+            ))}
+          </pre>
+        )}
+      </Highlight>
+    </div>
+  );
+});
+
+// Streamdown component overrides shared by every session-log markdown surface.
+const LOG_MD_COMPONENTS = {
+  code({
+    className,
+    children,
+    node: _node,
+    ...rest
+  }: {
+    className?: string;
+    children?: ReactNode;
+    node?: unknown;
+  }) {
+    const m = /language-([\w-]+)/.exec(className ?? "");
+    const raw = Array.isArray(children) ? children.join("") : String(children ?? "");
+    // Treat as a block when fenced with a language OR multi-line (inline
+    // markdown code is always single-line). Everything else is an inline chip
+    // styled by the .prose-* rules.
+    if (!m && !raw.includes("\n")) {
+      return (
+        <code className={className} {...rest}>
+          {children}
+        </code>
+      );
+    }
+    return <LogCodeBlock language={m?.[1] ?? ""} value={raw.replace(/\n$/, "")} />;
+  },
+  // Our block brings its own container — unwrap Streamdown's <pre> so we don't
+  // nest a styled block inside a styled <pre>.
+  pre({ children }: { children?: ReactNode }) {
+    return <>{children}</>;
+  },
+};
+
+// Single entry point for session-log markdown: tidies bullets/newlines, disables
+// Streamdown's floating table/code controls, and routes fenced code through the
+// clean LogCodeBlock above.
+function LogMarkdown({ children }: { children: string }) {
+  return (
+    <Streamdown components={LOG_MD_COMPONENTS} controls={false}>
+      {tidyMarkdown(children)}
+    </Streamdown>
+  );
+}
+
 const PROVIDER_STATUS_STYLES: Record<string, { label: string; bg: string; text: string }> = {
   running: { label: "Running", bg: "bg-status-paused/15", text: "text-status-paused-strong" },
   working: { label: "Working", bg: "bg-status-paused/15", text: "text-status-paused-strong" },
@@ -983,7 +1111,7 @@ function ProviderMetaBubble({ block }: { block: ProviderMetaBlock }) {
       {summary && <p className="text-xs text-muted-foreground">{summary}</p>}
       {output && (
         <div className="prose-chat prose-session-log text-sm text-foreground">
-          <Streamdown>{tidyMarkdown(output)}</Streamdown>
+          <LogMarkdown>{output}</LogMarkdown>
         </div>
       )}
     </div>
@@ -996,12 +1124,18 @@ function RowShell({
   iso,
   flash,
   isNew,
+  highlight,
+  streamDelayMs,
   children,
 }: {
   time: string;
   iso: string;
   flash?: boolean;
   isNew?: boolean;
+  /** Row streamed in while the viewer was following — slide in + light highlight. */
+  highlight?: boolean;
+  /** Delay (ms) before the entrance plays — drives the one-by-one staggered reveal. */
+  streamDelayMs?: number;
   children: ReactNode;
 }) {
   return (
@@ -1009,8 +1143,12 @@ function RowShell({
       className={cn(
         "group grid grid-cols-[46px_minmax(0,1fr)] items-start gap-x-3 border-b border-border/40 py-[7px] transition-colors hover:bg-muted/50 sm:grid-cols-[54px_minmax(0,1fr)] sm:gap-x-[18px]",
         flash && "sl-flash",
-        isNew && "sl-enter",
+        // One animation per element (the `animation` shorthands would clobber
+        // each other): a row that arrives while following slides in AND glows;
+        // otherwise it just slides in.
+        highlight ? "sl-stream" : isNew && "sl-enter",
       )}
+      style={streamDelayMs ? { animationDelay: `${streamDelayMs}ms` } : undefined}
     >
       <Tooltip>
         <TooltipTrigger asChild>
@@ -1252,6 +1390,13 @@ const MinimapRail = memo(function MinimapRail({
 
 const VIRTUALIZE_THRESHOLD = 120;
 
+// Staggered-reveal tuning: when a poll appends a small batch of new rows while
+// following, each row after the first is delayed by STAGGER_STEP_MS so they
+// cascade in one-by-one. Batches larger than STAGGER_MAX_ROWS (catch-up /
+// initial load) skip the stagger and appear together.
+const STAGGER_MAX_ROWS = 6;
+const STAGGER_STEP_MS = 100;
+
 interface SessionLogViewerProps {
   logs: SessionLog[];
   compactionSnapshots?: ContextSnapshot[];
@@ -1360,6 +1505,7 @@ export function SessionLogViewer({
 
   // --- Scroll plumbing (virtualizer + stick-to-bottom + jump pill) ---
   const parentRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
   const [atBottom, setAtBottom] = useState(true);
   const atBottomRef = useRef(true);
   const [pending, setPending] = useState(0);
@@ -1405,15 +1551,25 @@ export function SessionLogViewer({
       if (ab) setPending(0);
     };
     el.addEventListener("scroll", onScroll, { passive: true });
-    onScroll();
+    // Don't compute atBottom synchronously here: on first mount scrollTop is 0
+    // while content overflows, which would latch "not at bottom" and defeat the
+    // initial pin below. The pin establishes the at-bottom state; real scroll
+    // events take over from there.
     return () => el.removeEventListener("scroll", onScroll);
   }, []);
 
   const stickToBottom = useCallback(() => {
     const el = parentRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+    if (!el) return;
+    // In virtualized mode getTotalSize() is an estimate until rows measure, so a
+    // bare scrollTop can undershoot the real bottom. scrollToIndex forces the
+    // tail to render + measure; the scrollTop assignment then lands flush.
+    if (virtualize && visibleRows.length > 0) {
+      virtualizer.scrollToIndex(visibleRows.length - 1, { align: "end" });
+    }
+    el.scrollTop = el.scrollHeight;
     setPending(0);
-  }, []);
+  }, [virtualize, virtualizer, visibleRows.length]);
 
   // Keep pinned to the bottom as content grows/measures (only when already there).
   const totalSize = virtualize ? virtualizer.getTotalSize() : 0;
@@ -1421,6 +1577,52 @@ export function SessionLogViewer({
   useEffect(() => {
     if (atBottomRef.current) requestAnimationFrame(stickToBottom);
   }, [totalSize, visibleRows.length, stickToBottom]);
+
+  // Land at the newest event when the viewer first populates, and re-pin across
+  // a few frames while async content (virtualizer measurement, Streamdown,
+  // fonts) settles. Conventional log/chat behavior: opening a task drops you at
+  // the bottom whether the agent is still streaming or already finished — fixes
+  // both "doesn't auto-follow on open" and "completed task opens at the top".
+  const didInitialPin = useRef(false);
+  const hasRows = visibleRows.length > 0;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: one-shot on first content; intentionally re-pins across frames without re-subscribing.
+  useLayoutEffect(() => {
+    if (didInitialPin.current || !hasRows) return;
+    didInitialPin.current = true;
+    atBottomRef.current = true;
+    setAtBottom(true);
+    const lastIndex = visibleRows.length - 1;
+    const landAtBottom = () => {
+      const el = parentRef.current;
+      if (!el) return;
+      if (virtualize && lastIndex >= 0) {
+        virtualizer.scrollToIndex(lastIndex, { align: "end" });
+      }
+      el.scrollTop = el.scrollHeight;
+    };
+    landAtBottom();
+    let frame = 0;
+    let raf = requestAnimationFrame(function settle() {
+      landAtBottom();
+      if (++frame < 12) raf = requestAnimationFrame(settle);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [hasRows]);
+
+  // Re-pin to the bottom whenever the content grows while we're in follow mode.
+  // The growth-stick effect above only reacts to row-count / virtualizer-total
+  // changes; it misses a row whose own height grows after it's added (streaming
+  // text, async markdown + Prism layout). Observing the content box catches all
+  // of those — this is what actually keeps the log auto-following.
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => {
+      if (atBottomRef.current) stickToBottom();
+    });
+    ro.observe(content);
+    return () => ro.disconnect();
+  }, [stickToBottom]);
 
   // Track newly-appended events for the "N new" pill when scrolled up.
   useEffect(() => {
@@ -1451,22 +1653,46 @@ export function SessionLogViewer({
     [virtualize, virtualizer, flashRow, openGroup],
   );
 
+  // Staggered reveal — when a poll appends a small batch of new rows while we're
+  // following the tail, give each row after the first an incremental
+  // animation-delay so they cascade in one-by-one instead of popping in all at
+  // once. Excluded: scrolled-up state and large/initial batches (appear at
+  // once). Map: row id → delay (ms).
+  const staggerById = useMemo(() => {
+    const m = new Map<string, number>();
+    if (!atBottomRef.current) return m;
+    const fresh = visibleRows.filter((r) => r.type !== "compaction" && r.isNew);
+    if (fresh.length === 0 || fresh.length > STAGGER_MAX_ROWS) return m;
+    fresh.forEach((r, i) => {
+      if (i > 0) m.set(r.id, i * STAGGER_STEP_MS);
+    });
+    return m;
+  }, [visibleRows]);
+
   const renderRow = useCallback(
     (row: StreamRow) => {
       const flash = flashId === row.id;
       if (row.type === "compaction") return <CompactionDivider snapshot={row.snapshot} />;
+      const streamDelayMs = staggerById.get(row.id) ?? 0;
       if (row.type === "agent") {
         const isUser = row.role === "user";
         const isSystem = row.role === "system";
         return (
-          <RowShell time={row.time} iso={row.iso} flash={flash} isNew={row.isNew}>
+          <RowShell
+            time={row.time}
+            iso={row.iso}
+            flash={flash}
+            isNew={row.isNew}
+            highlight={row.isNew && atBottomRef.current}
+            streamDelayMs={streamDelayMs}
+          >
             {(isUser || isSystem) && (
               <span className="mb-0.5 block text-[10px] font-semibold uppercase tracking-[0.04em] text-muted-foreground">
                 {isUser ? "You" : "System"}
               </span>
             )}
             <div className="prose-chat prose-session-log mt-[3px] break-words text-foreground">
-              <Streamdown>{tidyMarkdown(row.md)}</Streamdown>
+              <LogMarkdown>{row.md}</LogMarkdown>
             </div>
             <CopyIconButton
               text={row.md}
@@ -1477,14 +1703,28 @@ export function SessionLogViewer({
       }
       if (row.type === "thinking") {
         return (
-          <RowShell time={row.time} iso={row.iso} flash={flash} isNew={row.isNew}>
+          <RowShell
+            time={row.time}
+            iso={row.iso}
+            flash={flash}
+            isNew={row.isNew}
+            highlight={row.isNew && atBottomRef.current}
+            streamDelayMs={streamDelayMs}
+          >
             <ThinkingRow text={row.text} />
           </RowShell>
         );
       }
       if (row.type === "meta") {
         return (
-          <RowShell time={row.time} iso={row.iso} flash={flash} isNew={row.isNew}>
+          <RowShell
+            time={row.time}
+            iso={row.iso}
+            flash={flash}
+            isNew={row.isNew}
+            highlight={row.isNew && atBottomRef.current}
+            streamDelayMs={streamDelayMs}
+          >
             <ProviderMetaBubble block={row.block} />
           </RowShell>
         );
@@ -1492,7 +1732,13 @@ export function SessionLogViewer({
       const open = isGroupOpen(row);
       const dur = formatDur(row.durMs);
       return (
-        <RowShell time={row.time} iso={row.iso} flash={flash} isNew={row.isNew}>
+        <RowShell
+          time={row.time}
+          iso={row.iso}
+          flash={flash}
+          isNew={row.isNew}
+          highlight={row.isNew && atBottomRef.current}
+        >
           <button
             type="button"
             onClick={() => toggleGroup(row.id, open)}
@@ -1531,7 +1777,16 @@ export function SessionLogViewer({
         </RowShell>
       );
     },
-    [flashId, isGroupOpen, openOutputs, openTools, toggleGroup, toggleOutput, toggleTool],
+    [
+      flashId,
+      isGroupOpen,
+      openOutputs,
+      openTools,
+      toggleGroup,
+      toggleOutput,
+      toggleTool,
+      staggerById,
+    ],
   );
 
   const virtualItems = virtualizer.getVirtualItems();
@@ -1567,44 +1822,46 @@ export function SessionLogViewer({
             ref={parentRef}
             className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-3 [overflow-anchor:none]"
           >
-            {visibleRows.length === 0 ? (
-              <div className="flex h-full items-center justify-center py-12 text-sm text-muted-foreground">
-                {rows.length === 0 ? "No session data" : "No matching events"}
-              </div>
-            ) : virtualize ? (
-              <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
-                {virtualItems.map((vi) => {
-                  const row = visibleRows[vi.index];
-                  if (!row) return null;
-                  const style: CSSProperties = {
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: "100%",
-                    transform: `translateY(${vi.start}px)`,
-                  };
-                  return (
-                    <div
-                      key={vi.key}
-                      ref={virtualizer.measureElement}
-                      data-index={vi.index}
-                      data-row-id={row.id}
-                      style={style}
-                    >
+            <div ref={contentRef}>
+              {visibleRows.length === 0 ? (
+                <div className="flex h-full items-center justify-center py-12 text-sm text-muted-foreground">
+                  {rows.length === 0 ? "No session data" : "No matching events"}
+                </div>
+              ) : virtualize ? (
+                <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
+                  {virtualItems.map((vi) => {
+                    const row = visibleRows[vi.index];
+                    if (!row) return null;
+                    const style: CSSProperties = {
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      width: "100%",
+                      transform: `translateY(${vi.start}px)`,
+                    };
+                    return (
+                      <div
+                        key={vi.key}
+                        ref={virtualizer.measureElement}
+                        data-index={vi.index}
+                        data-row-id={row.id}
+                        style={style}
+                      >
+                        {renderRow(row)}
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="flex flex-col">
+                  {visibleRows.map((row) => (
+                    <div key={row.id} data-row-id={row.id}>
                       {renderRow(row)}
                     </div>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="flex flex-col">
-                {visibleRows.map((row) => (
-                  <div key={row.id} data-row-id={row.id}>
-                    {renderRow(row)}
-                  </div>
-                ))}
-              </div>
-            )}
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
 
           {/* Minimap rail */}
@@ -1667,7 +1924,7 @@ function ThinkingRow({ text }: { text: string }) {
       {open && (
         <div className="border-t border-border/60 px-2.5 py-2">
           <div className="prose-chat prose-session-log text-xs text-muted-foreground">
-            <Streamdown>{tidyMarkdown(text)}</Streamdown>
+            <LogMarkdown>{text}</LogMarkdown>
           </div>
         </div>
       )}

--- a/ui/src/components/shared/status-badge.tsx
+++ b/ui/src/components/shared/status-badge.tsx
@@ -66,6 +66,7 @@ const statusConfig: Record<string, StatusConfig> = {
   },
   failed: { label: "FAILED", dot: "bg-status-error", text: "text-status-error-strong" },
   cancelled: { label: "CANCELLED", dot: "bg-status-neutral", text: "text-status-neutral" },
+  superseded: { label: "SUPERSEDED", dot: "bg-status-neutral", text: "text-status-neutral" },
 
   // Service statuses
   starting: {

--- a/ui/src/pages/tasks/[id]/page.tsx
+++ b/ui/src/pages/tasks/[id]/page.tsx
@@ -444,8 +444,10 @@ function TaskContextSection({
           </span>
         </div>
         <MetaRow icon={Cpu} label="Used">
-          <span className="text-xs font-mono inline-flex items-center gap-1.5">
-            {formatTokens(usedTokens)} / {formatTokens(totalTokens)}
+          <span className="flex flex-col items-start gap-1 font-mono text-xs">
+            <span className="whitespace-nowrap">
+              {formatTokens(usedTokens)} / {formatTokens(totalTokens)}
+            </span>
             {latestSnapshot?.contextFormula && latestSnapshot.contextFormula !== "unknown" && (
               <Badge
                 variant="outline"

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -284,6 +284,30 @@ body {
   animation: sl-flash 1.3s ease-out;
 }
 
+/* Streamed-in highlight — a row that arrives while the viewer is following the
+ * tail slides in and gets a brief, light primary glow that settles. Folds in
+ * the sl-enter motion so only one `animation` runs on the element. */
+@keyframes sl-stream {
+  0% {
+    opacity: 0;
+    transform: translateY(12px);
+    background-color: color-mix(in oklch, var(--color-primary) 14%, transparent);
+  }
+  28% {
+    opacity: 1;
+    transform: none;
+  }
+  100% {
+    opacity: 1;
+    transform: none;
+    background-color: transparent;
+  }
+}
+
+.sl-stream {
+  animation: sl-stream 1.5s cubic-bezier(0.25, 1, 0.5, 1) both;
+}
+
 @keyframes sl-orb {
   0% {
     box-shadow: 0 0 0 0 color-mix(in oklch, var(--color-status-active) 55%, transparent);
@@ -303,6 +327,7 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .sl-enter,
   .sl-flash,
+  .sl-stream,
   .sl-orb {
     animation: none;
   }
@@ -422,4 +447,22 @@ body {
 }
 .prose-session-log li > p + p {
   margin-top: 0.25em;
+}
+
+/* Session-log fenced code blocks (LogCodeBlock). These scoped selectors outrank
+ * the generic `.prose-* pre` rules above (extra class = higher specificity), so
+ * the inner <pre> is reset flat — no background, no radius, no double padding —
+ * and the single clean container around it owns the styling. Color is left to
+ * inherit so code reads as foreground in messages and muted in thinking blocks. */
+.prose-chat pre.sl-code-pre,
+.prose-session-log pre.sl-code-pre {
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0;
+  background: transparent;
+  max-height: 26rem;
+  overflow: auto;
+  font-family: "Space Mono", monospace;
+  font-size: 12px;
+  line-height: 1.6;
 }


### PR DESCRIPTION
Session log viewer + task detail page:
- Render fenced code as clean single-container blocks with Prism syntax highlighting and a working copy button (drop Streamdown's broken copy/download); adds prism-react-renderer.
- Stop tidyMarkdown's paragraph-spacing from running inside ``` fences, which was double-spacing every code line.
- Fix auto-follow: initial pin-to-bottom + ResizeObserver re-pin + virtualizer-aware stickToBottom, so logs open at the newest event whether the task is running or completed.
- Light "streamed-in" highlight for rows that arrive while following, with a staggered one-by-one reveal for small live batches.
- Context-usage "Used" stacks the numbers over the formula chip (two lines).
- Add a proper SUPERSEDED status chip (statusConfig + AgentTaskStatus type).