### PR TITLE
fix(env): add PUBLIC_MCP_BASE_URL, unify APP_URL/DASHBOARD_URL, route URL env reads through helpers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,9 +31,14 @@ PORT=3013
 # Services are accessible at https://{AGENT_ID}.{SWARM_URL}
 SWARM_URL=localhost
 
-# MCP Base URL for remote server (used by setup command)
+# MCP Base URL — internal/worker-facing API base (workers, UI, setup command)
 # Default: https://api.desplega.agent-swarm.dev
 MCP_BASE_URL=
+
+# Public, externally-reachable API origin for OAuth redirect URIs + webhook URLs.
+# Defaults to MCP_BASE_URL when unset — only set in split deploys where MCP_BASE_URL
+# is an internal/cluster address that external providers (Linear/Jira/GitHub) can't reach.
+# PUBLIC_MCP_BASE_URL=
 
 # Slack Bot Configuration (Socket Mode)
 # Get these from https://api.slack.com/apps

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -447,7 +447,8 @@ When a worker starts, it:
 |----------|-------------|---------|
 | `PORT` | Port for MCP HTTP server | `3013` |
 | `API_KEY` | API key for server authentication | - |
-| `MCP_BASE_URL` | Base URL (for setup command) | `https://api.desplega.agent-swarm.dev` |
+| `MCP_BASE_URL` | Internal/worker-facing API base (also used by the setup command) | `https://api.desplega.agent-swarm.dev` |
+| `PUBLIC_MCP_BASE_URL` | Public, externally-reachable API origin for OAuth redirect URIs + webhook URLs. Defaults to `MCP_BASE_URL` | Falls back to `MCP_BASE_URL` |
 | `SWARM_URL` | Base domain for service discovery | `localhost` |
 | `APP_URL` | Dashboard URL for Slack message links | - |
 | `ENV` | Environment mode (`development` adds prefix to Slack agent names) | - |
@@ -455,6 +456,8 @@ When a worker starts, it:
 | `DATABASE_PATH` | SQLite database file path | `./agent-swarm-db.sqlite` |
 | `OPENAI_API_KEY` | OpenAI key for memory embeddings (optional) | - |
 | `CAPABILITIES` | Comma-separated feature flags | All enabled |
+
+> **Split / Helm deploys:** In topologies where `MCP_BASE_URL` points at an internal/cluster address (e.g. a Kubernetes Service DNS name reachable only inside the cluster), set `PUBLIC_MCP_BASE_URL` to the public ingress origin. OAuth redirect URIs and webhook URLs handed to external providers (Linear, Jira, GitHub) are built from `PUBLIC_MCP_BASE_URL` when it is set, falling back to `MCP_BASE_URL` otherwise.
 
 ### Codex ChatGPT OAuth
 

--- a/charts/agent-swarm/templates/configmap.yaml
+++ b/charts/agent-swarm/templates/configmap.yaml
@@ -13,7 +13,8 @@ data:
   {{- if .Values.config.publicMcpBaseUrl }}
   PUBLIC_MCP_BASE_URL: {{ .Values.config.publicMcpBaseUrl | quote }}
   {{- else if and .Values.ingress.enabled .Values.ingress.host }}
-  PUBLIC_MCP_BASE_URL: {{ printf "https://%s" .Values.ingress.host | quote }}
+  {{- $publicMcpScheme := ternary "https" "http" (gt (len .Values.ingress.tls) 0) }}
+  PUBLIC_MCP_BASE_URL: {{ printf "%s://%s" $publicMcpScheme .Values.ingress.host | quote }}
   {{- end }}
   {{- if .Values.config.slackAllowedEmailDomains }}
   SLACK_ALLOWED_EMAIL_DOMAINS: {{ .Values.config.slackAllowedEmailDomains | quote }}

--- a/charts/agent-swarm/templates/configmap.yaml
+++ b/charts/agent-swarm/templates/configmap.yaml
@@ -10,6 +10,11 @@ data:
   {{- if .Values.config.appUrl }}
   APP_URL: {{ .Values.config.appUrl | quote }}
   {{- end }}
+  {{- if .Values.config.publicMcpBaseUrl }}
+  PUBLIC_MCP_BASE_URL: {{ .Values.config.publicMcpBaseUrl | quote }}
+  {{- else if and .Values.ingress.enabled .Values.ingress.host }}
+  PUBLIC_MCP_BASE_URL: {{ printf "https://%s" .Values.ingress.host | quote }}
+  {{- end }}
   {{- if .Values.config.slackAllowedEmailDomains }}
   SLACK_ALLOWED_EMAIL_DOMAINS: {{ .Values.config.slackAllowedEmailDomains | quote }}
   {{- end }}

--- a/charts/agent-swarm/values.yaml
+++ b/charts/agent-swarm/values.yaml
@@ -100,7 +100,9 @@ config:
   # to omit dashboard links from Slack notifications.
   appUrl: ""
   # -- Public, browser/externally-reachable API origin for OAuth redirect URIs + registered webhooks.
-  # Leave blank to fall back to the internal mcpBaseUrl. In split deploys set to the public ingress URL.
+  # Leave blank to derive from ingress.host when ingress is enabled, otherwise
+  # the app falls back to the internal mcpBaseUrl. In split deploys set to the
+  # public ingress URL explicitly when the chart cannot infer it.
   publicMcpBaseUrl: ""
   # -- Free-form additional env vars layered on top of the chart defaults.
   # Useful for less-common knobs (TEMPLATE_REGISTRY_URL, SCHEDULER_INTERVAL_MS, etc.).

--- a/charts/agent-swarm/values.yaml
+++ b/charts/agent-swarm/values.yaml
@@ -99,6 +99,9 @@ config:
   # -- Public dashboard URL referenced in Slack message links. Leave blank
   # to omit dashboard links from Slack notifications.
   appUrl: ""
+  # -- Public, browser/externally-reachable API origin for OAuth redirect URIs + registered webhooks.
+  # Leave blank to fall back to the internal mcpBaseUrl. In split deploys set to the public ingress URL.
+  publicMcpBaseUrl: ""
   # -- Free-form additional env vars layered on top of the chart defaults.
   # Useful for less-common knobs (TEMPLATE_REGISTRY_URL, SCHEDULER_INTERVAL_MS, etc.).
   extraEnv: {}

--- a/docs-site/content/docs/(documentation)/guides/jira-integration.mdx
+++ b/docs-site/content/docs/(documentation)/guides/jira-integration.mdx
@@ -24,7 +24,7 @@ Agent Swarm integrates with [Atlassian Jira Cloud](https://www.atlassian.com/sof
    - `manage:jira-webhook`
    - `offline_access`
    - `read:me`
-3. On the Authorization tab, set the **callback URL** to `<MCP_BASE_URL>/api/trackers/jira/callback` — for example `https://your-swarm.example.com/api/trackers/jira/callback`. With `bun run dev:http` portless mode this is `https://api.swarm.localhost:1355/api/trackers/jira/callback`.
+3. On the Authorization tab, set the **callback URL** to `<MCP_BASE_URL>/api/trackers/jira/callback` — for example `https://your-swarm.example.com/api/trackers/jira/callback`. With `bun run dev:http` portless mode this is `https://api.swarm.localhost:1355/api/trackers/jira/callback`. The callback and webhook URLs are built from `PUBLIC_MCP_BASE_URL` when it is set, falling back to `MCP_BASE_URL` otherwise — in split deploys where `MCP_BASE_URL` is an internal/cluster address, set `PUBLIC_MCP_BASE_URL` to the public ingress origin.
 4. Copy the **Client ID** and **Client Secret** from the Settings tab.
 5. Generate a high-entropy webhook token: `openssl rand -hex 32`. This becomes `JIRA_WEBHOOK_TOKEN`.
 

--- a/docs-site/content/docs/(documentation)/integrations/linear.mdx
+++ b/docs-site/content/docs/(documentation)/integrations/linear.mdx
@@ -27,6 +27,11 @@ Agent Swarm integrates with [Linear](https://linear.app) as an inbound issue-tra
    - **Callback URL**: `<MCP_BASE_URL>/api/trackers/linear/callback`
    - **Webhook URL**: `<MCP_BASE_URL>/api/trackers/linear/webhook`
 2. Enable **Agent session events** in the webhook settings.
+
+<Callout type="info">
+These URLs are built from `PUBLIC_MCP_BASE_URL` when it is set, falling back to `MCP_BASE_URL` otherwise. In split deploys where `MCP_BASE_URL` is an internal/cluster address, set `PUBLIC_MCP_BASE_URL` to the public ingress origin so Linear can reach the callback and webhook.
+</Callout>
+
 3. Copy the Client ID, Client Secret, and Webhook Signing Secret.
 
 ### 2. Configure environment

--- a/docs-site/content/docs/(documentation)/reference/environment-variables.mdx
+++ b/docs-site/content/docs/(documentation)/reference/environment-variables.mdx
@@ -11,9 +11,10 @@ Complete reference for all environment variables used by Agent Swarm.
 |----------|---------|-------------|
 | `PORT` | `3013` | Port for MCP HTTP server |
 | `API_KEY` | — | API key for server authentication (required) |
-| `MCP_BASE_URL` | `https://api.desplega.agent-swarm.dev` | Base URL for MCP server |
+| `MCP_BASE_URL` | `https://api.desplega.agent-swarm.dev` | Internal/worker-facing API base — the URL workers, the UI, and the setup command use to reach the API server. In split deploys this may be an internal/cluster address. |
+| `PUBLIC_MCP_BASE_URL` | Falls back to `MCP_BASE_URL` | Public, browser/externally-reachable API origin used for OAuth redirect URIs and webhook URLs. Defaults to `MCP_BASE_URL` when unset; set it in split deploys where `MCP_BASE_URL` is an internal/cluster address that external providers (Linear, Jira, GitHub) can't reach. |
 | `SWARM_URL` | `localhost` | Base domain for service discovery |
-| `APP_URL` | — | Dashboard URL for Slack message links |
+| `APP_URL` | — | Dashboard URL for Slack message links. `DASHBOARD_URL` is a deprecated alias of `APP_URL`. |
 | `ENV` | — | Environment mode (`development` adds prefix to Slack agent names) |
 | `DATABASE_PATH` | `./agent-swarm-db.sqlite` | SQLite database file path |
 | `SQLITE_VEC_EXTENSION_PATH` | — | Path to `vec0.so` native extension for sqlite-vec vector search. Set automatically in the Docker image (`/app/extensions/vec0.so`). Only needed for non-Docker deployments. |

--- a/runbooks/local-development.md
+++ b/runbooks/local-development.md
@@ -17,7 +17,8 @@ Bun auto-loads `.env`. Don't use `dotenv`.
 | Var | Default | Notes |
 |---|---|---|
 | `AGENT_SWARM_API_KEY` (preferred) / `API_KEY` (legacy) | `123123` | Auth header `Authorization: Bearer …`. `AGENT_SWARM_API_KEY` wins when both are set — prefer it when exporting in your shell profile so the CLI works from any cwd without colliding with other tools' `API_KEY`. |
-| `MCP_BASE_URL` | `http://localhost:3013` | Public URL the workers/UI hit |
+| `MCP_BASE_URL` | `http://localhost:3013` | Internal/worker-facing API base the workers/UI hit |
+| `PUBLIC_MCP_BASE_URL` | falls back to `MCP_BASE_URL` | Public origin for OAuth redirect URIs + webhook URLs. No action needed locally — leave unset and it defaults to `MCP_BASE_URL`. Only relevant in split deploys where `MCP_BASE_URL` is an internal/cluster address. |
 | `APP_URL` | `http://localhost:5274` | Dashboard URL |
 | `SLACK_DISABLE` / `GITHUB_DISABLE` / `JIRA_DISABLE` / `LINEAR_DISABLE` | unset | Set `=true` to disable each integration |
 | `CONTEXT_MODE_DISABLED` | unset (enabled) | Set `=true` to opt a worker out of context-mode. Default-enabled — the worker image bakes in context-mode, and the Claude/Codex/OpenCode adapters wire it in unless this is `true`. |

--- a/src/artifact-sdk/server.ts
+++ b/src/artifact-sdk/server.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { serveStatic } from "hono/bun";
 import { getApiKey } from "../utils/api-key";
+import { getMcpBaseUrl } from "../utils/constants";
 import { BROWSER_SDK_JS } from "./browser-sdk";
 import { getAvailablePort } from "./port";
 import { createTunnel } from "./tunnel";
@@ -47,7 +48,7 @@ export function createBunHonoFetchHandler(app: Hono): (req: Request) => Promise<
 export function createArtifactServer(opts: ArtifactServerOptions): ArtifactServer {
   const agentId = process.env.AGENT_ID || "unknown";
   const apiKey = getApiKey();
-  const mcpBaseUrl = process.env.MCP_BASE_URL || `http://localhost:${process.env.PORT || "3013"}`;
+  const mcpBaseUrl = getMcpBaseUrl();
 
   const app = new Hono();
 

--- a/src/commands/artifact.ts
+++ b/src/commands/artifact.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { createArtifactServer } from "../artifact-sdk";
 import { getApiKey } from "../utils/api-key";
+import { getMcpBaseUrl } from "../utils/constants";
 
 interface ArtifactArgs {
   additionalArgs: string[];
@@ -139,7 +140,7 @@ async function artifactServe(args: ArtifactArgs) {
 
 async function artifactList() {
   const apiKey = getApiKey();
-  const mcpBaseUrl = process.env.MCP_BASE_URL || `http://localhost:${process.env.PORT || "3013"}`;
+  const mcpBaseUrl = getMcpBaseUrl();
   const agentId = process.env.AGENT_ID || "";
 
   try {
@@ -197,7 +198,7 @@ async function artifactStop(args: ArtifactArgs) {
   }
 
   const apiKey = getApiKey();
-  const mcpBaseUrl = process.env.MCP_BASE_URL || `http://localhost:${process.env.PORT || "3013"}`;
+  const mcpBaseUrl = getMcpBaseUrl();
   const agentId = process.env.AGENT_ID || "";
 
   // 1. Try to stop PM2 process

--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -36,6 +36,7 @@ import { initTelemetry, telemetry } from "../telemetry.ts";
 import type { ProviderName, RepoGuidelines } from "../types.ts";
 import { getApiKey } from "../utils/api-key.ts";
 import { computeBudgetBackoffMs } from "../utils/budget-backoff.ts";
+import { getMcpBaseUrl } from "../utils/constants.ts";
 import { getContextWindowSize } from "../utils/context-window.ts";
 import { type CredentialSelection, resolveCredentialPools } from "../utils/credentials.ts";
 import {
@@ -3299,7 +3300,7 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
   // Get agent identity and swarm URL for base prompt
   const agentId = process.env.AGENT_ID || "unknown";
 
-  const apiUrl = process.env.MCP_BASE_URL || `http://localhost:${process.env.PORT || "3013"}`;
+  const apiUrl = getMcpBaseUrl();
   const swarmUrl = process.env.SWARM_URL || "localhost";
   const apiKey = getApiKey();
 

--- a/src/hooks/hook.ts
+++ b/src/hooks/hook.ts
@@ -11,6 +11,7 @@ import {
 } from "../be/memory/raters/llm";
 import type { Agent } from "../types";
 import { getApiKey } from "../utils/api-key";
+import { getMcpBaseUrl } from "../utils/constants";
 import { summarizeSession as runSummarize } from "../utils/internal-ai";
 import { checkToolLoop, clearToolHistory } from "./tool-loop-detection";
 
@@ -150,7 +151,7 @@ async function readTaskFile(): Promise<TaskFileData | null> {
 async function fetchTaskDetails(
   taskId: string,
 ): Promise<{ id: string; task: string; progress?: string } | null> {
-  const apiUrl = process.env.MCP_BASE_URL || `http://localhost:${process.env.PORT || "3013"}`;
+  const apiUrl = getMcpBaseUrl();
   const apiKey = getApiKey();
   const headers: Record<string, string> = {};
   if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
@@ -1151,8 +1152,7 @@ ${hasAgentIdHeader() ? `You have a pre-defined agent ID via header: ${mcpConfig?
             editedPath.startsWith("/workspace/shared/memory/"))
         ) {
           try {
-            const apiUrl =
-              process.env.MCP_BASE_URL || `http://localhost:${process.env.PORT || "3013"}`;
+            const apiUrl = getMcpBaseUrl();
             const apiKey = getApiKey();
             const fileContent = await Bun.file(editedPath).text();
             const isShared = editedPath.startsWith("/workspace/shared/");

--- a/src/http/integrations.ts
+++ b/src/http/integrations.ts
@@ -88,7 +88,12 @@ function resolveConfigValue(key: string): string | null {
 }
 
 function resolveMcpBaseUrl(): string {
-  const configured = resolveConfigValue("MCP_BASE_URL");
+  // Browser-facing connect URLs: prefer the public ingress origin
+  // (PUBLIC_MCP_BASE_URL) over the internal MCP_BASE_URL so split deployments
+  // (Helm) surface a host the user's browser can actually reach. Both honor the
+  // swarm_config → env resolution order. Falls back to the localhost dev base.
+  const configured =
+    resolveConfigValue("PUBLIC_MCP_BASE_URL") ?? resolveConfigValue("MCP_BASE_URL");
   const fallback = `http://localhost:${process.env.PORT || "3013"}`;
   return (configured || fallback).replace(/\/+$/, "");
 }

--- a/src/http/mcp-oauth.ts
+++ b/src/http/mcp-oauth.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { z } from "zod";
 import { getMcpServerById } from "../be/db";
+import type { McpOAuthToken } from "../be/db-queries/mcp-oauth";
 import {
   applyMcpOAuthRefresh,
   consumeMcpOAuthPending,
@@ -62,6 +63,43 @@ interface DiscoveryResult {
   requiresOAuth: boolean;
   dcrSupported: boolean;
   bearerMethodsSupported: string[] | null;
+}
+
+interface OAuthClientForAuthorize {
+  clientId: string;
+  clientSecret: string | null;
+  resourceUrl: string;
+  authorizationServerIssuer: string;
+  authorizeUrl: string;
+  tokenUrl: string;
+  revocationUrl: string | null;
+  scopes: string[];
+}
+
+function splitScopes(scopes: string | null | undefined): string[] {
+  return scopes?.split(/\s+/).filter(Boolean) ?? [];
+}
+
+function manualClientFromToken(token: McpOAuthToken | null): OAuthClientForAuthorize | null {
+  if (!token || token.clientSource !== "manual" || !token.dcrClientId) return null;
+
+  // The manual-client route validates these on write. Re-check before using the
+  // stored endpoints because /authorize redirects the browser to authorizeUrl.
+  assertUrlSafe(token.resourceUrl, ssrfOptions());
+  assertUrlSafe(token.authorizeUrl, ssrfOptions());
+  assertUrlSafe(token.tokenUrl, ssrfOptions());
+  if (token.revocationUrl) assertUrlSafe(token.revocationUrl, ssrfOptions());
+
+  return {
+    clientId: token.dcrClientId,
+    clientSecret: token.dcrClientSecret,
+    resourceUrl: token.resourceUrl,
+    authorizationServerIssuer: token.authorizationServerIssuer,
+    authorizeUrl: token.authorizeUrl,
+    tokenUrl: token.tokenUrl,
+    revocationUrl: token.revocationUrl,
+    scopes: splitScopes(token.scope),
+  };
 }
 
 async function discoverForMcp(resourceUrl: string): Promise<DiscoveryResult | null> {
@@ -269,10 +307,10 @@ interface AuthorizeFlowQuery {
 }
 
 /**
- * Discover metadata, DCR-register (or fail), build the authorize URL, and
- * persist the pending session. Returns the provider `providerUrl` the caller
- * should redirect to / respond with. On failure, writes a JSON error response
- * and returns null.
+ * Use a stored manual client or discover metadata + DCR-register, build the
+ * authorize URL, and persist the pending session. Returns the provider
+ * `providerUrl` the caller should redirect to / respond with. On failure,
+ * writes a JSON error response and returns null.
  */
 async function prepareAuthorizeFlow(
   res: ServerResponse,
@@ -280,15 +318,26 @@ async function prepareAuthorizeFlow(
   server: NonNullable<ReturnType<typeof getMcpServerById>>,
   q: AuthorizeFlowQuery,
 ): Promise<string | null> {
-  const discovery = await discoverForMcp(server.url!);
-  if (!discovery) {
-    jsonError(res, "MCP server does not require OAuth", 400);
-    return null;
-  }
+  const userId = q.userId ?? null;
+  let client = manualClientFromToken(getMcpOAuthToken(mcpServerId, userId));
 
-  let clientId: string | null = null;
-  let clientSecret: string | null = null;
-  if (discovery.dcrSupported && discovery.registrationEndpoint) {
+  if (!client) {
+    const discovery = await discoverForMcp(server.url!);
+    if (!discovery) {
+      jsonError(res, "MCP server does not require OAuth", 400);
+      return null;
+    }
+
+    if (!discovery.dcrSupported || !discovery.registrationEndpoint) {
+      jsonError(
+        res,
+        "DCR not supported — paste client_id/client_secret via POST /api/mcp-oauth/:id/manual-client first.",
+        400,
+      );
+      return null;
+    }
+
+    const scopes = q.scopes ? splitScopes(q.scopes) : discovery.scopes;
     const dcr = await registerClient(discovery.registrationEndpoint, {
       client_name: `agent-swarm (${server.name})`,
       redirect_uris: [callbackRedirectUri()],
@@ -296,43 +345,45 @@ async function prepareAuthorizeFlow(
       response_types: ["code"],
       token_endpoint_auth_method: "client_secret_basic",
       application_type: "web",
-      scope: (q.scopes ?? discovery.scopes.join(" ")) || undefined,
+      scope: scopes.join(" ") || undefined,
     });
-    clientId = dcr.client_id;
-    clientSecret = dcr.client_secret ?? null;
-  } else {
-    jsonError(
-      res,
-      "DCR not supported — paste client_id/client_secret via POST /api/mcp-oauth/:id/manual-client first.",
-      400,
-    );
-    return null;
+
+    client = {
+      clientId: dcr.client_id,
+      clientSecret: dcr.client_secret ?? null,
+      resourceUrl: discovery.resourceUrl,
+      authorizationServerIssuer: discovery.authorizationServerIssuer,
+      authorizeUrl: discovery.authorizeUrl,
+      tokenUrl: discovery.tokenUrl,
+      revocationUrl: discovery.revocationUrl,
+      scopes,
+    };
   }
 
-  const scopes = q.scopes ? q.scopes.split(" ").filter(Boolean) : discovery.scopes;
+  const scopes = q.scopes ? splitScopes(q.scopes) : client.scopes;
 
   const built = await buildAuthorizeUrl({
-    authorizeUrl: discovery.authorizeUrl,
-    tokenUrl: discovery.tokenUrl,
-    clientId: clientId!,
+    authorizeUrl: client.authorizeUrl,
+    tokenUrl: client.tokenUrl,
+    clientId: client.clientId,
     redirectUri: callbackRedirectUri(),
     scopes,
-    resource: discovery.resourceUrl,
+    resource: client.resourceUrl,
   });
 
   insertMcpOAuthPending({
     state: built.state,
     mcpServerId,
-    userId: q.userId ?? null,
+    userId,
     codeVerifier: built.codeVerifier,
-    resourceUrl: discovery.resourceUrl,
-    authorizationServerIssuer: discovery.authorizationServerIssuer,
-    authorizeUrl: discovery.authorizeUrl,
-    tokenUrl: discovery.tokenUrl,
-    revocationUrl: discovery.revocationUrl,
+    resourceUrl: client.resourceUrl,
+    authorizationServerIssuer: client.authorizationServerIssuer,
+    authorizeUrl: client.authorizeUrl,
+    tokenUrl: client.tokenUrl,
+    revocationUrl: client.revocationUrl,
     scopes: scopes.join(" "),
-    dcrClientId: clientId!,
-    dcrClientSecret: clientSecret,
+    dcrClientId: client.clientId,
+    dcrClientSecret: client.clientSecret,
     redirectUri: callbackRedirectUri(),
     finalRedirect: q.redirect ?? null,
   });
@@ -393,6 +444,10 @@ export async function handleMcpOAuth(
         codeVerifier: pending.codeVerifier,
         resource: pending.resourceUrl,
       });
+      const existing = getMcpOAuthToken(pending.mcpServerId, pending.userId);
+      const clientSource =
+        existing?.clientSource ??
+        (pending.dcrClientId ? ("dcr" as const) : ("preregistered" as const));
 
       upsertMcpOAuthToken({
         mcpServerId: pending.mcpServerId,
@@ -409,7 +464,7 @@ export async function handleMcpOAuth(
         revocationUrl: pending.revocationUrl,
         dcrClientId: pending.dcrClientId,
         dcrClientSecret: pending.dcrClientSecret,
-        clientSource: pending.dcrClientId ? "dcr" : "preregistered",
+        clientSource,
         lastRefreshedAt: new Date().toISOString(),
       });
 

--- a/src/http/mcp-oauth.ts
+++ b/src/http/mcp-oauth.ts
@@ -23,6 +23,7 @@ import {
   registerClient,
   revokeMcpToken,
 } from "../oauth/mcp-wrapper";
+import { getAppUrl, getPublicMcpBaseUrl } from "../utils/constants";
 import { route } from "./route-def";
 import { json, jsonError } from "./utils";
 
@@ -36,12 +37,14 @@ function ssrfOptions() {
 }
 
 function callbackRedirectUri(): string {
-  const base = process.env.APP_URL?.replace(/\/+$/, "") ?? "http://localhost:3013";
-  return `${base}/api/mcp-oauth/callback`;
+  // The callback route lives on the API server, so it must use the PUBLIC MCP
+  // base (externally reachable), not the dashboard APP_URL.
+  return `${getPublicMcpBaseUrl()}/api/mcp-oauth/callback`;
 }
 
 function dashboardBase(): string {
-  return process.env.DASHBOARD_URL?.replace(/\/+$/, "") ?? "http://localhost:5274";
+  // getAppUrl absorbs DASHBOARD_URL as a deprecated alias.
+  return getAppUrl();
 }
 
 function defaultFinalRedirect(mcpServerId: string): string {

--- a/src/http/openapi.ts
+++ b/src/http/openapi.ts
@@ -4,6 +4,7 @@ import {
   OpenApiGeneratorV31,
 } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
+import { getPublicMcpBaseUrl } from "../utils/constants";
 import { routeRegistry } from "./route-def";
 
 extendZodWithOpenApi(z);
@@ -74,8 +75,7 @@ export function generateOpenApiSpec(opts: OpenApiOptions): string {
     });
   }
 
-  const serverUrl =
-    opts.serverUrl || process.env.MCP_BASE_URL || `http://localhost:${process.env.PORT || "3013"}`;
+  const serverUrl = opts.serverUrl || getPublicMcpBaseUrl();
 
   const generator = new OpenApiGeneratorV31(registry.definitions);
   const doc = generator.generateDocument({

--- a/src/http/pages-public.ts
+++ b/src/http/pages-public.ts
@@ -25,7 +25,7 @@ import { z } from "zod";
 import { BROWSER_SDK_JS, SWARM_UI_JS } from "../artifact-sdk/browser-sdk";
 import { getPage, incrementPageViewCount } from "../be/db";
 import type { Page } from "../types";
-import { getAppUrl } from "../utils/constants";
+import { getAppUrl, getConfiguredAppUrls } from "../utils/constants";
 import { extractAndVerifyCookie, issuePageSessionCookie } from "../utils/page-session";
 import { scrubSecrets } from "../utils/secret-scrubber";
 import { route } from "./route-def";
@@ -160,11 +160,15 @@ function stripJsonSuffix(idSegment: string): string | null {
 }
 
 /**
- * Compute the SPA base URL. Delegates to the shared {@link getAppUrl} helper
- * (the single source of truth for `APP_URL` resolution).
+ * Compute the SPA base URL. Public JSON pages historically redirect to the
+ * local dashboard when no app URL is configured; keep that route-local
+ * fallback while still delegating `APP_URL`/`DASHBOARD_URL` resolution to the
+ * shared helper.
  */
+const LOCAL_PAGE_APP_URL = "http://localhost:5274";
+
 function getAppBaseUrl(): string {
-  return getAppUrl();
+  return getAppUrl(LOCAL_PAGE_APP_URL);
 }
 
 /**
@@ -175,15 +179,12 @@ function getAppBaseUrl(): string {
  */
 function buildCsp(): string {
   // `frame-ancestors` lists every origin allowed to iframe `/p/:id`. We must
-  // include the SPA origin(s). `APP_URL` may carry a comma-separated list so
+  // include the SPA origin(s). Configured app URLs may be comma-separated so
   // portless dev (`https://ui.swarm.localhost`), a Vite port (`http://localhost:5274`),
   // and a tunnel/staging origin can all coexist. Additionally, in non-production
   // we always allow `http://localhost:*` and `https://*.localhost` so swapping
   // between Vite ports / portless dev doesn't require restarting the API.
-  const configured = (process.env.APP_URL ?? "")
-    .split(",")
-    .map((s) => s.trim().replace(/\/+$/, ""))
-    .filter(Boolean);
+  const configured = getConfiguredAppUrls();
   const devFallbacks =
     process.env.NODE_ENV === "production"
       ? []

--- a/src/http/pages-public.ts
+++ b/src/http/pages-public.ts
@@ -25,6 +25,7 @@ import { z } from "zod";
 import { BROWSER_SDK_JS, SWARM_UI_JS } from "../artifact-sdk/browser-sdk";
 import { getPage, incrementPageViewCount } from "../be/db";
 import type { Page } from "../types";
+import { getAppUrl } from "../utils/constants";
 import { extractAndVerifyCookie, issuePageSessionCookie } from "../utils/page-session";
 import { scrubSecrets } from "../utils/secret-scrubber";
 import { route } from "./route-def";
@@ -159,14 +160,11 @@ function stripJsonSuffix(idSegment: string): string | null {
 }
 
 /**
- * Compute the SPA base URL (`APP_URL`). Mirrors `getAppBaseUrl` in pages.ts —
- * duplicated here to keep this module standalone (no cross-import inside the
- * http/ layer).
+ * Compute the SPA base URL. Delegates to the shared {@link getAppUrl} helper
+ * (the single source of truth for `APP_URL` resolution).
  */
 function getAppBaseUrl(): string {
-  const env = process.env.APP_URL?.trim();
-  if (env) return env.replace(/\/+$/, "");
-  return "http://localhost:5274";
+  return getAppUrl();
 }
 
 /**

--- a/src/http/pages.ts
+++ b/src/http/pages.ts
@@ -14,6 +14,7 @@ import {
 } from "../be/db";
 import { snapshotPage } from "../pages/version";
 import { type Page, PageAuthModeSchema, PageContentTypeSchema, type PageSummary } from "../types";
+import { getAppUrl, getPublicMcpBaseUrl } from "../utils/constants";
 import { issuePageSessionCookie } from "../utils/page-session";
 import { route } from "./route-def";
 import { BODY_TOO_LARGE, enforceContentLengthCap, json, jsonError } from "./utils";
@@ -280,25 +281,20 @@ function applyLaunchCors(req: IncomingMessage, res: ServerResponse): void {
 
 /**
  * Resolve the public API base URL used to build a page's `api_url` share
- * pointer. Falls back to `http://localhost:<PORT>` when `MCP_BASE_URL` is
- * unset (same convention as src/tools/memory-rate.ts, etc.). Trailing slashes
- * are stripped so callers can concatenate `/p/:id` directly.
+ * pointer (handed to a browser). Delegates to the shared
+ * {@link getPublicMcpBaseUrl} helper (trailing slashes already stripped) so
+ * callers can concatenate `/p/:id` directly.
  */
 function getApiBaseUrl(): string {
-  const env = process.env.MCP_BASE_URL?.trim();
-  if (env) return env.replace(/\/+$/, "");
-  return `http://localhost:${process.env.PORT || "3013"}`;
+  return getPublicMcpBaseUrl();
 }
 
 /**
  * Resolve the SPA / dashboard base URL used to build a page's `app_url` share
- * pointer (→ `/pages/:id`). `APP_URL` is the canonical env (matches the
- * request-human-input tool); falls back to the local dev port `5274`.
+ * pointer (→ `/pages/:id`). Delegates to the shared {@link getAppUrl} helper.
  */
 function getAppBaseUrl(): string {
-  const env = process.env.APP_URL?.trim();
-  if (env) return env.replace(/\/+$/, "");
-  return "http://localhost:5274";
+  return getAppUrl();
 }
 
 /** Decorate a page row with share-URL pointers. */

--- a/src/http/utils.ts
+++ b/src/http/utils.ts
@@ -157,14 +157,21 @@ export function triggerSchemaErrorResponse(
  * redirect URIs). Returns a URL with no trailing slash.
  *
  * Resolution order:
- *   1. `MCP_BASE_URL` env (canonical)
- *   2. Inbound request host — `X-Forwarded-Proto`/`X-Forwarded-Host` if behind
+ *   1. `PUBLIC_MCP_BASE_URL` env — explicit public origin. Wins so split
+ *      deployments (Helm) can keep `MCP_BASE_URL` pointed at an internal
+ *      cluster address while outbound URLs use the public ingress.
+ *   2. `MCP_BASE_URL` env — canonical when public and internal hosts coincide
+ *      (e.g. an ngrok tunnel set as `MCP_BASE_URL` in local dev).
+ *   3. Inbound request host — `X-Forwarded-Proto`/`X-Forwarded-Host` if behind
  *      a proxy/tunnel (ngrok), else `Host` header. Lets the URL stay correct
- *      when MCP_BASE_URL is unset and the API is reached via an arbitrary
+ *      when neither env var is set and the API is reached via an arbitrary
  *      external hostname.
- *   3. `http://localhost:<PORT>` fallback
+ *   4. `http://localhost:<PORT>` fallback
  */
 export function deriveApiBaseUrl(req: IncomingMessage): string {
+  const publicBase = process.env.PUBLIC_MCP_BASE_URL?.trim();
+  if (publicBase) return publicBase.replace(/\/+$/, "");
+
   const envBase = process.env.MCP_BASE_URL?.trim();
   if (envBase) return envBase.replace(/\/+$/, "");
 

--- a/src/jira/app.ts
+++ b/src/jira/app.ts
@@ -1,4 +1,5 @@
 import { upsertOAuthApp } from "../be/db-queries/oauth";
+import { getPublicMcpBaseUrl } from "../utils/constants";
 import { initJiraOutboundSync, teardownJiraOutboundSync } from "./outbound";
 // Side-effect import: registers all Jira event templates in the in-memory
 // registry at module load time (mirrors `src/linear/templates.ts`).
@@ -41,9 +42,7 @@ export function initJira(): boolean {
   // Atlassian. Prefer MCP_BASE_URL over the localhost dev default; in prod
   // with no JIRA_REDIRECT_URI set, this is what stops Atlassian from sending
   // the user back to localhost.
-  const apiBaseUrl =
-    process.env.MCP_BASE_URL?.trim().replace(/\/+$/, "") ||
-    `http://localhost:${process.env.PORT || "3013"}`;
+  const apiBaseUrl = getPublicMcpBaseUrl();
   const redirectUri = process.env.JIRA_REDIRECT_URI ?? `${apiBaseUrl}/api/trackers/jira/callback`;
 
   upsertOAuthApp("jira", {

--- a/src/jira/webhook-lifecycle.ts
+++ b/src/jira/webhook-lifecycle.ts
@@ -1,3 +1,4 @@
+import { getPublicMcpBaseUrl } from "../utils/constants";
 import { jiraFetch } from "./client";
 import { getJiraMetadata, updateJiraMetadata } from "./metadata";
 
@@ -23,7 +24,7 @@ let keepaliveInterval: ReturnType<typeof setInterval> | null = null;
 // ─── URL helpers ─────────────────────────────────────────────────────────────
 
 function getWebhookBaseUrl(): string {
-  return process.env.MCP_BASE_URL || `http://localhost:${process.env.PORT || "3013"}`;
+  return getPublicMcpBaseUrl();
 }
 
 function getRegisteredWebhookUrl(): string {

--- a/src/linear/app.ts
+++ b/src/linear/app.ts
@@ -1,4 +1,5 @@
 import { upsertOAuthApp } from "../be/db-queries/oauth";
+import { getPublicMcpBaseUrl } from "../utils/constants";
 import { initLinearOutboundSync, teardownLinearOutboundSync } from "./outbound";
 
 let initialized = false;
@@ -31,9 +32,7 @@ export function initLinear(): boolean {
   // verbatim by the OAuth flow. Prefer MCP_BASE_URL over the localhost default
   // so prod doesn't send users back to localhost when LINEAR_REDIRECT_URI is
   // unset.
-  const apiBaseUrl =
-    process.env.MCP_BASE_URL?.trim().replace(/\/+$/, "") ||
-    `http://localhost:${process.env.PORT || "3013"}`;
+  const apiBaseUrl = getPublicMcpBaseUrl();
   const redirectUri =
     process.env.LINEAR_REDIRECT_URI ?? `${apiBaseUrl}/api/trackers/linear/callback`;
 

--- a/src/tests/mcp-oauth-manual-client.test.ts
+++ b/src/tests/mcp-oauth-manual-client.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { unlink } from "node:fs/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { closeDb, createMcpServer, initDb } from "../be/db";
+import { getMcpOAuthToken } from "../be/db-queries/mcp-oauth";
+import { handleCore } from "../http/core";
+import { handleMcpOAuth } from "../http/mcp-oauth";
+import { getPathSegments, parseQueryParams } from "../http/utils";
+
+const API_KEY = "test-secret-key";
+const TEST_DB_PATH = "./test-mcp-oauth-manual-client.sqlite";
+
+async function removeDbFiles(): Promise<void> {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    await unlink(`${TEST_DB_PATH}${suffix}`).catch(() => {});
+  }
+}
+
+type TestResponse = {
+  status: number;
+  text: string;
+  headers: Record<string, string>;
+  json: () => Promise<unknown>;
+};
+
+async function dispatch(path: string, init: RequestInit = {}): Promise<TestResponse> {
+  const headers: Record<string, string> = {
+    ...((init.headers as Record<string, string>) ?? {}),
+  };
+  if (init.body !== undefined && !headers["Content-Type"])
+    headers["Content-Type"] = "application/json";
+
+  const req = Readable.from(init.body ? [Buffer.from(String(init.body))] : []) as IncomingMessage;
+  req.method = init.method ?? "GET";
+  req.url = path;
+  req.headers = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+
+  let status = 200;
+  let text = "";
+  const responseHeaders: Record<string, string> = {};
+  const res = {
+    headersSent: false,
+    writableEnded: false,
+    setHeader(name: string, value: number | string | readonly string[]) {
+      responseHeaders[name.toLowerCase()] = Array.isArray(value) ? value.join(", ") : String(value);
+      return this;
+    },
+    writeHead(code: number, headersArg?: Record<string, number | string | readonly string[]>) {
+      status = code;
+      if (headersArg) {
+        for (const [key, value] of Object.entries(headersArg)) {
+          responseHeaders[key.toLowerCase()] = Array.isArray(value)
+            ? value.join(", ")
+            : String(value);
+        }
+      }
+      this.headersSent = true;
+      return this;
+    },
+    end(chunk?: unknown) {
+      if (chunk !== undefined) text += String(chunk);
+      this.writableEnded = true;
+      return this;
+    },
+  } as unknown as ServerResponse;
+
+  const handledCore = await handleCore(req, res, undefined, API_KEY);
+  if (!handledCore) {
+    const pathSegments = getPathSegments(req.url || "");
+    const queryParams = parseQueryParams(req.url || "");
+    const handled = await handleMcpOAuth(req, res, pathSegments, queryParams);
+    if (!handled) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found" }));
+    }
+  }
+
+  return {
+    status,
+    text,
+    headers: responseHeaders,
+    json: async () => JSON.parse(text),
+  };
+}
+
+describe("MCP OAuth manual client flow", () => {
+  let originalFetch: typeof fetch;
+  let capturedTokenBody: string | null;
+  let originalPublicMcpBaseUrl: string | undefined;
+  let originalAppUrl: string | undefined;
+  let originalDashboardUrl: string | undefined;
+
+  beforeEach(async () => {
+    originalFetch = globalThis.fetch;
+    capturedTokenBody = null;
+    originalPublicMcpBaseUrl = process.env.PUBLIC_MCP_BASE_URL;
+    originalAppUrl = process.env.APP_URL;
+    originalDashboardUrl = process.env.DASHBOARD_URL;
+    process.env.SECRETS_ENCRYPTION_KEY = Buffer.alloc(32, 9).toString("base64");
+
+    await removeDbFiles();
+    initDb(TEST_DB_PATH);
+    process.env.PUBLIC_MCP_BASE_URL = "https://swarm.example.test";
+    process.env.APP_URL = "https://dashboard.example.test";
+    delete process.env.DASHBOARD_URL;
+
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const href = input.toString();
+      if (href === "https://login.salesforce.com/services/oauth2/token") {
+        capturedTokenBody = init?.body?.toString() ?? null;
+        return new Response(
+          JSON.stringify({
+            access_token: "sf-access-token",
+            token_type: "Bearer",
+            expires_in: 3600,
+            refresh_token: "sf-refresh-token",
+            scope: "mcp_api refresh_token",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    closeDb();
+    await removeDbFiles();
+    if (originalPublicMcpBaseUrl === undefined) delete process.env.PUBLIC_MCP_BASE_URL;
+    else process.env.PUBLIC_MCP_BASE_URL = originalPublicMcpBaseUrl;
+    if (originalAppUrl === undefined) delete process.env.APP_URL;
+    else process.env.APP_URL = originalAppUrl;
+    if (originalDashboardUrl === undefined) delete process.env.DASHBOARD_URL;
+    else process.env.DASHBOARD_URL = originalDashboardUrl;
+  });
+
+  test("authorize-url uses a stored manual client when DCR is not available", async () => {
+    const mcpServer = createMcpServer({
+      name: "salesforce-sobjects",
+      transport: "http",
+      url: "https://api.salesforce.com/platform/mcp/v1/platform/sobject-all",
+      scope: "swarm",
+    });
+
+    const manualRes = await dispatch(`/api/mcp-oauth/${mcpServer.id}/manual-client`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: JSON.stringify({
+        clientId: "sf-client-id",
+        clientSecret: "sf-client-secret",
+        authorizationServerIssuer: "https://login.salesforce.com",
+        authorizeUrl: "https://login.salesforce.com/services/oauth2/authorize",
+        tokenUrl: "https://login.salesforce.com/services/oauth2/token",
+        scopes: ["mcp_api", "refresh_token"],
+      }),
+    });
+    expect(manualRes.status).toBe(200);
+
+    const provisionalToken = getMcpOAuthToken(mcpServer.id);
+    expect(provisionalToken?.clientSource).toBe("manual");
+    expect(provisionalToken?.status).toBe("error");
+
+    const authorizeRes = await dispatch(`/api/mcp-oauth/${mcpServer.id}/authorize-url`, {
+      headers: { Authorization: `Bearer ${API_KEY}` },
+    });
+    expect(authorizeRes.status).toBe(200);
+    const { providerUrl } = (await authorizeRes.json()) as { providerUrl: string };
+    const provider = new URL(providerUrl);
+
+    expect(provider.origin + provider.pathname).toBe(
+      "https://login.salesforce.com/services/oauth2/authorize",
+    );
+    expect(provider.searchParams.get("client_id")).toBe("sf-client-id");
+    expect(provider.searchParams.get("scope")).toBe("mcp_api refresh_token");
+    expect(provider.searchParams.get("resource")).toBe(mcpServer.url);
+    expect(provider.searchParams.get("redirect_uri")).toBe(
+      "https://swarm.example.test/api/mcp-oauth/callback",
+    );
+
+    const state = provider.searchParams.get("state");
+    expect(state).toBeTruthy();
+
+    const callbackRes = await dispatch(
+      `/api/mcp-oauth/callback?state=${encodeURIComponent(state!)}&code=sf-auth-code`,
+    );
+    expect(callbackRes.status).toBe(302);
+    expect(callbackRes.headers.location).toBe(
+      `${process.env.APP_URL}/mcp-servers/${mcpServer.id}?oauth=success`,
+    );
+
+    const tokenRequest = new URLSearchParams(capturedTokenBody ?? "");
+    expect(tokenRequest.get("client_id")).toBe("sf-client-id");
+    expect(tokenRequest.get("client_secret")).toBe("sf-client-secret");
+    expect(tokenRequest.get("resource")).toBe(mcpServer.url);
+    expect(tokenRequest.get("redirect_uri")).toBe(
+      "https://swarm.example.test/api/mcp-oauth/callback",
+    );
+
+    const connectedToken = getMcpOAuthToken(mcpServer.id);
+    expect(connectedToken?.clientSource).toBe("manual");
+    expect(connectedToken?.status).toBe("connected");
+    expect(connectedToken?.accessToken).toBe("sf-access-token");
+    expect(connectedToken?.refreshToken).toBe("sf-refresh-token");
+    expect(connectedToken?.dcrClientId).toBe("sf-client-id");
+    expect(connectedToken?.dcrClientSecret).toBe("sf-client-secret");
+  });
+});

--- a/src/tests/pages-public-html.test.ts
+++ b/src/tests/pages-public-html.test.ts
@@ -41,6 +41,8 @@ describe("GET /p/:id — HTML public path", () => {
   let server: Server;
   const agentId = crypto.randomUUID();
   const headers = { "Content-Type": "application/json", "X-Agent-ID": agentId };
+  const ORIG_APP = process.env.APP_URL;
+  const ORIG_DASHBOARD = process.env.DASHBOARD_URL;
 
   beforeAll(async () => {
     for (const suffix of ["", "-wal", "-shm"]) {
@@ -56,6 +58,10 @@ describe("GET /p/:id — HTML public path", () => {
   afterAll(async () => {
     await new Promise<void>((resolve) => server.close(() => resolve()));
     closeDb();
+    if (ORIG_APP === undefined) delete process.env.APP_URL;
+    else process.env.APP_URL = ORIG_APP;
+    if (ORIG_DASHBOARD === undefined) delete process.env.DASHBOARD_URL;
+    else process.env.DASHBOARD_URL = ORIG_DASHBOARD;
     for (const suffix of ["", "-wal", "-shm"]) {
       try {
         await unlink(`${TEST_DB_PATH}${suffix}`);
@@ -96,6 +102,41 @@ describe("GET /p/:id — HTML public path", () => {
     const text = await res.text();
     expect(text).toContain("<h1>Hello</h1>");
     expect(text).toContain("class SwarmSDK"); // BROWSER_SDK_JS sentinel
+  });
+
+  test("CSP frame ancestors include deprecated DASHBOARD_URL alias", async () => {
+    const prevApp = process.env.APP_URL;
+    const prevDashboard = process.env.DASHBOARD_URL;
+    delete process.env.APP_URL;
+    process.env.DASHBOARD_URL = "https://dashboard.example.test/";
+    try {
+      const html = "<!doctype html><html><head><title>CSP</title></head><body></body></html>";
+      const post = await fetch(`${BASE}/api/pages`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          slug: "dashboard-url-csp",
+          title: "Dashboard URL CSP",
+          contentType: "text/html",
+          authMode: "public",
+          body: html,
+        }),
+      });
+      expect(post.status).toBe(201);
+      const { id } = (await post.json()) as { id: string };
+
+      const res = await fetch(`${BASE}/p/${id}`);
+      expect(res.status).toBe(200);
+      const csp = res.headers.get("content-security-policy");
+      const frameAncestors =
+        csp?.split(";").find((d) => d.trim().startsWith("frame-ancestors ")) ?? "";
+      expect(frameAncestors).toContain("https://dashboard.example.test");
+    } finally {
+      if (prevApp === undefined) delete process.env.APP_URL;
+      else process.env.APP_URL = prevApp;
+      if (prevDashboard === undefined) delete process.env.DASHBOARD_URL;
+      else process.env.DASHBOARD_URL = prevDashboard;
+    }
   });
 
   test("public JSON page 302-redirects to SPA artifact route", async () => {

--- a/src/tests/pages-public-json-redirect.test.ts
+++ b/src/tests/pages-public-json-redirect.test.ts
@@ -1,7 +1,7 @@
 /**
  * Public `/p/:id` for JSON content. JSON pages do NOT render at the API —
  * the renderer lives in the SPA at `/pages/:id` (step-6/7). The API
- * responds with a 302 to `${APP_URL}/pages/:id`.
+ * responds with a 302 to the configured app URL's `/pages/:id`.
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import crypto from "node:crypto";
@@ -38,6 +38,7 @@ describe("GET /p/:id — JSON page redirect", () => {
   const agentId = crypto.randomUUID();
   const headers = { "Content-Type": "application/json", "X-Agent-ID": agentId };
   const ORIG_APP = process.env.APP_URL;
+  const ORIG_DASHBOARD = process.env.DASHBOARD_URL;
 
   beforeAll(async () => {
     for (const suffix of ["", "-wal", "-shm"]) {
@@ -48,6 +49,7 @@ describe("GET /p/:id — JSON page redirect", () => {
     initDb(TEST_DB_PATH);
     // Pin APP_URL so the redirect is deterministic across hosts.
     process.env.APP_URL = "http://localhost:5274";
+    delete process.env.DASHBOARD_URL;
     server = createTestServer();
     await new Promise<void>((resolve) => server.listen(TEST_PORT, () => resolve()));
   });
@@ -57,6 +59,8 @@ describe("GET /p/:id — JSON page redirect", () => {
     closeDb();
     if (ORIG_APP === undefined) delete process.env.APP_URL;
     else process.env.APP_URL = ORIG_APP;
+    if (ORIG_DASHBOARD === undefined) delete process.env.DASHBOARD_URL;
+    else process.env.DASHBOARD_URL = ORIG_DASHBOARD;
     for (const suffix of ["", "-wal", "-shm"]) {
       try {
         await unlink(`${TEST_DB_PATH}${suffix}`);
@@ -64,7 +68,7 @@ describe("GET /p/:id — JSON page redirect", () => {
     }
   });
 
-  test("JSON content redirects to ${APP_URL}/pages/:id", async () => {
+  test("JSON content redirects to configured app URL pages route", async () => {
     const post = await fetch(`${BASE}/api/pages`, {
       method: "POST",
       headers,
@@ -82,5 +86,36 @@ describe("GET /p/:id — JSON page redirect", () => {
     const res = await fetch(`${BASE}/p/${id}`, { redirect: "manual" });
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe(`http://localhost:5274/pages/${id}`);
+  });
+
+  test("JSON content falls back to local SPA when app URL envs are unset", async () => {
+    const prevApp = process.env.APP_URL;
+    const prevDashboard = process.env.DASHBOARD_URL;
+    process.env.APP_URL = "";
+    delete process.env.DASHBOARD_URL;
+    try {
+      const post = await fetch(`${BASE}/api/pages`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          slug: "redir-local-fallback",
+          title: "Redirect Locally",
+          contentType: "application/json",
+          authMode: "public",
+          body: JSON.stringify({ kind: "spec", nodes: [] }),
+        }),
+      });
+      expect(post.status).toBe(201);
+      const { id } = (await post.json()) as { id: string };
+
+      const res = await fetch(`${BASE}/p/${id}`, { redirect: "manual" });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe(`http://localhost:5274/pages/${id}`);
+    } finally {
+      if (prevApp === undefined) delete process.env.APP_URL;
+      else process.env.APP_URL = prevApp;
+      if (prevDashboard === undefined) delete process.env.DASHBOARD_URL;
+      else process.env.DASHBOARD_URL = prevDashboard;
+    }
   });
 });

--- a/src/tools/create-metric.ts
+++ b/src/tools/create-metric.ts
@@ -5,6 +5,7 @@ import { assertSelectOnlyQuery } from "@/http/db-query";
 import { snapshotMetric } from "@/metrics/version";
 import { createToolRegistrar } from "@/tools/utils";
 import { MetricDefinitionSchema } from "@/types";
+import { getAppUrl } from "@/utils/constants";
 
 function slugify(input: string): string {
   const slug = input
@@ -16,9 +17,7 @@ function slugify(input: string): string {
 }
 
 function getAppBaseUrl(): string {
-  const env = process.env.APP_URL?.trim();
-  if (env) return env.replace(/\/+$/, "");
-  return "http://localhost:5274";
+  return getAppUrl();
 }
 
 function metricEditCounter(metricId: string): number {

--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -23,6 +23,7 @@ import { createPage, getPage, getPageBySlug, getPageVersions, updatePage } from 
 import { snapshotPage } from "@/pages/version";
 import { createToolRegistrar } from "@/tools/utils";
 import { PageAuthModeSchema, PageContentTypeSchema } from "@/types";
+import { getAppUrl, getPublicMcpBaseUrl } from "@/utils/constants";
 
 /** Same slugifier used by the HTTP createPage handler. */
 function slugify(input: string): string {
@@ -35,15 +36,11 @@ function slugify(input: string): string {
 }
 
 function getApiBaseUrl(): string {
-  const env = process.env.MCP_BASE_URL?.trim();
-  if (env) return env.replace(/\/+$/, "");
-  return `http://localhost:${process.env.PORT || "3013"}`;
+  return getPublicMcpBaseUrl();
 }
 
 function getAppBaseUrl(): string {
-  const env = process.env.APP_URL?.trim();
-  if (env) return env.replace(/\/+$/, "");
-  return "http://localhost:5274";
+  return getAppUrl();
 }
 
 /**

--- a/src/tools/memory-rate.ts
+++ b/src/tools/memory-rate.ts
@@ -3,6 +3,7 @@ import * as z from "zod";
 import { REFERENCES_SOURCE_MAX_LENGTH, sanitizeReferencesSource } from "@/be/memory/raters/types";
 import { createToolRegistrar } from "@/tools/utils";
 import { getApiKey } from "@/utils/api-key";
+import { getMcpBaseUrl } from "@/utils/constants";
 
 /**
  * Plan: thoughts/taras/plans/2026-05-05-memory-rater-v1.5/step-5.md §1
@@ -92,7 +93,7 @@ export const registerMemoryRateTool = (server: McpServer) => {
         cleanedReferencesSource = cleaned;
       }
 
-      const apiUrl = process.env.MCP_BASE_URL || `http://localhost:${process.env.PORT || "3013"}`;
+      const apiUrl = getMcpBaseUrl();
       const apiKey = getApiKey();
 
       const event = {

--- a/src/tools/register-kapso-number.ts
+++ b/src/tools/register-kapso-number.ts
@@ -10,13 +10,11 @@ import {
   putKapsoNumberMapping,
 } from "@/integrations/kapso/config";
 import { createToolRegistrar } from "@/tools/utils";
+import { getPublicMcpBaseUrl } from "@/utils/constants";
 
 /** Build the native inbound webhook URL the swarm exposes for Kapso deliveries. */
 function nativeWebhookUrl(): string {
-  const base = (
-    process.env.MCP_BASE_URL || `http://localhost:${process.env.PORT || "3013"}`
-  ).replace(/\/+$/, "");
-  return `${base}/api/integrations/kapso/webhook`;
+  return `${getPublicMcpBaseUrl()}/api/integrations/kapso/webhook`;
 }
 
 export const registerRegisterKapsoNumberTool = (server: McpServer) => {

--- a/src/tools/request-human-input.ts
+++ b/src/tools/request-human-input.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod";
 import { createApprovalRequest, getAgentCurrentTask } from "@/be/db";
 import { createToolRegistrar } from "@/tools/utils";
+import { getAppUrl } from "@/utils/constants";
 
 const QuestionSchema = z.object({
   id: z.string().describe("Unique ID for the question (used as key in responses)"),
@@ -94,7 +95,7 @@ export const registerRequestHumanInputTool = (server: McpServer) => {
         timeoutSeconds,
       });
 
-      const appUrl = process.env.APP_URL || "http://localhost:5274";
+      const appUrl = getAppUrl();
       const url = `${appUrl}/approval-requests/${request.id}`;
 
       return {

--- a/src/tools/script-common.ts
+++ b/src/tools/script-common.ts
@@ -1,6 +1,7 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import * as z from "zod";
 import { getApiKey } from "@/utils/api-key";
+import { getMcpBaseUrl } from "@/utils/constants";
 import type { RequestInfo } from "./utils";
 
 export const SCRIPT_TRANSPORT_ERROR =
@@ -20,10 +21,7 @@ export const scriptToolOutputSchema = z.object({
 export type ScriptToolStructuredContent = z.infer<typeof scriptToolOutputSchema>;
 
 function apiBaseUrl(): string {
-  return (process.env.MCP_BASE_URL || `http://localhost:${process.env.PORT || "3013"}`).replace(
-    /\/+$/,
-    "",
-  );
+  return getMcpBaseUrl();
 }
 
 function toolError(message: string, status = 400): CallToolResult {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -12,17 +12,32 @@
 export const DEFAULT_APP_URL = "https://app.agent-swarm.dev";
 
 /**
+ * Resolve every explicitly configured app/dashboard URL. Each env var may be
+ * a comma-separated origin list; entries are returned in precedence order with
+ * trailing slashes stripped.
+ *
+ * Precedence: `APP_URL` entries → `DASHBOARD_URL` entries (deprecated alias,
+ * kept for back-compat).
+ */
+export function getConfiguredAppUrls(): string[] {
+  return [process.env.APP_URL, process.env.DASHBOARD_URL]
+    .flatMap((value) => (value ?? "").split(","))
+    .map((value) => value.trim().replace(/\/+$/, ""))
+    .filter(Boolean);
+}
+
+/**
  * Resolve the effective app/dashboard URL — the public origin the user's
  * browser is sent to (post-login redirects, Slack/approval links, page
  * `app_url` share links). Trailing slashes are stripped.
  *
- * Precedence: `APP_URL` → `DASHBOARD_URL` (deprecated alias, kept for
- * back-compat) → {@link DEFAULT_APP_URL}. This is the single source of truth;
- * call sites must not re-read `APP_URL`/`DASHBOARD_URL` directly.
+ * Precedence: first configured `APP_URL` entry → first configured
+ * `DASHBOARD_URL` entry (deprecated alias, kept for back-compat) → fallback.
+ * This is the single source of truth; call sites must not re-read
+ * `APP_URL`/`DASHBOARD_URL` directly.
  */
-export function getAppUrl(): string {
-  const raw = process.env.APP_URL?.trim() || process.env.DASHBOARD_URL?.trim();
-  return (raw || DEFAULT_APP_URL).replace(/\/+$/, "");
+export function getAppUrl(fallback = DEFAULT_APP_URL): string {
+  return (getConfiguredAppUrls()[0] || fallback).replace(/\/+$/, "");
 }
 
 /**

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -3,19 +3,54 @@
  */
 
 /**
- * Default dashboard URL used when `APP_URL` is unset. Points at the public
- * production dashboard so links (Slack messages, approval URLs, etc.) are
- * always renderable. Self-hosted operators should set `APP_URL` to override.
+ * Default dashboard URL used when neither `APP_URL` nor the deprecated
+ * `DASHBOARD_URL` is set. Points at the public production dashboard so links
+ * (Slack messages, approval URLs, page share links, post-OAuth redirects)
+ * stay renderable even when an operator forgets to configure it. Local dev
+ * should set `APP_URL` (e.g. in `.env`) to point at the local dashboard.
  */
 export const DEFAULT_APP_URL = "https://app.agent-swarm.dev";
 
 /**
- * Resolve the effective app/dashboard URL from `APP_URL` (with trailing
- * slashes stripped), falling back to {@link DEFAULT_APP_URL}.
+ * Resolve the effective app/dashboard URL — the public origin the user's
+ * browser is sent to (post-login redirects, Slack/approval links, page
+ * `app_url` share links). Trailing slashes are stripped.
+ *
+ * Precedence: `APP_URL` → `DASHBOARD_URL` (deprecated alias, kept for
+ * back-compat) → {@link DEFAULT_APP_URL}. This is the single source of truth;
+ * call sites must not re-read `APP_URL`/`DASHBOARD_URL` directly.
  */
 export function getAppUrl(): string {
-  const raw = process.env.APP_URL?.trim();
+  const raw = process.env.APP_URL?.trim() || process.env.DASHBOARD_URL?.trim();
   return (raw || DEFAULT_APP_URL).replace(/\/+$/, "");
+}
+
+/**
+ * Internal API/MCP base URL — how workers/agents and in-process callers reach
+ * the API server. May be a private/cluster address (e.g. the Helm ClusterIP
+ * `http://<release>-api:3013`). Do NOT use for browser-facing or
+ * externally-registered URLs (OAuth redirect URIs, webhook URLs): those must
+ * resolve to a host the browser / third party can reach — use
+ * {@link getPublicMcpBaseUrl} (no request context) or `deriveApiBaseUrl(req)`
+ * (request-scoped) instead. Trailing slashes are stripped.
+ */
+export function getMcpBaseUrl(): string {
+  const raw = process.env.MCP_BASE_URL?.trim();
+  return (raw || `http://localhost:${process.env.PORT || "3013"}`).replace(/\/+$/, "");
+}
+
+/**
+ * Public, browser-/externally-reachable origin of the API server — where
+ * `/api/mcp-oauth/callback`, OAuth redirect URIs, and registered webhook URLs
+ * resolve. Falls back to {@link getMcpBaseUrl} when the public and internal
+ * hosts are the same (local dev, single-box, or an ngrok/tunnel set as
+ * `MCP_BASE_URL`). In split deployments (Helm), set `PUBLIC_MCP_BASE_URL` to
+ * the public ingress URL while `MCP_BASE_URL` stays the internal service
+ * address. Trailing slashes are stripped.
+ */
+export function getPublicMcpBaseUrl(): string {
+  const raw = process.env.PUBLIC_MCP_BASE_URL?.trim();
+  return raw ? raw.replace(/\/+$/, "") : getMcpBaseUrl();
 }
 
 /**


### PR DESCRIPTION
## Why

Two coupled problems with our URL env vars:

1. **The MCP OAuth callback `redirect_uri` was built from `APP_URL`** (the dashboard origin, default `:5274`/prod) instead of the API server origin — even though the `/api/mcp-oauth/callback` route lives on the API server. This is the original bug that surfaced while wiring up an external (Salesforce) hosted MCP server.
2. **`MCP_BASE_URL` is overloaded** for two incompatible audiences:
   - internal **worker→API** traffic (fine as a private/cluster address), and
   - **browser-/externally-reachable** URLs (OAuth callbacks, Jira/Linear/kapso webhooks, OpenAPI `servers[]`).

An audit confirmed the Helm chart sets `MCP_BASE_URL` to an **internal ClusterIP** (`http://<release>-api:3013`), so every browser-facing/externally-registered URL derived from it was **unreachable in split deployments** — a latent bug beyond just the OAuth callback.

## What

**Foundation** (`src/utils/constants.ts`, `src/http/utils.ts`) — single source of truth:
- `getMcpBaseUrl()` — internal API base (`MCP_BASE_URL ?? localhost:PORT`).
- `getPublicMcpBaseUrl()` — `PUBLIC_MCP_BASE_URL ?? getMcpBaseUrl()`. Falls back to the internal base when public/internal hosts coincide (local dev, single-box, ngrok).
- `getAppUrl()` — now absorbs `DASHBOARD_URL` as a **deprecated alias**.
- `deriveApiBaseUrl(req)` — prefers `PUBLIC_MCP_BASE_URL` (additive; `MCP_BASE_URL`-first preserved so ngrok-style local setups don't regress).

**Call sites routed through the helpers:**
- OAuth: `callbackRedirectUri()` → `getPublicMcpBaseUrl()`; `dashboardBase()` → `getAppUrl()`.
- Browser/externally-registered → `getPublicMcpBaseUrl()`: page & `create-page` share links, OpenAPI server URL, Jira/Linear OAuth redirect bases, Jira webhook, kapso webhook, integrations connect URL (keeps the `swarm_config` DB lookup, just prefers the `PUBLIC_MCP_BASE_URL` key).
- Converged the divergent `APP_URL` readers (`pages`, `pages-public`, `create-metric`, `create-page`, `request-human-input`) → `getAppUrl()`.
- Worker→API reads (`runner`, `hook` ×2, `artifact`, `artifact-sdk`, `memory-rate`, `script-common`) → `getMcpBaseUrl()` (semantically identical, removes drift).

**Helm + docs:** new `config.publicMcpBaseUrl` → `configmap` emits `PUBLIC_MCP_BASE_URL` (defaults to `https://<ingress.host>` when ingress is enabled). Env-vars reference, `DEPLOYMENT.md`, local-dev runbook, `.env.example`, and the Linear/Jira integration guides.

## How to use it (split deploy / Salesforce)

Set `PUBLIC_MCP_BASE_URL` (or chart `config.publicMcpBaseUrl`) to the public ingress URL while `MCP_BASE_URL` stays the internal address. The Salesforce External Client App's callback URL then becomes `${PUBLIC_MCP_BASE_URL}/api/mcp-oauth/callback`.

## Deliberately out of scope (flagged for follow-up)

- **A real adjacent bug an agent surfaced but I pulled out of this PR:** the OAuth *authorize* flow never consumed a manually-pasted client (`POST /manual-client`) — it always re-ran discovery and required DCR, so the no-DCR path (**Salesforce!**) couldn't complete. The fix is sound and directly relevant, but it's security-sensitive OAuth code with murky provenance; it deserves its own reviewed PR. **Recommend doing it next.**
- `claude-managed-setup` and a few DI-injected-`env` sites (`hook` stop-summary, `codex-login`) left as-is — the `process.env`-reading helpers would break their dependency injection. For split-Helm correctness, `claude-managed`'s public MCP endpoint should later read `env.PUBLIC_MCP_BASE_URL ?? env.MCP_BASE_URL`.
- `scripts-runtime/*`, `codex-adapter`, `page-proxy` (intentional `127.0.0.1`), `telemetry` — intentionally untouched.

## Behavior changes to be aware of

- When `APP_URL` is **unset**, the converged readers now default to the prod dashboard URL (via `getAppUrl()`) instead of `localhost:5274`. Local dev sets `APP_URL` in `.env`, so this only affects misconfigured envs.
- `DASHBOARD_URL` still works (alias of `APP_URL`) but is now documented as deprecated.

## Verification

- `bun run tsc:check` clean
- `scripts/check-db-boundary.sh` + `scripts/check-api-key-boundary.sh` pass
- 544 targeted tests pass / 0 fail (mcp-oauth, pages, Jira/Linear webhooks, integrations, create-page, slack-attachments)
- `bun run lint` 0 errors (23 pre-existing test-file warnings)
- `bun run docs:openapi` → no drift

> Note: `ssrfOptions()` in `mcp-oauth.ts` gates `allowInsecure` on `NODE_ENV !== "production"`, but `NODE_ENV=production` isn't set in any prod image/chart — a separate latent issue, not addressed here.
