### PR TITLE
Script Runs: detail redesign, inline-run persistence & waterfall timeline

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7410,6 +7410,10 @@
                   "result": {},
                   "error": {
                     "type": "string"
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": 0
                   }
                 },
                 "required": [

--- a/src/be/db.ts
+++ b/src/be/db.ts
@@ -64,6 +64,7 @@ import type {
   ScheduledTaskSummary,
   ScriptRun,
   ScriptRunJournalEntry,
+  ScriptRunKind,
   ScriptRunStatus,
   Service,
   ServiceStatus,
@@ -11231,6 +11232,7 @@ type ScriptRunRow = {
   scriptName: string | null;
   source: string;
   args: string;
+  kind: string;
   status: string;
   pid: number | null;
   startedAt: string;
@@ -11256,6 +11258,7 @@ function rowToScriptRun(row: ScriptRunRow): ScriptRun {
     scriptName: row.scriptName ?? undefined,
     source: row.source,
     args: JSON.parse(row.args),
+    kind: row.kind as ScriptRunKind,
     status: row.status as ScriptRunStatus,
     pid: row.pid ?? undefined,
     startedAt: row.startedAt,
@@ -11320,6 +11323,67 @@ export function createScriptRun(data: {
     );
   if (!row) throw new Error("Failed to create script run");
   return { run: rowToScriptRun(row), existing: false };
+}
+
+// Persist a synchronous inline run (POST /api/scripts/run) as an already-terminal
+// row. Unlike createScriptRun these never get a journal and never use the
+// idempotencyKey column (inline idempotency lives in the kv table).
+export function recordInlineScriptRun(data: {
+  id: string;
+  agentId: string;
+  source: string;
+  args: unknown;
+  scriptName?: string;
+  status: "completed" | "failed";
+  output?: unknown;
+  error?: string;
+  startedAt: string;
+  finishedAt: string;
+  requestedByUserId?: string;
+  createdBy?: string;
+}): ScriptRun {
+  const row = getDb()
+    .prepare<
+      ScriptRunRow,
+      [
+        string,
+        string,
+        string | null,
+        string,
+        string,
+        string,
+        string | null,
+        string | null,
+        string,
+        string,
+        string | null,
+        string | null,
+        string | null,
+      ]
+    >(
+      `INSERT INTO script_runs
+        (id, agentId, scriptName, source, args, kind, status, output, error,
+         startedAt, finishedAt, requestedByUserId, created_by, updated_by)
+       VALUES (?, ?, ?, ?, ?, 'inline', ?, ?, ?, ?, ?, ?, ?, ?)
+       RETURNING *`,
+    )
+    .get(
+      data.id,
+      data.agentId,
+      data.scriptName ?? null,
+      data.source,
+      JSON.stringify(data.args ?? null),
+      data.status,
+      data.output === undefined ? null : JSON.stringify(data.output),
+      data.error ?? null,
+      data.startedAt,
+      data.finishedAt,
+      data.requestedByUserId ?? null,
+      data.createdBy ?? null,
+      data.createdBy ?? null,
+    );
+  if (!row) throw new Error("Failed to record inline script run");
+  return rowToScriptRun(row);
 }
 
 export function getScriptRun(id: string): ScriptRun | null {

--- a/src/be/db.ts
+++ b/src/be/db.ts
@@ -11459,6 +11459,7 @@ type ScriptRunJournalRow = {
   error: string | null;
   startedAt: string;
   completedAt: string | null;
+  durationMs: number | null;
   created_by: string | null;
   updated_by: string | null;
 };
@@ -11475,6 +11476,7 @@ function rowToScriptRunJournalEntry(row: ScriptRunJournalRow): ScriptRunJournalE
     error: row.error ?? undefined,
     startedAt: row.startedAt,
     completedAt: row.completedAt ?? undefined,
+    durationMs: row.durationMs ?? undefined,
   };
 }
 
@@ -11498,11 +11500,12 @@ export function upsertScriptRunJournalStep(data: {
   status: "completed" | "failed";
   result?: unknown;
   error?: string;
+  durationMs?: number;
 }): void {
   getDb().run(
     `INSERT OR IGNORE INTO script_run_journal
-      (id, runId, stepKey, stepType, config, status, result, error, completedAt)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+      (id, runId, stepKey, stepType, config, status, result, error, durationMs, completedAt)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
     [
       crypto.randomUUID(),
       data.runId,
@@ -11512,6 +11515,7 @@ export function upsertScriptRunJournalStep(data: {
       data.status,
       data.result !== undefined ? JSON.stringify(data.result) : null,
       data.error ?? null,
+      data.durationMs ?? null,
     ],
   );
 }

--- a/src/be/migrations/084_script_run_journal_duration.sql
+++ b/src/be/migrations/084_script_run_journal_duration.sql
@@ -1,0 +1,5 @@
+-- Script Workflows: record real per-step wall-clock duration (ms) measured in the
+-- subprocess, so the dashboard can render a truthful waterfall. Nullable — existing
+-- journal rows stay NULL and are treated as "unmeasured".
+
+ALTER TABLE script_run_journal ADD COLUMN durationMs INTEGER;

--- a/src/be/migrations/085_script_runs_kind.sql
+++ b/src/be/migrations/085_script_runs_kind.sql
@@ -1,0 +1,9 @@
+-- Discriminate durable script-workflow runs from inline/one-off `/api/scripts/run`
+-- executions so both can be persisted in the same script_runs table.
+-- Existing rows are all durable workflow runs, hence the 'workflow' default.
+
+ALTER TABLE script_runs
+  ADD COLUMN kind TEXT NOT NULL DEFAULT 'workflow'
+  CHECK(kind IN ('workflow', 'inline'));
+
+CREATE INDEX IF NOT EXISTS idx_script_runs_kind ON script_runs(kind);

--- a/src/http/script-runs.ts
+++ b/src/http/script-runs.ts
@@ -62,6 +62,7 @@ const journalStepBodySchema = z.object({
   status: z.enum(["completed", "failed"]),
   result: z.unknown().optional(),
   error: z.string().optional(),
+  durationMs: z.number().int().nonnegative().optional(),
 });
 
 const statusBodySchema = z.discriminatedUnion("status", [
@@ -440,6 +441,7 @@ export async function handleScriptRuns(
       status: parsed.body.status,
       result: parsed.body.result,
       error: parsed.body.error,
+      durationMs: parsed.body.durationMs,
     });
     const limit = assertRunWithinLimits(run.id);
     if (!limit.ok) {

--- a/src/http/scripts.ts
+++ b/src/http/scripts.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { z } from "zod";
-import { getAgentById, upsertKv } from "../be/db";
+import { getAgentById, recordInlineScriptRun, upsertKv } from "../be/db";
 import { createEvent } from "../be/events";
 import { deleteScript, getScript, upsertScriptByName } from "../be/scripts/db";
 import { searchScripts } from "../be/scripts/embeddings";
@@ -14,7 +14,7 @@ import {
   type ScriptScope,
   ScriptScopeSchema,
 } from "../types";
-import { scrubObject } from "../utils/secret-scrubber";
+import { scrubObject, scrubSecrets } from "../utils/secret-scrubber";
 import { route } from "./route-def";
 import { json, jsonError } from "./utils";
 
@@ -283,6 +283,7 @@ export async function handleScripts(
       return true;
     }
 
+    const startedAt = new Date().toISOString();
     const output = await runScript({
       source: source as string,
       args: parsed.body.args,
@@ -329,6 +330,39 @@ export async function handleScripts(
         changeReason: "Auto-saved successful inline run",
       });
       autoSaved = { slug, reason: "successful_inline_run" };
+    }
+
+    // Persist the inline run (no journal) so one-off executions show up alongside
+    // durable workflow runs in the Script Runs dashboard. Best-effort: recording
+    // must never fail the actual execution.
+    const ok = output.exitCode === 0 && !output.error && !output.runtimeError;
+    const runError = ok
+      ? undefined
+      : scrubSecrets(
+          [
+            output.error,
+            output.runtimeError
+              ? `${output.runtimeError.name}: ${output.runtimeError.message}`
+              : undefined,
+          ]
+            .filter(Boolean)
+            .join(" — ") || `Script exited with code ${output.exitCode}`,
+        );
+    try {
+      recordInlineScriptRun({
+        id: crypto.randomUUID(),
+        agentId: agent.id,
+        source: source as string,
+        args: parsed.body.args ?? null,
+        scriptName: parsed.body.name,
+        status: ok ? "completed" : "failed",
+        output: output.result,
+        error: runError,
+        startedAt,
+        finishedAt: new Date().toISOString(),
+      });
+    } catch {
+      // swallow — the run already executed; persistence is observability only.
     }
 
     json(

--- a/src/http/scripts.ts
+++ b/src/http/scripts.ts
@@ -353,10 +353,13 @@ export async function handleScripts(
         id: crypto.randomUUID(),
         agentId: agent.id,
         source: source as string,
-        args: parsed.body.args ?? null,
+        // Scrub args + result before persisting: the stored row is later served
+        // raw by GET /api/script-runs/{id} to the dashboard, so it needs the same
+        // redaction guarantees as the scrubbed run response below.
+        args: scrubObject(parsed.body.args ?? null),
         scriptName: parsed.body.name,
         status: ok ? "completed" : "failed",
-        output: output.result,
+        output: scrubObject(output.result),
         error: runError,
         startedAt,
         finishedAt: new Date().toISOString(),

--- a/src/script-workflows/workflow-ctx.ts
+++ b/src/script-workflows/workflow-ctx.ts
@@ -124,10 +124,11 @@ export function buildWorkflowCtx(input: {
     status: "completed" | "failed",
     result?: unknown,
     error?: string,
+    durationMs?: number,
   ): Promise<void> {
     const body = (await fetchJson(`/api/internal/script-runs/${input.runId}/steps`, {
       method: "POST",
-      body: JSON.stringify({ stepKey: label, stepType, config, status, result, error }),
+      body: JSON.stringify({ stepKey: label, stepType, config, status, result, error, durationMs }),
     })) as StepWriteResponse;
     if (!("ok" in body)) throw new Error(`Failed to write journal step ${label}`);
   }
@@ -140,13 +141,16 @@ export function buildWorkflowCtx(input: {
   ): Promise<unknown> {
     const replayed = await completedStep(label);
     if (replayed.found) return replayed.result;
+    const startedAt = Date.now();
     try {
       const result = await execute();
-      await writeStep(label, stepType, config, "completed", result);
+      const durationMs = Date.now() - startedAt;
+      await writeStep(label, stepType, config, "completed", result, undefined, durationMs);
       return result;
     } catch (err) {
+      const durationMs = Date.now() - startedAt;
       const error = err instanceof Error ? err.message : String(err);
-      await writeStep(label, stepType, config, "failed", undefined, error);
+      await writeStep(label, stepType, config, "failed", undefined, error, durationMs);
       throw err;
     }
   }

--- a/src/tests/scripts-mcp-e2e.test.ts
+++ b/src/tests/scripts-mcp-e2e.test.ts
@@ -232,6 +232,59 @@ describe("script_ MCP HTTP proxy tools", () => {
     expect(del.structuredContent.data?.deleted).toBe(true);
   });
 
+  test("persists a successful inline run with kind 'inline' and no journal", async () => {
+    const tools = buildToolServer();
+    const source = `export default async (args: { value: number }) => ({ doubled: args.value * 2 });`;
+
+    const run = (await tools.run.handler(
+      { source, args: { value: 21 }, intent: "inline persist e2e" },
+      meta(workerId),
+    )) as StructuredResult<{ result: { doubled: number } }>;
+    expect(run.structuredContent.success).toBe(true);
+    expect(run.structuredContent.data?.result).toEqual({ doubled: 42 });
+
+    const listed = (await tools.listScriptRuns.handler(
+      { limit: 10, offset: 0 },
+      meta(workerId),
+    )) as StructuredResult<{
+      runs: Array<{ id: string; kind: string; status: string }>;
+      total: number;
+    }>;
+    expect(listed.structuredContent.data?.total).toBe(1);
+    const inlineRun = listed.structuredContent.data?.runs[0];
+    expect(inlineRun?.kind).toBe("inline");
+    expect(inlineRun?.status).toBe("completed");
+
+    const detail = (await tools.getScriptRun.handler(
+      { id: inlineRun?.id },
+      meta(workerId),
+    )) as StructuredResult<{ run: { kind: string }; journal: unknown[] }>;
+    expect(detail.structuredContent.data?.run.kind).toBe("inline");
+    expect(detail.structuredContent.data?.journal).toEqual([]);
+  });
+
+  test("persists a failed inline run with kind 'inline' and an error", async () => {
+    const tools = buildToolServer();
+    const source = `export default async () => { throw new Error("boom"); };`;
+
+    const run = (await tools.run.handler(
+      { source, intent: "inline failure e2e" },
+      meta(workerId),
+    )) as StructuredResult<unknown>;
+    expect(run.structuredContent.success).toBe(true);
+
+    const listed = (await tools.listScriptRuns.handler(
+      { limit: 10, offset: 0 },
+      meta(workerId),
+    )) as StructuredResult<{
+      runs: Array<{ kind: string; status: string; error?: string }>;
+    }>;
+    const failed = listed.structuredContent.data?.runs[0];
+    expect(failed?.kind).toBe("inline");
+    expect(failed?.status).toBe("failed");
+    expect(failed?.error).toBeTruthy();
+  });
+
   test("stdio-style missing agent identity short-circuits clearly", async () => {
     const tools = buildToolServer();
     const result = (await tools.search.handler({ query: "anything" }, meta())) as StructuredResult<{

--- a/src/types.ts
+++ b/src/types.ts
@@ -1555,12 +1555,18 @@ export const TERMINAL_SCRIPT_RUN_STATUSES = [
 ] as const;
 export type TerminalScriptRunStatus = (typeof TERMINAL_SCRIPT_RUN_STATUSES)[number];
 
+// `workflow` = durable background run launched via /api/script-runs (has a journal).
+// `inline` = synchronous one-off run via /api/scripts/run (no journal).
+export const ScriptRunKindSchema = z.enum(["workflow", "inline"]);
+export type ScriptRunKind = z.infer<typeof ScriptRunKindSchema>;
+
 export const ScriptRunSchema = z.object({
   id: z.string().uuid(),
   agentId: z.string(),
   scriptName: z.string().optional(),
   source: z.string(),
   args: z.unknown(),
+  kind: ScriptRunKindSchema,
   status: ScriptRunStatusSchema,
   pid: z.number().int().optional(),
   startedAt: z.string(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1584,6 +1584,7 @@ export const ScriptRunJournalEntrySchema = z.object({
   error: z.string().optional(),
   startedAt: z.string(),
   completedAt: z.string().optional(),
+  durationMs: z.number().optional(),
 });
 export type ScriptRunJournalEntry = z.infer<typeof ScriptRunJournalEntrySchema>;
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -952,12 +952,16 @@ export type ScriptRunStatus =
   | "cancelled"
   | "aborted_limit";
 
+// `workflow` = durable background run (has a journal). `inline` = synchronous one-off run.
+export type ScriptRunKind = "workflow" | "inline";
+
 export interface ScriptRun {
   id: string;
   agentId: string;
   scriptName?: string;
   source: string;
   args?: unknown;
+  kind: ScriptRunKind;
   status: ScriptRunStatus;
   pid?: number;
   startedAt: string;

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -982,6 +982,12 @@ export interface ScriptRunJournalEntry {
   error?: string;
   startedAt: string;
   completedAt?: string;
+  /**
+   * Real wall-clock duration of the step in milliseconds, measured in the
+   * subprocess around the step's execution. Absent on runs recorded before
+   * per-step timing was added (the waterfall falls back to sequence mode).
+   */
+  durationMs?: number;
 }
 
 export interface ScriptRunsResponse {

--- a/ui/src/components/layout/breadcrumbs.tsx
+++ b/ui/src/components/layout/breadcrumbs.tsx
@@ -6,6 +6,7 @@ import { useMcpServer } from "@/api/hooks/use-mcp-servers";
 import { usePage } from "@/api/hooks/use-pages";
 import { useRepo } from "@/api/hooks/use-repos";
 import { useScheduledTask } from "@/api/hooks/use-schedules";
+import { useScriptRun } from "@/api/hooks/use-script-runs";
 import { useSession } from "@/api/hooks/use-sessions";
 import { useSkill } from "@/api/hooks/use-skills";
 import { useTask } from "@/api/hooks/use-tasks";
@@ -23,6 +24,7 @@ const routeLabels: Record<string, string> = {
   schedules: "Schedules",
   workflows: "Workflows",
   "workflow-runs": "Workflow Runs",
+  "script-runs": "Script Runs",
   "approval-requests": "Approvals",
   skills: "Skills",
   "mcp-servers": "MCP Servers",
@@ -112,6 +114,7 @@ export function Breadcrumbs() {
   const { data: taskMeta } = useTask(idFor("tasks"));
   const { data: workflowMeta } = useWorkflow(idFor("workflows"));
   const { data: scheduleMeta } = useScheduledTask(idFor("schedules"));
+  const { data: scriptRunMeta } = useScriptRun(idFor("script-runs"));
   const { data: skillMeta } = useSkill(idFor("skills"));
   const { data: mcpServerMeta } = useMcpServer(idFor("mcp-servers"));
   const { data: repoMeta } = useRepo(idFor("repos"));
@@ -136,15 +139,17 @@ export function Breadcrumbs() {
                 ? workflowMeta?.name
                 : parent === "schedules"
                   ? scheduleMeta?.name
-                  : parent === "skills"
-                    ? skillMeta?.name
-                    : parent === "mcp-servers"
-                      ? mcpServerMeta?.name
-                      : parent === "repos"
-                        ? repoMeta?.name
-                        : parent === "approval-requests"
-                          ? approvalMeta?.title
-                          : undefined
+                  : parent === "script-runs"
+                    ? scriptRunMeta?.run.scriptName
+                    : parent === "skills"
+                      ? skillMeta?.name
+                      : parent === "mcp-servers"
+                        ? mcpServerMeta?.name
+                        : parent === "repos"
+                          ? repoMeta?.name
+                          : parent === "approval-requests"
+                            ? approvalMeta?.title
+                            : undefined
     : undefined;
 
   const crumbs = segments.map((segment, index) => {

--- a/ui/src/components/script-runs/json-view.tsx
+++ b/ui/src/components/script-runs/json-view.tsx
@@ -1,0 +1,201 @@
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { cn } from "@/lib/utils";
+
+const STRING_INLINE_MAX = 140;
+const STRING_PREVIEW = 320;
+const INDENT = 14;
+
+interface JsonViewProps {
+  data: unknown;
+  maxHeight?: string;
+  defaultExpandDepth?: number;
+  className?: string;
+}
+
+/**
+ * Readable, brace-free tree view of arbitrary JSON. Object keys are teal,
+ * values type-colored; nested objects/arrays collapse behind a chevron with a
+ * "N keys" hint. Long/multi-line strings preview with a `+N chars` toggle.
+ */
+export function JsonView({
+  data,
+  maxHeight = "300px",
+  defaultExpandDepth = 1,
+  className,
+}: JsonViewProps) {
+  return (
+    <div
+      className={cn(
+        "overflow-auto rounded-md bg-muted p-3 font-mono text-xs leading-relaxed",
+        className,
+      )}
+      // inline-style: dynamic max-height driven by prop
+      style={{ maxHeight }}
+    >
+      <Node
+        nodeKey={null}
+        fromArray={false}
+        value={data}
+        depth={0}
+        expandDepth={defaultExpandDepth}
+      />
+    </div>
+  );
+}
+
+function StringValue({ value }: { value: string }) {
+  const [open, setOpen] = useState(false);
+  const multiline = value.includes("\n");
+
+  if (!multiline && value.length <= STRING_INLINE_MAX) {
+    return <span className="text-status-success-strong">{value}</span>;
+  }
+
+  const overflow = value.length - STRING_PREVIEW;
+  const shown = open || overflow <= 0 ? value : value.slice(0, STRING_PREVIEW);
+  return (
+    <span className="align-top">
+      <span className="whitespace-pre-wrap text-status-success-strong">{shown}</span>
+      {overflow > 0 && (
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="ml-1 rounded-sm px-1 text-[10px] text-muted-foreground transition-colors hover:bg-muted-foreground/15 hover:text-foreground"
+        >
+          {open ? "show less" : `+${overflow} chars`}
+        </button>
+      )}
+    </span>
+  );
+}
+
+function Primitive({ value }: { value: unknown }) {
+  if (value === null) return <span className="text-muted-foreground italic">null</span>;
+  if (value === undefined) return <span className="text-muted-foreground italic">—</span>;
+  if (typeof value === "string") return <StringValue value={value} />;
+  if (typeof value === "number")
+    return <span className="text-status-active-strong">{String(value)}</span>;
+  if (typeof value === "boolean")
+    return <span className="text-status-info-strong">{String(value)}</span>;
+  return <span className="text-foreground/80">{String(value)}</span>;
+}
+
+function KeyLabel({ nodeKey, fromArray }: { nodeKey: string | number; fromArray: boolean }) {
+  if (fromArray) {
+    return <span className="mr-2 select-none text-muted-foreground/50">{nodeKey}</span>;
+  }
+  return <span className="text-action-notify">{nodeKey}</span>;
+}
+
+function Node({
+  nodeKey,
+  fromArray,
+  value,
+  depth,
+  expandDepth,
+}: {
+  nodeKey: string | number | null;
+  fromArray: boolean;
+  value: unknown;
+  depth: number;
+  expandDepth: number;
+}) {
+  const isRoot = nodeKey === null;
+  const keyNode = isRoot ? null : <KeyLabel nodeKey={nodeKey} fromArray={fromArray} />;
+  const isContainer = value !== null && typeof value === "object";
+
+  if (!isContainer) {
+    return (
+      <div className="break-words" style={{ paddingLeft: `${depth * INDENT}px` }}>
+        {keyNode}
+        {keyNode && !fromArray && <span className="text-muted-foreground">: </span>}
+        <Primitive value={value} />
+      </div>
+    );
+  }
+
+  const isArray = Array.isArray(value);
+  const entries: Array<[string | number, unknown]> = isArray
+    ? (value as unknown[]).map((v, i) => [i, v])
+    : Object.entries(value as Record<string, unknown>);
+  const childDepth = isRoot ? depth : depth + 1;
+  const children = entries.map(([k, v]) => (
+    <Node
+      key={String(k)}
+      nodeKey={k}
+      fromArray={isArray}
+      value={v}
+      depth={childDepth}
+      expandDepth={expandDepth}
+    />
+  ));
+
+  if (isRoot) {
+    if (entries.length === 0) {
+      return (
+        <span className="text-muted-foreground italic">{isArray ? "empty list" : "empty"}</span>
+      );
+    }
+    return <>{children}</>;
+  }
+
+  return (
+    <Branch
+      keyNode={keyNode}
+      count={entries.length}
+      isArray={isArray}
+      depth={depth}
+      defaultOpen={depth < expandDepth}
+    >
+      {children}
+    </Branch>
+  );
+}
+
+function Branch({
+  keyNode,
+  count,
+  isArray,
+  depth,
+  defaultOpen,
+  children,
+}: {
+  keyNode: ReactNode;
+  count: number;
+  isArray: boolean;
+  depth: number;
+  defaultOpen: boolean;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const empty = count === 0;
+  const summary = empty
+    ? isArray
+      ? "empty list"
+      : "empty"
+    : `${count} ${isArray ? (count === 1 ? "item" : "items") : count === 1 ? "key" : "keys"}`;
+
+  return (
+    <>
+      <div style={{ paddingLeft: `${depth * INDENT}px` }}>
+        <button
+          type="button"
+          onClick={() => !empty && setOpen((o) => !o)}
+          className="inline-flex items-center gap-1 text-left align-top"
+        >
+          {empty ? (
+            <span className="inline-block w-3" />
+          ) : open ? (
+            <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+          )}
+          {keyNode}
+          <span className="text-[10px] text-muted-foreground/60">{summary}</span>
+        </button>
+      </div>
+      {open && !empty && children}
+    </>
+  );
+}

--- a/ui/src/components/script-runs/source-map.ts
+++ b/ui/src/components/script-runs/source-map.ts
@@ -49,6 +49,28 @@ function buildMatcher(labelRaw: string): (stepKey: string) => boolean {
   return () => false;
 }
 
+/**
+ * Build a `lineOf(charIndex) → 0-based line` lookup for `source`. Scans newlines
+ * once into a sorted `lineStarts` array, then answers each query with a binary
+ * search. Shared by both source parsers so the indexing logic lives in one place.
+ */
+function lineIndexer(source: string): (idx: number) => number {
+  const lineStarts = [0];
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === "\n") lineStarts.push(i + 1);
+  }
+  return (idx: number): number => {
+    let lo = 0;
+    let hi = lineStarts.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (lineStarts[mid] <= idx) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo;
+  };
+}
+
 /** Is the char at `i` escaped? Counts consecutive preceding backslashes (odd = escaped). */
 function isEscaped(src: string, i: number): boolean {
   let n = 0;
@@ -64,21 +86,7 @@ function isEscaped(src: string, i: number): boolean {
 export function parseStepBlocks(source: string): StepBlock[] {
   const blocks: StepBlock[] = [];
   const re = /ctx\s*\.\s*step\s*\.\s*(swarmScript|agentTask|rawLlm|humanInTheLoop)\s*\(/g;
-
-  const lineStarts = [0];
-  for (let i = 0; i < source.length; i++) {
-    if (source[i] === "\n") lineStarts.push(i + 1);
-  }
-  const lineOf = (idx: number): number => {
-    let lo = 0;
-    let hi = lineStarts.length - 1;
-    while (lo < hi) {
-      const mid = (lo + hi + 1) >> 1;
-      if (lineStarts[mid] <= idx) lo = mid;
-      else hi = mid - 1;
-    }
-    return lo;
-  };
+  const lineOf = lineIndexer(source);
 
   let m: RegExpExecArray | null = re.exec(source);
   while (m !== null) {
@@ -150,20 +158,7 @@ export interface RunAnchors {
 
 /** Locate the source lines that correspond to the run's input (args) and output (return). */
 export function parseRunAnchors(source: string): RunAnchors {
-  const lineStarts = [0];
-  for (let i = 0; i < source.length; i++) {
-    if (source[i] === "\n") lineStarts.push(i + 1);
-  }
-  const lineOf = (idx: number): number => {
-    let lo = 0;
-    let hi = lineStarts.length - 1;
-    while (lo < hi) {
-      const mid = (lo + hi + 1) >> 1;
-      if (lineStarts[mid] <= idx) lo = mid;
-      else hi = mid - 1;
-    }
-    return lo;
-  };
+  const lineOf = lineIndexer(source);
 
   const sig =
     /^[^\n]*\bmain\b[^\n]*\(/m.exec(source) ?? /^[^\n]*\bfunction\b[^\n]*\(/m.exec(source);

--- a/ui/src/components/script-runs/source-map.ts
+++ b/ui/src/components/script-runs/source-map.ts
@@ -1,0 +1,207 @@
+import type { ScriptRunJournalEntry } from "@/api/types";
+
+const METHOD_TO_TYPE: Record<string, string> = {
+  swarmScript: "swarm-script",
+  agentTask: "agent-task",
+  rawLlm: "raw-llm",
+  humanInTheLoop: "human-in-the-loop",
+};
+
+export interface StepBlock {
+  /** The ctx.step.* method (swarmScript | agentTask | rawLlm | humanInTheLoop). */
+  method: string;
+  /** Journal stepType this block produces (swarm-script | agent-task | raw-llm). */
+  stepType: string;
+  /** 0-based first line of the call statement. */
+  startLine: number;
+  /** 0-based last line (inclusive) — spans multi-line config objects. */
+  endLine: number;
+  /** Raw first-argument text (the step label expression). */
+  labelRaw: string;
+  /** Does a given runtime stepKey originate from this call site? */
+  matches: (stepKey: string) => boolean;
+}
+
+/**
+ * Derive a stepKey matcher from the label expression:
+ * - string literal `"foo"` → exact match
+ * - template literal `` `step-${i}` `` → regex from the static segments (handles loops)
+ * - anything else (a bare variable) → matches nothing (falls back to type heuristics)
+ */
+function buildMatcher(labelRaw: string): (stepKey: string) => boolean {
+  const t = labelRaw.trim();
+  if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) {
+    const literal = t.slice(1, -1);
+    return (k) => k === literal;
+  }
+  if (t.startsWith("`") && t.endsWith("`")) {
+    const inner = t.slice(1, -1);
+    const segments = inner
+      .split(/\$\{[^}]*\}/g)
+      .map((p) => p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+    try {
+      const re = new RegExp(`^${segments.join(".*")}$`);
+      return (k) => re.test(k);
+    } catch {
+      return () => false;
+    }
+  }
+  return () => false;
+}
+
+/** Is the char at `i` escaped? Counts consecutive preceding backslashes (odd = escaped). */
+function isEscaped(src: string, i: number): boolean {
+  let n = 0;
+  let j = i - 1;
+  while (j >= 0 && src[j] === "\\") {
+    n++;
+    j--;
+  }
+  return n % 2 === 1;
+}
+
+/** Find every `ctx.step.<method>(...)` call site in the source and its line span. */
+export function parseStepBlocks(source: string): StepBlock[] {
+  const blocks: StepBlock[] = [];
+  const re = /ctx\s*\.\s*step\s*\.\s*(swarmScript|agentTask|rawLlm|humanInTheLoop)\s*\(/g;
+
+  const lineStarts = [0];
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === "\n") lineStarts.push(i + 1);
+  }
+  const lineOf = (idx: number): number => {
+    let lo = 0;
+    let hi = lineStarts.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (lineStarts[mid] <= idx) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo;
+  };
+
+  let m: RegExpExecArray | null = re.exec(source);
+  while (m !== null) {
+    const method = m[1];
+    const openParen = re.lastIndex - 1;
+    let depth = 0;
+    let firstArgEnd = -1;
+    let endIdx = -1;
+    let inStr: string | null = null;
+    for (let i = openParen; i < source.length; i++) {
+      const c = source[i];
+      if (inStr) {
+        if (c === inStr && !isEscaped(source, i)) inStr = null;
+        continue;
+      }
+      if (c === '"' || c === "'" || c === "`") inStr = c;
+      else if (c === "(") depth++;
+      else if (c === ")") {
+        depth--;
+        if (depth === 0) {
+          endIdx = i;
+          break;
+        }
+      } else if (c === "," && depth === 1 && firstArgEnd === -1) firstArgEnd = i;
+    }
+    if (endIdx !== -1) {
+      const labelRaw = source
+        .slice(openParen + 1, firstArgEnd === -1 ? endIdx : firstArgEnd)
+        .trim();
+      blocks.push({
+        method,
+        stepType: METHOD_TO_TYPE[method] ?? method,
+        startLine: lineOf(m.index),
+        endLine: lineOf(endIdx),
+        labelRaw,
+        matches: buildMatcher(labelRaw),
+      });
+    }
+    m = re.exec(source);
+  }
+  return blocks;
+}
+
+export interface StepBlockMapping {
+  /** stepId → block index. */
+  stepToBlock: Record<string, number>;
+  /** block index → stepIds produced by it (in journal order). */
+  blockToStepIds: Record<number, string[]>;
+}
+
+/** What the user has focused — a journal step, the run input (args), or the run output (return). */
+export type Selection =
+  | { kind: "step"; stepId: string }
+  | { kind: "input" }
+  | { kind: "output" }
+  | null;
+
+export interface SourceAnchor {
+  startLine: number;
+  endLine: number;
+}
+
+export interface RunAnchors {
+  /** The `main(args, …)` signature line — maps to the run's args. */
+  input: SourceAnchor | null;
+  /** The script's final `return` line — maps to the run's output. */
+  output: SourceAnchor | null;
+}
+
+/** Locate the source lines that correspond to the run's input (args) and output (return). */
+export function parseRunAnchors(source: string): RunAnchors {
+  const lineStarts = [0];
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === "\n") lineStarts.push(i + 1);
+  }
+  const lineOf = (idx: number): number => {
+    let lo = 0;
+    let hi = lineStarts.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (lineStarts[mid] <= idx) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo;
+  };
+
+  const sig =
+    /^[^\n]*\bmain\b[^\n]*\(/m.exec(source) ?? /^[^\n]*\bfunction\b[^\n]*\(/m.exec(source);
+  const input = sig ? { startLine: lineOf(sig.index), endLine: lineOf(sig.index) } : null;
+
+  const returnRe = /\breturn\b/g;
+  let lastReturn = -1;
+  let rm: RegExpExecArray | null = returnRe.exec(source);
+  while (rm !== null) {
+    lastReturn = rm.index;
+    rm = returnRe.exec(source);
+  }
+  const output =
+    lastReturn >= 0 ? { startLine: lineOf(lastReturn), endLine: lineOf(lastReturn) } : null;
+
+  return { input, output };
+}
+
+/** Attribute each journal step to the call site that produced it. */
+export function mapStepsToBlocks(
+  journal: ScriptRunJournalEntry[],
+  blocks: StepBlock[],
+): StepBlockMapping {
+  const stepToBlock: Record<string, number> = {};
+  const blockToStepIds: Record<number, string[]> = {};
+
+  for (const entry of journal) {
+    let idx = blocks.findIndex((b) => b.stepType === entry.stepType && b.matches(entry.stepKey));
+    if (idx === -1) {
+      // Fallback: exactly one call site of this type → unambiguous attribution.
+      const sameType = blocks.flatMap((b, i) => (b.stepType === entry.stepType ? [i] : []));
+      if (sameType.length === 1) idx = sameType[0];
+    }
+    if (idx !== -1) {
+      stepToBlock[entry.id] = idx;
+      if (!blockToStepIds[idx]) blockToStepIds[idx] = [];
+      blockToStepIds[idx].push(entry.id);
+    }
+  }
+  return { stepToBlock, blockToStepIds };
+}

--- a/ui/src/components/script-runs/source-view.tsx
+++ b/ui/src/components/script-runs/source-view.tsx
@@ -1,6 +1,7 @@
 import { Check, Copy, WrapText } from "lucide-react";
 import { Highlight, themes } from "prism-react-renderer";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { useTheme } from "@/hooks/use-theme";
 import { cn } from "@/lib/utils";
 import type { SourceAnchor, StepBlock } from "./source-map";
@@ -57,7 +58,7 @@ export function SourceView({
   className,
 }: SourceViewProps) {
   const { theme } = useTheme();
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
   const [wrap, setWrap] = useState(false);
 
   const lineInfo = useMemo(() => {
@@ -98,13 +99,6 @@ export function SourceView({
     const target = container.scrollTop + offset - container.clientHeight * 0.3;
     container.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
   }, [selectedBlock, selectedAnchor]);
-
-  const copy = () => {
-    navigator.clipboard.writeText(source).then(() => {
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
-    });
-  };
 
   const isSelected = (region: Region): boolean => {
     if (region.kind === "step") return region.blockIndex === selectedBlock;
@@ -148,7 +142,7 @@ export function SourceView({
           </button>
           <button
             type="button"
-            onClick={copy}
+            onClick={() => copy(source)}
             aria-label={copied ? "Copied" : "Copy source"}
             className={cn(
               "inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted-foreground/15 hover:text-foreground",

--- a/ui/src/components/script-runs/source-view.tsx
+++ b/ui/src/components/script-runs/source-view.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy } from "lucide-react";
+import { Check, Copy, WrapText } from "lucide-react";
 import { Highlight, themes } from "prism-react-renderer";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTheme } from "@/hooks/use-theme";
@@ -58,6 +58,7 @@ export function SourceView({
 }: SourceViewProps) {
   const { theme } = useTheme();
   const [copied, setCopied] = useState(false);
+  const [wrap, setWrap] = useState(false);
 
   const lineInfo = useMemo(() => {
     const map = new Map<
@@ -131,17 +132,32 @@ export function SourceView({
             </span>
           )}
         </div>
-        <button
-          type="button"
-          onClick={copy}
-          aria-label={copied ? "Copied" : "Copy source"}
-          className={cn(
-            "inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted-foreground/15 hover:text-foreground",
-            copied && "text-status-success-strong",
-          )}
-        >
-          {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setWrap((w) => !w)}
+            aria-label={wrap ? "Disable line wrap" : "Enable line wrap"}
+            aria-pressed={wrap}
+            title={wrap ? "Disable line wrap" : "Wrap long lines"}
+            className={cn(
+              "inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted-foreground/15 hover:text-foreground",
+              wrap && "bg-muted-foreground/15 text-foreground",
+            )}
+          >
+            <WrapText className="h-3 w-3" />
+          </button>
+          <button
+            type="button"
+            onClick={copy}
+            aria-label={copied ? "Copied" : "Copy source"}
+            className={cn(
+              "inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted-foreground/15 hover:text-foreground",
+              copied && "text-status-success-strong",
+            )}
+          >
+            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          </button>
+        </div>
       </div>
 
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
@@ -151,7 +167,15 @@ export function SourceView({
           theme={theme === "dark" ? themes.vsDark : themes.github}
         >
           {({ tokens, getLineProps, getTokenProps }) => (
-            <pre className="m-0 py-2 font-mono text-xs leading-relaxed">
+            <pre
+              className={cn(
+                "m-0 py-2 font-mono text-xs leading-relaxed",
+                // No-wrap: grow to the longest line (w-max) so row highlights/edges
+                // span the full scroll width when scrolled right. min-w-full keeps
+                // them filling the viewport when every line is short.
+                wrap ? "min-w-full" : "w-max min-w-full",
+              )}
+            >
               {tokens.map((line, i) => {
                 const info = lineInfo.get(i);
                 const region = info?.region;
@@ -172,6 +196,7 @@ export function SourceView({
                     onClick={region ? () => onRegionClick(region, selected) : undefined}
                     className={cn(
                       "flex border-l-2 border-l-transparent pr-3 transition-colors",
+                      wrap && "items-start",
                       region && "cursor-pointer",
                       meta?.codeBg,
                       meta?.rail,
@@ -186,7 +211,13 @@ export function SourceView({
                     <span className="w-10 shrink-0 select-none pr-3 text-right text-muted-foreground/40">
                       {i + 1}
                     </span>
-                    <span {...getLineProps({ line })} className="flex-1">
+                    <span
+                      {...getLineProps({ line })}
+                      className={cn(
+                        "flex-1",
+                        wrap ? "min-w-0 whitespace-pre-wrap break-words" : "whitespace-pre",
+                      )}
+                    >
                       {line.map((token, k) => (
                         <span key={k} {...getTokenProps({ token })} />
                       ))}

--- a/ui/src/components/script-runs/source-view.tsx
+++ b/ui/src/components/script-runs/source-view.tsx
@@ -1,0 +1,213 @@
+import { Check, Copy } from "lucide-react";
+import { Highlight, themes } from "prism-react-renderer";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTheme } from "@/hooks/use-theme";
+import { cn } from "@/lib/utils";
+import type { SourceAnchor, StepBlock } from "./source-map";
+import { stepTypeMeta } from "./step-shared";
+
+type Region =
+  | { kind: "step"; blockIndex: number; stepType: string }
+  | { kind: "input" }
+  | { kind: "output" };
+
+interface SourceViewProps {
+  source: string;
+  blocks: StepBlock[];
+  inputAnchor: SourceAnchor | null;
+  outputAnchor: SourceAnchor | null;
+  selectedBlock: number | null;
+  selectedAnchor: "input" | "output" | null;
+  onSelectBlock: (index: number | null) => void;
+  onSelectAnchor: (anchor: "input" | "output" | null) => void;
+  className?: string;
+}
+
+const ANCHOR_STYLE = {
+  input: {
+    bg: "bg-status-info/10",
+    rail: "border-l-status-info",
+    edge: "border-status-info/50",
+    label: "input",
+    tag: "text-status-info-strong",
+  },
+  output: {
+    bg: "bg-status-success/10",
+    rail: "border-l-status-success",
+    edge: "border-status-success/50",
+    label: "output",
+    tag: "text-status-success-strong",
+  },
+} as const;
+
+/**
+ * Read-only source viewer. Overlays each `ctx.step.*` call site (typed colors)
+ * plus the run's input (args signature) and output (return) as clickable,
+ * scrollable regions linked to the timeline sidebar.
+ */
+export function SourceView({
+  source,
+  blocks,
+  inputAnchor,
+  outputAnchor,
+  selectedBlock,
+  selectedAnchor,
+  onSelectBlock,
+  onSelectAnchor,
+  className,
+}: SourceViewProps) {
+  const { theme } = useTheme();
+  const [copied, setCopied] = useState(false);
+
+  const lineInfo = useMemo(() => {
+    const map = new Map<
+      number,
+      { region: Region; isStart: boolean; isEnd: boolean; key: string }
+    >();
+    const put = (startLine: number, endLine: number, region: Region, key: string) => {
+      for (let ln = startLine; ln <= endLine; ln++) {
+        if (!map.has(ln)) {
+          map.set(ln, { region, isStart: ln === startLine, isEnd: ln === endLine, key });
+        }
+      }
+    };
+    blocks.forEach((b, i) => {
+      put(
+        b.startLine,
+        b.endLine,
+        { kind: "step", blockIndex: i, stepType: b.stepType },
+        `step:${i}`,
+      );
+    });
+    if (inputAnchor) put(inputAnchor.startLine, inputAnchor.endLine, { kind: "input" }, "input");
+    if (outputAnchor)
+      put(outputAnchor.startLine, outputAnchor.endLine, { kind: "output" }, "output");
+    return map;
+  }, [blocks, inputAnchor, outputAnchor]);
+
+  const refs = useRef(new Map<string, HTMLDivElement>());
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const key = selectedAnchor ?? (selectedBlock !== null ? `step:${selectedBlock}` : null);
+    if (!key) return;
+    const row = refs.current.get(key);
+    const container = scrollRef.current;
+    if (!row || !container) return;
+    const offset = row.getBoundingClientRect().top - container.getBoundingClientRect().top;
+    const target = container.scrollTop + offset - container.clientHeight * 0.3;
+    container.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
+  }, [selectedBlock, selectedAnchor]);
+
+  const copy = () => {
+    navigator.clipboard.writeText(source).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  const isSelected = (region: Region): boolean => {
+    if (region.kind === "step") return region.blockIndex === selectedBlock;
+    return selectedAnchor === region.kind;
+  };
+
+  const onRegionClick = (region: Region, selected: boolean) => {
+    if (region.kind === "step") onSelectBlock(selected ? null : region.blockIndex);
+    else onSelectAnchor(selected ? null : region.kind);
+  };
+
+  return (
+    <div
+      className={cn("flex min-h-0 flex-col overflow-hidden rounded-lg border bg-card", className)}
+    >
+      <div className="flex items-center justify-between gap-2 border-b px-4 py-2">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold">Source</h2>
+          <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+            typescript
+          </span>
+          {blocks.length > 0 && (
+            <span className="text-xs text-muted-foreground">
+              · {blocks.length} step {blocks.length === 1 ? "block" : "blocks"}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={copy}
+          aria-label={copied ? "Copied" : "Copy source"}
+          className={cn(
+            "inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted-foreground/15 hover:text-foreground",
+            copied && "text-status-success-strong",
+          )}
+        >
+          {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+        </button>
+      </div>
+
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
+        <Highlight
+          code={source.replace(/\n$/, "")}
+          language="tsx"
+          theme={theme === "dark" ? themes.vsDark : themes.github}
+        >
+          {({ tokens, getLineProps, getTokenProps }) => (
+            <pre className="m-0 py-2 font-mono text-xs leading-relaxed">
+              {tokens.map((line, i) => {
+                const info = lineInfo.get(i);
+                const region = info?.region;
+                const selected = region ? isSelected(region) : false;
+                const meta = region?.kind === "step" ? stepTypeMeta(region.stepType) : null;
+                const anchor = region && region.kind !== "step" ? ANCHOR_STYLE[region.kind] : null;
+                const edge = meta?.edge ?? anchor?.edge;
+                return (
+                  <div
+                    key={i}
+                    ref={
+                      info?.isStart
+                        ? (el) => {
+                            if (el) refs.current.set(info.key, el);
+                          }
+                        : undefined
+                    }
+                    onClick={region ? () => onRegionClick(region, selected) : undefined}
+                    className={cn(
+                      "flex border-l-2 border-l-transparent pr-3 transition-colors",
+                      region && "cursor-pointer",
+                      meta?.codeBg,
+                      meta?.rail,
+                      anchor?.bg,
+                      anchor?.rail,
+                      info?.isStart && edge && `border-t ${edge}`,
+                      info?.isEnd && edge && `border-b ${edge}`,
+                      selected && "bg-primary/10 ring-1 ring-inset ring-primary/40",
+                      region && !selected && "hover:brightness-110",
+                    )}
+                  >
+                    <span className="w-10 shrink-0 select-none pr-3 text-right text-muted-foreground/40">
+                      {i + 1}
+                    </span>
+                    <span {...getLineProps({ line })} className="flex-1">
+                      {line.map((token, k) => (
+                        <span key={k} {...getTokenProps({ token })} />
+                      ))}
+                    </span>
+                    {anchor && info?.isStart && (
+                      <span
+                        className={cn(
+                          "ml-2 shrink-0 self-center rounded-sm border border-border px-1 text-[9px] font-semibold uppercase tracking-wider",
+                          anchor.tag,
+                        )}
+                      >
+                        {anchor.label}
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </pre>
+          )}
+        </Highlight>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/script-runs/step-shared.tsx
+++ b/ui/src/components/script-runs/step-shared.tsx
@@ -1,4 +1,5 @@
 import { Bot, Braces, FileCode2, type LucideIcon, Workflow } from "lucide-react";
+import type { ScriptRunJournalEntry } from "@/api/types";
 
 /**
  * Visual + semantic metadata for a journal step type, shared by the source-code
@@ -92,4 +93,31 @@ export function formatDurationMs(ms: number): string {
   if (m < 60) return `${m}m ${rem}s`;
   const h = Math.floor(m / 60);
   return `${h}h ${m % 60}m`;
+}
+
+/** A journal entry laid out on the timeline: measured duration + cumulative offset. */
+export interface TimelineStep {
+  entry: ScriptRunJournalEntry;
+  index: number;
+  offsetMs: number;
+  durationMs: number;
+}
+
+/**
+ * Lay journal steps end-to-end by their measured wall-clock duration, producing a
+ * cumulative offset per step (a sequential cascade). Step `startedAt`/`completedAt`
+ * are only second-precise, so `durationMs` (sub-second, measured in-subprocess) is
+ * the trustworthy timing signal — we reconstruct the waterfall from it.
+ */
+export function buildSteps(journal: ScriptRunJournalEntry[]) {
+  let cursor = 0;
+  let max = 0;
+  const steps: TimelineStep[] = journal.map((entry, index) => {
+    const durationMs = typeof entry.durationMs === "number" ? Math.max(0, entry.durationMs) : 0;
+    const offsetMs = cursor;
+    cursor += durationMs;
+    if (durationMs > max) max = durationMs;
+    return { entry, index, offsetMs, durationMs };
+  });
+  return { steps, totalMs: cursor, maxMs: max, hasTiming: cursor > 0 };
 }

--- a/ui/src/components/script-runs/step-shared.tsx
+++ b/ui/src/components/script-runs/step-shared.tsx
@@ -1,5 +1,6 @@
 import { Bot, Braces, FileCode2, type LucideIcon, Workflow } from "lucide-react";
 import type { ScriptRunJournalEntry } from "@/api/types";
+import { formatDurationMs as formatMs } from "@/lib/format-duration-ms";
 
 /**
  * Visual + semantic metadata for a journal step type, shared by the source-code
@@ -79,21 +80,11 @@ export function stepTypeMeta(stepType: string): StepTypeMeta {
 }
 
 /**
- * Sub-second-aware duration formatter. `formatElapsed`/`formatDuration` floor to
- * whole seconds (120ms → "0s"); the timeline needs millisecond fidelity.
+ * Sub-second-aware duration label for the timeline. Delegates to the canonical
+ * `@/lib/format-duration-ms` in `precise` mode — `formatElapsed`/`formatDuration`
+ * floor to whole seconds (120ms → "0s"), but the timeline needs ms fidelity.
  */
-export function formatDurationMs(ms: number): string {
-  if (!Number.isFinite(ms) || ms < 0) return "—";
-  if (ms < 1000) return `${Math.round(ms)}ms`;
-  const s = ms / 1000;
-  if (s < 10) return `${s.toFixed(2).replace(/0$/, "")}s`;
-  if (s < 60) return `${Math.round(s)}s`;
-  const m = Math.floor(s / 60);
-  const rem = Math.round(s % 60);
-  if (m < 60) return `${m}m ${rem}s`;
-  const h = Math.floor(m / 60);
-  return `${h}h ${m % 60}m`;
-}
+export const formatDurationMs = (ms: number): string => formatMs(ms, { precise: true });
 
 /** A journal entry laid out on the timeline: measured duration + cumulative offset. */
 export interface TimelineStep {

--- a/ui/src/components/script-runs/step-shared.tsx
+++ b/ui/src/components/script-runs/step-shared.tsx
@@ -1,0 +1,95 @@
+import { Bot, Braces, FileCode2, type LucideIcon, Workflow } from "lucide-react";
+
+/**
+ * Visual + semantic metadata for a journal step type, shared by the source-code
+ * view (block highlights) and the timeline panel (rows + bars). Colors come from
+ * the action-* semantic tokens (the same palette workflow nodes use).
+ */
+export interface StepTypeMeta {
+  /** Short human label (e.g. "script"). */
+  name: string;
+  Icon: LucideIcon;
+  /** Text accent — `text-action-script`. */
+  accent: string;
+  /** Solid dot / rail — `bg-action-script`. */
+  dot: string;
+  /** Timeline duration bar — fill + left edge. */
+  bar: string;
+  /** Code-block background tint (subtle). */
+  codeBg: string;
+  /** Left-rail border color (for code blocks / row accents). */
+  rail: string;
+  /** Top/bottom edge border color — delineates one code block from the next. */
+  edge: string;
+  /** Outline badge classes. */
+  badge: string;
+}
+
+const META: Record<string, StepTypeMeta> = {
+  "swarm-script": {
+    name: "script",
+    Icon: FileCode2,
+    accent: "text-action-script",
+    dot: "bg-action-script",
+    bar: "bg-action-script/30 border-l-action-script",
+    codeBg: "bg-action-script/10",
+    rail: "border-l-action-script",
+    edge: "border-action-script/50",
+    badge: "border-action-script/40 text-action-script",
+  },
+  "agent-task": {
+    name: "agent task",
+    Icon: Bot,
+    accent: "text-action-agent-task",
+    dot: "bg-action-agent-task",
+    bar: "bg-action-agent-task/30 border-l-action-agent-task",
+    codeBg: "bg-action-agent-task/10",
+    rail: "border-l-action-agent-task",
+    edge: "border-action-agent-task/50",
+    badge: "border-action-agent-task/40 text-action-agent-task",
+  },
+  "raw-llm": {
+    name: "llm",
+    Icon: Braces,
+    accent: "text-action-raw-llm",
+    dot: "bg-action-raw-llm",
+    bar: "bg-action-raw-llm/30 border-l-action-raw-llm",
+    codeBg: "bg-action-raw-llm/10",
+    rail: "border-l-action-raw-llm",
+    edge: "border-action-raw-llm/50",
+    badge: "border-action-raw-llm/40 text-action-raw-llm",
+  },
+};
+
+export function stepTypeMeta(stepType: string): StepTypeMeta {
+  return (
+    META[stepType] ?? {
+      name: stepType,
+      Icon: Workflow,
+      accent: "text-muted-foreground",
+      dot: "bg-status-neutral",
+      bar: "bg-action-default/30 border-l-action-default",
+      codeBg: "bg-action-default/10",
+      rail: "border-l-action-default",
+      edge: "border-action-default/50",
+      badge: "border-border text-muted-foreground",
+    }
+  );
+}
+
+/**
+ * Sub-second-aware duration formatter. `formatElapsed`/`formatDuration` floor to
+ * whole seconds (120ms → "0s"); the timeline needs millisecond fidelity.
+ */
+export function formatDurationMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const s = ms / 1000;
+  if (s < 10) return `${s.toFixed(2).replace(/0$/, "")}s`;
+  if (s < 60) return `${Math.round(s)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s % 60);
+  if (m < 60) return `${m}m ${rem}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}

--- a/ui/src/components/script-runs/timeline-panel.tsx
+++ b/ui/src/components/script-runs/timeline-panel.tsx
@@ -5,12 +5,10 @@ import type { ScriptRunJournalEntry } from "@/api/types";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn, formatSmartTime } from "@/lib/utils";
 import { JsonView } from "./json-view";
 import type { Selection, StepBlockMapping } from "./source-map";
 import { buildSteps, formatDurationMs, stepTypeMeta, type TimelineStep } from "./step-shared";
-import { WaterfallView } from "./waterfall-view";
 
 function MetaItem({ label, children }: { label: string; children: ReactNode }) {
   return (
@@ -258,7 +256,6 @@ export function TimelinePanel({
 }: TimelinePanelProps) {
   const { steps, totalMs, maxMs, hasTiming } = useMemo(() => buildSteps(journal), [journal]);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
-  const [tab, setTab] = useState<"steps" | "waterfall">("steps");
   const rowRefs = useRef(new Map<string, HTMLDivElement>());
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -318,109 +315,82 @@ export function TimelinePanel({
     <div
       className={cn("flex min-h-0 flex-col overflow-hidden rounded-lg border bg-card", className)}
     >
-      <Tabs
-        value={tab}
-        onValueChange={(v) => setTab(v as "steps" | "waterfall")}
-        className="flex min-h-0 flex-1 flex-col gap-0"
-      >
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b px-4 py-2">
-          <h2 className="text-sm font-semibold">Timeline</h2>
-          {hasTiming && (
-            <span className="font-mono text-xs tabular-nums text-muted-foreground">
-              {formatDurationMs(totalMs)} total
-            </span>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b px-4 py-2">
+        <h2 className="text-sm font-semibold">Timeline</h2>
+        {hasTiming && (
+          <span className="font-mono text-xs tabular-nums text-muted-foreground">
+            {formatDurationMs(totalMs)} total
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-1">
+          {selection && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onSelect(null)}
+              className="h-7 text-xs"
+            >
+              Clear
+            </Button>
           )}
-          <div className="ml-auto flex items-center gap-2">
-            <TabsList variant="line">
-              <TabsTrigger value="steps">Steps</TabsTrigger>
-              <TabsTrigger value="waterfall">Waterfall</TabsTrigger>
-            </TabsList>
-            {selection && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => onSelect(null)}
-                className="h-7 text-xs"
-              >
-                Clear
-              </Button>
-            )}
-            {tab === "steps" && (
-              <Button variant="ghost" size="sm" onClick={toggleAll} className="h-7 text-xs">
-                {allExpanded ? "Collapse all" : "Expand all"}
-              </Button>
-            )}
-          </div>
+          <Button variant="ghost" size="sm" onClick={toggleAll} className="h-7 text-xs">
+            {allExpanded ? "Collapse all" : "Expand all"}
+          </Button>
         </div>
+      </div>
 
-        <TabsContent value="steps" className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
-            <IoRow
-              kind="input"
-              data={runArgs}
-              expanded={expanded.has("input")}
-              selected={selection?.kind === "input"}
-              onActivate={() => activateIo("input")}
-              rowRef={(el) => {
-                if (el) rowRefs.current.set("input", el);
-                else rowRefs.current.delete("input");
-              }}
-            />
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
+        <IoRow
+          kind="input"
+          data={runArgs}
+          expanded={expanded.has("input")}
+          selected={selection?.kind === "input"}
+          onActivate={() => activateIo("input")}
+          rowRef={(el) => {
+            if (el) rowRefs.current.set("input", el);
+            else rowRefs.current.delete("input");
+          }}
+        />
 
-            {steps.map((step) => (
-              <TimelineRow
-                key={step.entry.id}
-                step={step}
-                hasTiming={hasTiming}
-                maxMs={maxMs}
-                expanded={expanded.has(step.entry.id)}
-                selected={selection?.kind === "step" && selection.stepId === step.entry.id}
-                blockActive={
-                  selectedBlock !== undefined &&
-                  mapping.stepToBlock[step.entry.id] === selectedBlock
-                }
-                onActivate={() => activateStep(step.entry.id)}
-                rowRef={(el) => {
-                  if (el) rowRefs.current.set(step.entry.id, el);
-                  else rowRefs.current.delete(step.entry.id);
-                }}
-              />
-            ))}
-
-            {hasOutput && (
-              <IoRow
-                kind="output"
-                data={runOutput}
-                expanded={expanded.has("output")}
-                selected={selection?.kind === "output"}
-                onActivate={() => activateIo("output")}
-                rowRef={(el) => {
-                  if (el) rowRefs.current.set("output", el);
-                  else rowRefs.current.delete("output");
-                }}
-              />
-            )}
-          </div>
-
-          {!hasTiming && journal.length > 0 && (
-            <div className="border-t px-4 py-2 text-[11px] text-muted-foreground">
-              Per-step timing wasn&rsquo;t recorded for this run.
-            </div>
-          )}
-        </TabsContent>
-
-        <TabsContent value="waterfall" className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          <WaterfallView
-            steps={steps}
-            totalMs={totalMs}
+        {steps.map((step) => (
+          <TimelineRow
+            key={step.entry.id}
+            step={step}
             hasTiming={hasTiming}
-            mapping={mapping}
-            selection={selection}
-            onSelect={onSelect}
-            hasOutput={hasOutput}
+            maxMs={maxMs}
+            expanded={expanded.has(step.entry.id)}
+            selected={selection?.kind === "step" && selection.stepId === step.entry.id}
+            blockActive={
+              selectedBlock !== undefined && mapping.stepToBlock[step.entry.id] === selectedBlock
+            }
+            onActivate={() => activateStep(step.entry.id)}
+            rowRef={(el) => {
+              if (el) rowRefs.current.set(step.entry.id, el);
+              else rowRefs.current.delete(step.entry.id);
+            }}
           />
-        </TabsContent>
-      </Tabs>
+        ))}
+
+        {hasOutput && (
+          <IoRow
+            kind="output"
+            data={runOutput}
+            expanded={expanded.has("output")}
+            selected={selection?.kind === "output"}
+            onActivate={() => activateIo("output")}
+            rowRef={(el) => {
+              if (el) rowRefs.current.set("output", el);
+              else rowRefs.current.delete("output");
+            }}
+          />
+        )}
+      </div>
+
+      {!hasTiming && journal.length > 0 && (
+        <div className="border-t px-4 py-2 text-[11px] text-muted-foreground">
+          Per-step timing wasn&rsquo;t recorded for this run.
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/components/script-runs/timeline-panel.tsx
+++ b/ui/src/components/script-runs/timeline-panel.tsx
@@ -5,30 +5,12 @@ import type { ScriptRunJournalEntry } from "@/api/types";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn, formatSmartTime } from "@/lib/utils";
 import { JsonView } from "./json-view";
 import type { Selection, StepBlockMapping } from "./source-map";
-import { formatDurationMs, stepTypeMeta } from "./step-shared";
-
-interface TimelineStep {
-  entry: ScriptRunJournalEntry;
-  index: number;
-  offsetMs: number;
-  durationMs: number;
-}
-
-function buildSteps(journal: ScriptRunJournalEntry[]) {
-  let cursor = 0;
-  let max = 0;
-  const steps: TimelineStep[] = journal.map((entry, index) => {
-    const durationMs = typeof entry.durationMs === "number" ? Math.max(0, entry.durationMs) : 0;
-    const offsetMs = cursor;
-    cursor += durationMs;
-    if (durationMs > max) max = durationMs;
-    return { entry, index, offsetMs, durationMs };
-  });
-  return { steps, totalMs: cursor, maxMs: max, hasTiming: cursor > 0 };
-}
+import { buildSteps, formatDurationMs, stepTypeMeta, type TimelineStep } from "./step-shared";
+import { WaterfallView } from "./waterfall-view";
 
 function MetaItem({ label, children }: { label: string; children: ReactNode }) {
   return (
@@ -276,6 +258,7 @@ export function TimelinePanel({
 }: TimelinePanelProps) {
   const { steps, totalMs, maxMs, hasTiming } = useMemo(() => buildSteps(journal), [journal]);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const [tab, setTab] = useState<"steps" | "waterfall">("steps");
   const rowRefs = useRef(new Map<string, HTMLDivElement>());
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -335,82 +318,109 @@ export function TimelinePanel({
     <div
       className={cn("flex min-h-0 flex-col overflow-hidden rounded-lg border bg-card", className)}
     >
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b px-4 py-2">
-        <h2 className="text-sm font-semibold">Timeline</h2>
-        {hasTiming && (
-          <span className="font-mono text-xs tabular-nums text-muted-foreground">
-            {formatDurationMs(totalMs)} total
-          </span>
-        )}
-        <div className="ml-auto flex items-center gap-1">
-          {selection && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => onSelect(null)}
-              className="h-7 text-xs"
-            >
-              Clear
-            </Button>
+      <Tabs
+        value={tab}
+        onValueChange={(v) => setTab(v as "steps" | "waterfall")}
+        className="flex min-h-0 flex-1 flex-col gap-0"
+      >
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b px-4 py-2">
+          <h2 className="text-sm font-semibold">Timeline</h2>
+          {hasTiming && (
+            <span className="font-mono text-xs tabular-nums text-muted-foreground">
+              {formatDurationMs(totalMs)} total
+            </span>
           )}
-          <Button variant="ghost" size="sm" onClick={toggleAll} className="h-7 text-xs">
-            {allExpanded ? "Collapse all" : "Expand all"}
-          </Button>
+          <div className="ml-auto flex items-center gap-2">
+            <TabsList variant="line">
+              <TabsTrigger value="steps">Steps</TabsTrigger>
+              <TabsTrigger value="waterfall">Waterfall</TabsTrigger>
+            </TabsList>
+            {selection && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => onSelect(null)}
+                className="h-7 text-xs"
+              >
+                Clear
+              </Button>
+            )}
+            {tab === "steps" && (
+              <Button variant="ghost" size="sm" onClick={toggleAll} className="h-7 text-xs">
+                {allExpanded ? "Collapse all" : "Expand all"}
+              </Button>
+            )}
+          </div>
         </div>
-      </div>
 
-      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
-        <IoRow
-          kind="input"
-          data={runArgs}
-          expanded={expanded.has("input")}
-          selected={selection?.kind === "input"}
-          onActivate={() => activateIo("input")}
-          rowRef={(el) => {
-            if (el) rowRefs.current.set("input", el);
-            else rowRefs.current.delete("input");
-          }}
-        />
+        <TabsContent value="steps" className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
+            <IoRow
+              kind="input"
+              data={runArgs}
+              expanded={expanded.has("input")}
+              selected={selection?.kind === "input"}
+              onActivate={() => activateIo("input")}
+              rowRef={(el) => {
+                if (el) rowRefs.current.set("input", el);
+                else rowRefs.current.delete("input");
+              }}
+            />
 
-        {steps.map((step) => (
-          <TimelineRow
-            key={step.entry.id}
-            step={step}
+            {steps.map((step) => (
+              <TimelineRow
+                key={step.entry.id}
+                step={step}
+                hasTiming={hasTiming}
+                maxMs={maxMs}
+                expanded={expanded.has(step.entry.id)}
+                selected={selection?.kind === "step" && selection.stepId === step.entry.id}
+                blockActive={
+                  selectedBlock !== undefined &&
+                  mapping.stepToBlock[step.entry.id] === selectedBlock
+                }
+                onActivate={() => activateStep(step.entry.id)}
+                rowRef={(el) => {
+                  if (el) rowRefs.current.set(step.entry.id, el);
+                  else rowRefs.current.delete(step.entry.id);
+                }}
+              />
+            ))}
+
+            {hasOutput && (
+              <IoRow
+                kind="output"
+                data={runOutput}
+                expanded={expanded.has("output")}
+                selected={selection?.kind === "output"}
+                onActivate={() => activateIo("output")}
+                rowRef={(el) => {
+                  if (el) rowRefs.current.set("output", el);
+                  else rowRefs.current.delete("output");
+                }}
+              />
+            )}
+          </div>
+
+          {!hasTiming && journal.length > 0 && (
+            <div className="border-t px-4 py-2 text-[11px] text-muted-foreground">
+              Per-step timing wasn&rsquo;t recorded for this run.
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="waterfall" className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <WaterfallView
+            steps={steps}
+            totalMs={totalMs}
             hasTiming={hasTiming}
-            maxMs={maxMs}
-            expanded={expanded.has(step.entry.id)}
-            selected={selection?.kind === "step" && selection.stepId === step.entry.id}
-            blockActive={
-              selectedBlock !== undefined && mapping.stepToBlock[step.entry.id] === selectedBlock
-            }
-            onActivate={() => activateStep(step.entry.id)}
-            rowRef={(el) => {
-              if (el) rowRefs.current.set(step.entry.id, el);
-              else rowRefs.current.delete(step.entry.id);
-            }}
+            mapping={mapping}
+            selection={selection}
+            onSelect={onSelect}
+            hasOutput={hasOutput}
           />
-        ))}
-
-        {hasOutput && (
-          <IoRow
-            kind="output"
-            data={runOutput}
-            expanded={expanded.has("output")}
-            selected={selection?.kind === "output"}
-            onActivate={() => activateIo("output")}
-            rowRef={(el) => {
-              if (el) rowRefs.current.set("output", el);
-              else rowRefs.current.delete("output");
-            }}
-          />
-        )}
-      </div>
-
-      {!hasTiming && journal.length > 0 && (
-        <div className="border-t px-4 py-2 text-[11px] text-muted-foreground">
-          Per-step timing wasn&rsquo;t recorded for this run.
-        </div>
-      )}
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/ui/src/components/script-runs/timeline-panel.tsx
+++ b/ui/src/components/script-runs/timeline-panel.tsx
@@ -1,0 +1,416 @@
+import { ChevronDown, ChevronRight, CircleAlert, ExternalLink, LogIn, LogOut } from "lucide-react";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import type { ScriptRunJournalEntry } from "@/api/types";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn, formatSmartTime } from "@/lib/utils";
+import { JsonView } from "./json-view";
+import type { Selection, StepBlockMapping } from "./source-map";
+import { formatDurationMs, stepTypeMeta } from "./step-shared";
+
+interface TimelineStep {
+  entry: ScriptRunJournalEntry;
+  index: number;
+  offsetMs: number;
+  durationMs: number;
+}
+
+function buildSteps(journal: ScriptRunJournalEntry[]) {
+  let cursor = 0;
+  let max = 0;
+  const steps: TimelineStep[] = journal.map((entry, index) => {
+    const durationMs = typeof entry.durationMs === "number" ? Math.max(0, entry.durationMs) : 0;
+    const offsetMs = cursor;
+    cursor += durationMs;
+    if (durationMs > max) max = durationMs;
+    return { entry, index, offsetMs, durationMs };
+  });
+  return { steps, totalMs: cursor, maxMs: max, hasTiming: cursor > 0 };
+}
+
+function MetaItem({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </span>
+      <span className="text-xs">{children}</span>
+    </div>
+  );
+}
+
+function ValueBlock({ label, data }: { label: string; data: unknown }) {
+  if (data === null || data === undefined) {
+    return <span className="text-xs text-muted-foreground">No {label.toLowerCase()}.</span>;
+  }
+  return <JsonView data={data} defaultExpandDepth={1} maxHeight="280px" />;
+}
+
+/** A run-level Input (args) or Output (return) entry, bracketing the step list. */
+function IoRow({
+  kind,
+  data,
+  expanded,
+  selected,
+  onActivate,
+  rowRef,
+}: {
+  kind: "input" | "output";
+  data: unknown;
+  expanded: boolean;
+  selected: boolean;
+  onActivate: () => void;
+  rowRef: (el: HTMLDivElement | null) => void;
+}) {
+  const isInput = kind === "input";
+  const accent = isInput ? "text-status-info-strong" : "text-status-success-strong";
+  const railSel = isInput ? "border-l-status-info" : "border-l-status-success";
+  const Icon = isInput ? LogIn : LogOut;
+  return (
+    <div
+      ref={rowRef}
+      className={cn(
+        "border-b border-l-2 border-l-transparent",
+        selected && `${railSel} bg-muted/40`,
+      )}
+    >
+      <button
+        type="button"
+        onClick={onActivate}
+        className="w-full px-3 py-2 text-left transition-colors hover:bg-muted/40"
+      >
+        <div className="flex items-center gap-2">
+          {expanded ? (
+            <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <Icon className={cn("h-3.5 w-3.5 shrink-0", accent)} />
+          <span className="text-xs font-semibold">{isInput ? "Input" : "Output"}</span>
+          <Badge variant="outline" size="tag" className="ml-auto">
+            {isInput ? "args" : "return"}
+          </Badge>
+        </div>
+      </button>
+      {expanded && (
+        <div className="border-t bg-surface/40 px-3 py-3">
+          <ValueBlock label={isInput ? "args" : "output"} data={data} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StepDetails({ step, hasTiming }: { step: TimelineStep; hasTiming: boolean }) {
+  const { entry, offsetMs, durationMs } = step;
+  const failed = entry.status === "failed";
+  const taskId =
+    entry.stepType === "agent-task" &&
+    entry.result &&
+    typeof entry.result === "object" &&
+    typeof (entry.result as { taskId?: unknown }).taskId === "string"
+      ? (entry.result as { taskId: string }).taskId
+      : null;
+
+  return (
+    <div className="space-y-3 border-t bg-surface/40 px-3 py-3">
+      <div className="flex flex-wrap gap-x-6 gap-y-2">
+        <MetaItem label="Status">
+          <span className={failed ? "text-status-error-strong" : "text-status-success-strong"}>
+            {entry.status}
+          </span>
+        </MetaItem>
+        {hasTiming && (
+          <MetaItem label="Offset">
+            <span className="font-mono tabular-nums">+{formatDurationMs(offsetMs)}</span>
+          </MetaItem>
+        )}
+        <MetaItem label="Duration">
+          <span className="font-mono tabular-nums">
+            {typeof entry.durationMs === "number" ? formatDurationMs(durationMs) : "—"}
+          </span>
+        </MetaItem>
+        <MetaItem label="Recorded">{formatSmartTime(entry.startedAt)}</MetaItem>
+      </div>
+
+      {entry.error && (
+        <Alert variant="destructive">
+          <AlertDescription className="max-h-[200px] overflow-y-auto whitespace-pre-wrap font-mono text-xs">
+            {entry.error}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {entry.config && Object.keys(entry.config).length > 0 && (
+        <div className="space-y-1.5">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Input
+          </span>
+          <ValueBlock label="input" data={entry.config} />
+        </div>
+      )}
+
+      {entry.result !== undefined && (
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Output
+            </span>
+            {taskId && (
+              <Link
+                to={`/tasks/${taskId}`}
+                className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+              >
+                View task <ExternalLink className="h-3 w-3" />
+              </Link>
+            )}
+          </div>
+          <ValueBlock label="output" data={entry.result} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TimelineRow({
+  step,
+  hasTiming,
+  maxMs,
+  expanded,
+  selected,
+  blockActive,
+  onActivate,
+  rowRef,
+}: {
+  step: TimelineStep;
+  hasTiming: boolean;
+  maxMs: number;
+  expanded: boolean;
+  selected: boolean;
+  blockActive: boolean;
+  onActivate: () => void;
+  rowRef: (el: HTMLDivElement | null) => void;
+}) {
+  const { entry, index, durationMs } = step;
+  const meta = stepTypeMeta(entry.stepType);
+  const failed = entry.status === "failed";
+  const Icon = meta.Icon;
+  const widthPct = maxMs > 0 ? Math.max((durationMs / maxMs) * 100, 2) : 0;
+
+  return (
+    <div
+      ref={rowRef}
+      className={cn(
+        "border-b border-l-2 border-l-transparent last:border-b-0",
+        selected && "border-l-primary bg-primary/5",
+        !selected && blockActive && "border-l-border bg-muted/30",
+      )}
+    >
+      <button
+        type="button"
+        onClick={onActivate}
+        className="w-full px-3 py-2 text-left transition-colors hover:bg-muted/40"
+      >
+        <div className="flex items-center gap-2">
+          {expanded ? (
+            <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <span className="w-4 shrink-0 text-right font-mono text-[10px] text-muted-foreground/70">
+            {index + 1}
+          </span>
+          <Icon
+            className={cn("h-3.5 w-3.5 shrink-0", failed ? "text-status-error" : meta.accent)}
+          />
+          <span className="truncate font-mono text-xs font-medium">{entry.stepKey}</span>
+          {failed && <CircleAlert className="h-3.5 w-3.5 shrink-0 text-status-error" />}
+          <div className="ml-auto flex shrink-0 items-center gap-2">
+            {hasTiming && (
+              <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+                {formatDurationMs(durationMs)}
+              </span>
+            )}
+            <Badge variant="outline" size="tag" className={meta.badge}>
+              {meta.name}
+            </Badge>
+          </div>
+        </div>
+        {hasTiming && (
+          <div className="mt-1.5 h-1 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className={cn("h-full rounded-full", failed ? "bg-status-error" : meta.dot)}
+              // inline-style: bar width proportional to the slowest step
+              style={{ width: `${widthPct}%` }}
+            />
+          </div>
+        )}
+      </button>
+      {expanded && <StepDetails step={step} hasTiming={hasTiming} />}
+    </div>
+  );
+}
+
+interface TimelinePanelProps {
+  journal: ScriptRunJournalEntry[];
+  mapping: StepBlockMapping;
+  runArgs: unknown;
+  runOutput: unknown;
+  hasOutput: boolean;
+  selection: Selection;
+  onSelect: (sel: Selection) => void;
+  className?: string;
+}
+
+export function TimelinePanel({
+  journal,
+  mapping,
+  runArgs,
+  runOutput,
+  hasOutput,
+  selection,
+  onSelect,
+  className,
+}: TimelinePanelProps) {
+  const { steps, totalMs, maxMs, hasTiming } = useMemo(() => buildSteps(journal), [journal]);
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const rowRefs = useRef(new Map<string, HTMLDivElement>());
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const selectionKey: string | null =
+    selection?.kind === "step" ? selection.stepId : (selection?.kind ?? null);
+  const selectedBlock =
+    selection?.kind === "step" ? mapping.stepToBlock[selection.stepId] : undefined;
+
+  // When something becomes selected (e.g. by clicking its code block), reveal it
+  // and scroll it to the top of the panel — without scrolling the whole page.
+  useEffect(() => {
+    if (!selectionKey) return;
+    setExpanded((prev) => (prev.has(selectionKey) ? prev : new Set(prev).add(selectionKey)));
+    const row = rowRefs.current.get(selectionKey);
+    const container = scrollRef.current;
+    if (!row || !container) return;
+    const offset = row.getBoundingClientRect().top - container.getBoundingClientRect().top;
+    container.scrollTo({ top: Math.max(0, container.scrollTop + offset - 12), behavior: "smooth" });
+  }, [selectionKey]);
+
+  const allKeys = useMemo(() => {
+    const keys = journal.map((e) => e.id);
+    keys.unshift("input");
+    if (hasOutput) keys.push("output");
+    return keys;
+  }, [journal, hasOutput]);
+  const allExpanded = expanded.size >= allKeys.length && allKeys.length > 0;
+  const toggleAll = () => setExpanded(allExpanded ? new Set() : new Set(allKeys));
+
+  const toggleExpand = (key: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+
+  const activateStep = (id: string) => {
+    if (selection?.kind === "step" && selection.stepId === id) {
+      onSelect(null);
+      toggleExpand(id);
+    } else {
+      onSelect({ kind: "step", stepId: id });
+    }
+  };
+
+  const activateIo = (kind: "input" | "output") => {
+    if (selection?.kind === kind) {
+      onSelect(null);
+      toggleExpand(kind);
+    } else {
+      onSelect({ kind });
+    }
+  };
+
+  return (
+    <div
+      className={cn("flex min-h-0 flex-col overflow-hidden rounded-lg border bg-card", className)}
+    >
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b px-4 py-2">
+        <h2 className="text-sm font-semibold">Timeline</h2>
+        {hasTiming && (
+          <span className="font-mono text-xs tabular-nums text-muted-foreground">
+            {formatDurationMs(totalMs)} total
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-1">
+          {selection && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onSelect(null)}
+              className="h-7 text-xs"
+            >
+              Clear
+            </Button>
+          )}
+          <Button variant="ghost" size="sm" onClick={toggleAll} className="h-7 text-xs">
+            {allExpanded ? "Collapse all" : "Expand all"}
+          </Button>
+        </div>
+      </div>
+
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
+        <IoRow
+          kind="input"
+          data={runArgs}
+          expanded={expanded.has("input")}
+          selected={selection?.kind === "input"}
+          onActivate={() => activateIo("input")}
+          rowRef={(el) => {
+            if (el) rowRefs.current.set("input", el);
+            else rowRefs.current.delete("input");
+          }}
+        />
+
+        {steps.map((step) => (
+          <TimelineRow
+            key={step.entry.id}
+            step={step}
+            hasTiming={hasTiming}
+            maxMs={maxMs}
+            expanded={expanded.has(step.entry.id)}
+            selected={selection?.kind === "step" && selection.stepId === step.entry.id}
+            blockActive={
+              selectedBlock !== undefined && mapping.stepToBlock[step.entry.id] === selectedBlock
+            }
+            onActivate={() => activateStep(step.entry.id)}
+            rowRef={(el) => {
+              if (el) rowRefs.current.set(step.entry.id, el);
+              else rowRefs.current.delete(step.entry.id);
+            }}
+          />
+        ))}
+
+        {hasOutput && (
+          <IoRow
+            kind="output"
+            data={runOutput}
+            expanded={expanded.has("output")}
+            selected={selection?.kind === "output"}
+            onActivate={() => activateIo("output")}
+            rowRef={(el) => {
+              if (el) rowRefs.current.set("output", el);
+              else rowRefs.current.delete("output");
+            }}
+          />
+        )}
+      </div>
+
+      {!hasTiming && journal.length > 0 && (
+        <div className="border-t px-4 py-2 text-[11px] text-muted-foreground">
+          Per-step timing wasn&rsquo;t recorded for this run.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/script-runs/waterfall-view.tsx
+++ b/ui/src/components/script-runs/waterfall-view.tsx
@@ -1,0 +1,240 @@
+import { LogIn, LogOut } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { Selection, StepBlockMapping } from "./source-map";
+import { formatDurationMs, stepTypeMeta, type TimelineStep } from "./step-shared";
+
+// Shared column widths so the ruler ticks line up with the bar track across rows.
+const NAME_COL = "w-44 shrink-0";
+const DUR_COL = "w-14 shrink-0";
+
+/** Time axis above the bars — labels at start / midpoint / end of the run. */
+function Ruler({ totalMs }: { totalMs: number }) {
+  return (
+    <div className="flex items-center border-b px-3 py-1">
+      <div className={NAME_COL} />
+      <div className="relative h-3 flex-1">
+        <span className="absolute left-0 font-mono text-[10px] tabular-nums text-muted-foreground/70">
+          0
+        </span>
+        <span className="absolute left-1/2 -translate-x-1/2 font-mono text-[10px] tabular-nums text-muted-foreground/70">
+          {formatDurationMs(totalMs / 2)}
+        </span>
+        <span className="absolute right-0 font-mono text-[10px] tabular-nums text-muted-foreground/70">
+          {formatDurationMs(totalMs)}
+        </span>
+      </div>
+      <div className={DUR_COL} />
+    </div>
+  );
+}
+
+function GridLines() {
+  return (
+    <>
+      {[25, 50, 75].map((p) => (
+        <div
+          key={p}
+          className="absolute inset-y-0 w-px bg-border/40"
+          // inline-style: gridline at a fixed fraction of the track width
+          style={{ left: `${p}%` }}
+        />
+      ))}
+    </>
+  );
+}
+
+function WaterfallRow({
+  step,
+  totalMs,
+  selected,
+  blockActive,
+  onActivate,
+}: {
+  step: TimelineStep;
+  totalMs: number;
+  selected: boolean;
+  blockActive: boolean;
+  onActivate: () => void;
+}) {
+  const { entry, index, offsetMs, durationMs } = step;
+  const meta = stepTypeMeta(entry.stepType);
+  const failed = entry.status === "failed";
+  const Icon = meta.Icon;
+  const leftPct = totalMs > 0 ? (offsetMs / totalMs) * 100 : 0;
+  const widthPct = totalMs > 0 ? Math.min(Math.max((durationMs / totalMs) * 100, 1.5), 100) : 0;
+
+  return (
+    <button
+      type="button"
+      onClick={onActivate}
+      className={cn(
+        "flex w-full items-center gap-2 border-l-2 border-l-transparent px-3 py-1.5 text-left transition-colors hover:bg-muted/40",
+        selected && "border-l-primary bg-primary/5",
+        !selected && blockActive && "border-l-border bg-muted/30",
+      )}
+    >
+      <div className={cn("flex items-center gap-2", NAME_COL)}>
+        <span className="w-4 shrink-0 text-right font-mono text-[10px] text-muted-foreground/70">
+          {index + 1}
+        </span>
+        <Icon className={cn("h-3.5 w-3.5 shrink-0", failed ? "text-status-error" : meta.accent)} />
+        <span className="truncate font-mono text-xs">{entry.stepKey}</span>
+      </div>
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="relative h-4 flex-1 overflow-hidden rounded bg-muted/30">
+            <GridLines />
+            <div
+              className={cn(
+                "absolute inset-y-[3px] rounded-sm border-l-2",
+                failed ? "border-l-status-error bg-status-error/30" : meta.bar,
+              )}
+              // inline-style: bar offset by cumulative start, width by measured duration
+              style={{ left: `${leftPct}%`, width: `${widthPct}%` }}
+            />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="space-y-0.5">
+          <div className="font-medium">{entry.stepKey}</div>
+          <div className="text-muted-foreground">
+            {meta.name} · {entry.status}
+          </div>
+          <div className="font-mono text-[11px] tabular-nums">
+            starts +{formatDurationMs(offsetMs)} · runs {formatDurationMs(durationMs)}
+          </div>
+        </TooltipContent>
+      </Tooltip>
+
+      <span className="w-14 shrink-0 text-right font-mono text-[11px] tabular-nums text-muted-foreground">
+        {formatDurationMs(durationMs)}
+      </span>
+    </button>
+  );
+}
+
+/** Run boundary marker (Input at t=0, Output at t=end) — a diamond on the track. */
+function BoundaryRow({
+  kind,
+  selected,
+  onActivate,
+}: {
+  kind: "input" | "output";
+  selected: boolean;
+  onActivate: () => void;
+}) {
+  const isInput = kind === "input";
+  const Icon = isInput ? LogIn : LogOut;
+  return (
+    <button
+      type="button"
+      onClick={onActivate}
+      className={cn(
+        "flex w-full items-center gap-2 border-l-2 border-l-transparent px-3 py-1.5 text-left transition-colors hover:bg-muted/40",
+        selected &&
+          (isInput ? "border-l-status-info bg-muted/40" : "border-l-status-success bg-muted/40"),
+      )}
+    >
+      <div className={cn("flex items-center gap-2", NAME_COL)}>
+        <span className="w-4 shrink-0" />
+        <Icon
+          className={cn(
+            "h-3.5 w-3.5 shrink-0",
+            isInput ? "text-status-info-strong" : "text-status-success-strong",
+          )}
+        />
+        <span className="text-xs font-semibold">{isInput ? "Input" : "Output"}</span>
+      </div>
+      <div className="relative h-4 flex-1">
+        <div
+          className={cn(
+            "absolute top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 rotate-45 rounded-[2px]",
+            isInput ? "bg-status-info" : "bg-status-success",
+          )}
+          // inline-style: marker pinned to the run's start (0%) or end (100%)
+          style={{ left: isInput ? "0%" : "100%" }}
+        />
+      </div>
+      <span className="w-14 shrink-0 text-right font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+        {isInput ? "args" : "return"}
+      </span>
+    </button>
+  );
+}
+
+interface WaterfallViewProps {
+  steps: TimelineStep[];
+  totalMs: number;
+  hasTiming: boolean;
+  mapping: StepBlockMapping;
+  selection: Selection;
+  onSelect: (sel: Selection) => void;
+  hasOutput: boolean;
+}
+
+export function WaterfallView({
+  steps,
+  totalMs,
+  hasTiming,
+  mapping,
+  selection,
+  onSelect,
+  hasOutput,
+}: WaterfallViewProps) {
+  if (steps.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-8 text-center text-sm text-muted-foreground">
+        No steps to chart — this run executed in a single call.
+      </div>
+    );
+  }
+  if (!hasTiming) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-8 text-center text-sm text-muted-foreground">
+        Per-step timing wasn&rsquo;t recorded for this run.
+      </div>
+    );
+  }
+
+  const selectedBlock =
+    selection?.kind === "step" ? mapping.stepToBlock[selection.stepId] : undefined;
+  const activateStep = (id: string) =>
+    onSelect(
+      selection?.kind === "step" && selection.stepId === id ? null : { kind: "step", stepId: id },
+    );
+  const activateIo = (kind: "input" | "output") =>
+    onSelect(selection?.kind === kind ? null : { kind });
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <Ruler totalMs={totalMs} />
+      <div className="min-h-0 flex-1 overflow-auto py-1">
+        <BoundaryRow
+          kind="input"
+          selected={selection?.kind === "input"}
+          onActivate={() => activateIo("input")}
+        />
+        {steps.map((step) => (
+          <WaterfallRow
+            key={step.entry.id}
+            step={step}
+            totalMs={totalMs}
+            selected={selection?.kind === "step" && selection.stepId === step.entry.id}
+            blockActive={
+              selectedBlock !== undefined && mapping.stepToBlock[step.entry.id] === selectedBlock
+            }
+            onActivate={() => activateStep(step.entry.id)}
+          />
+        ))}
+        {hasOutput && (
+          <BoundaryRow
+            kind="output"
+            selected={selection?.kind === "output"}
+            onActivate={() => activateIo("output")}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/shared/charts/nivo-charts.tsx
+++ b/ui/src/components/shared/charts/nivo-charts.tsx
@@ -2,7 +2,17 @@ import { ResponsiveBar } from "@nivo/bar";
 import { ResponsiveLine } from "@nivo/line";
 import { useMemo } from "react";
 
-const CHART_COLORS = ["#2563eb", "#16a34a", "#dc2626", "#9333ea", "#ea580c", "#0891b2"];
+// Categorical palette sourced from semantic design tokens (theme-aware via the
+// CSS custom properties; nivo applies these strings as SVG `fill`). Keeps the
+// `check:tokens` gate happy — no raw hex literals in src/.
+const CHART_COLORS = [
+  "var(--color-action-default)",
+  "var(--color-status-success)",
+  "var(--color-status-error)",
+  "var(--color-action-delegate-to-agent)",
+  "var(--color-status-warning)",
+  "var(--color-action-script)",
+];
 
 export interface CategoricalChartProps {
   data: Record<string, unknown>[];

--- a/ui/src/components/shared/script-run-kind-badge.tsx
+++ b/ui/src/components/shared/script-run-kind-badge.tsx
@@ -1,0 +1,23 @@
+import type { ScriptRunKind } from "@/api/types";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+const KIND_CONFIG: Record<ScriptRunKind, { label: string; className: string }> = {
+  workflow: { label: "WORKFLOW", className: "border-action-script/50 text-action-script" },
+  inline: { label: "INLINE", className: "border-status-info/30 text-status-info-strong" },
+};
+
+export function ScriptRunKindBadge({
+  kind,
+  className,
+}: {
+  kind: ScriptRunKind;
+  className?: string;
+}) {
+  const config = KIND_CONFIG[kind] ?? KIND_CONFIG.workflow;
+  return (
+    <Badge variant="outline" size="tag" className={cn(config.className, className)}>
+      {config.label}
+    </Badge>
+  );
+}

--- a/ui/src/lib/format-duration-ms.ts
+++ b/ui/src/lib/format-duration-ms.ts
@@ -1,15 +1,27 @@
-// Format an integer millisecond duration as the most compact human-readable
-// label. Used by tasks/[id] cost panel:
-//   < 1000ms  → "423ms"
-//   < 60s     → "42s"
-//   < 60m     → "5m 12s"
-//   ≥ 60m     → "1h 5m"
+// Single source of truth for "compact ms duration" labels. Two call sites:
+//   • tasks/[id] cost panel — default mode, whole-second rounding:
+//       < 1000ms → "423ms" · < 60s → "42s" · < 60m → "5m 12s" · ≥ 60m → "1h 5m"
+//   • script-runs timeline (via step-shared) — `precise: true`, sub-second
+//     fidelity so short steps don't all read "0s":
+//       < 1000ms → "423ms" · < 10s → "2.31s" · < 60s → "42s" · then m/h
 //
 // Distinct from `formatDuration(ms)` in `lib/utils.ts` which always rounds to
-// whole seconds (no `Xms` form). Kept separate so the two existing call sites
-// don't accidentally diverge.
+// whole seconds (no `Xms` form). Keeping both modes here means the two call
+// sites can't drift apart with subtly different rounding.
 
-export function formatDurationMs(ms: number): string {
+export function formatDurationMs(ms: number, opts?: { precise?: boolean }): string {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  if (opts?.precise) {
+    if (ms < 1000) return `${Math.round(ms)}ms`;
+    const s = ms / 1000;
+    if (s < 10) return `${s.toFixed(2).replace(/0$/, "")}s`;
+    if (s < 60) return `${Math.round(s)}s`;
+    const m = Math.floor(s / 60);
+    const rem = Math.round(s % 60);
+    if (m < 60) return `${m}m ${rem}s`;
+    const h = Math.floor(m / 60);
+    return `${h}h ${m % 60}m`;
+  }
   if (ms < 1000) return `${ms}ms`;
   const seconds = Math.floor(ms / 1000);
   if (seconds < 60) return `${seconds}s`;

--- a/ui/src/pages/script-runs/[id]/page.tsx
+++ b/ui/src/pages/script-runs/[id]/page.tsx
@@ -12,6 +12,7 @@ import {
 import { SourceView } from "@/components/script-runs/source-view";
 import { TimelinePanel } from "@/components/script-runs/timeline-panel";
 import { AgentLink } from "@/components/shared/agent-link";
+import { ScriptRunKindBadge } from "@/components/shared/script-run-kind-badge";
 import { StatusBadge } from "@/components/shared/status-badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -129,6 +130,7 @@ export default function ScriptRunDetailPage() {
             <div className="flex min-w-0 flex-wrap items-center gap-3">
               <h1 className="truncate text-xl font-semibold">{run.scriptName || "Script run"}</h1>
               <StatusBadge status={run.status} size="md" />
+              <ScriptRunKindBadge kind={run.kind} />
               <Badge variant="outline" size="tag" className="font-mono">
                 {formatSmartTime(run.startedAt)}
               </Badge>

--- a/ui/src/pages/script-runs/[id]/page.tsx
+++ b/ui/src/pages/script-runs/[id]/page.tsx
@@ -22,6 +22,7 @@ import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/ui/page-header";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { cn, formatElapsed, formatSmartTime } from "@/lib/utils";
 
 function Fact({ label, children }: { label: string; children: ReactNode }) {
@@ -36,18 +37,12 @@ function Fact({ label, children }: { label: string; children: ReactNode }) {
 }
 
 function RunId({ id }: { id: string }) {
-  const [copied, setCopied] = useState(false);
-  const copy = () => {
-    navigator.clipboard.writeText(id).then(() => {
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
-    });
-  };
+  const { copied, copy } = useCopyToClipboard();
   return (
     <Fact label="Run ID">
       <button
         type="button"
-        onClick={copy}
+        onClick={() => copy(id)}
         className="group inline-flex items-center gap-1.5 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground"
         aria-label={copied ? "Copied" : "Copy run ID"}
       >

--- a/ui/src/pages/script-runs/[id]/page.tsx
+++ b/ui/src/pages/script-runs/[id]/page.tsx
@@ -10,7 +10,9 @@ import {
   type Selection,
 } from "@/components/script-runs/source-map";
 import { SourceView } from "@/components/script-runs/source-view";
+import { buildSteps, formatDurationMs } from "@/components/script-runs/step-shared";
 import { TimelinePanel } from "@/components/script-runs/timeline-panel";
+import { WaterfallView } from "@/components/script-runs/waterfall-view";
 import { AgentLink } from "@/components/shared/agent-link";
 import { ScriptRunKindBadge } from "@/components/shared/script-run-kind-badge";
 import { StatusBadge } from "@/components/shared/status-badge";
@@ -19,6 +21,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/ui/page-header";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn, formatElapsed, formatSmartTime } from "@/lib/utils";
 
 function Fact({ label, children }: { label: string; children: ReactNode }) {
@@ -86,6 +89,8 @@ export default function ScriptRunDetailPage() {
   const mapping = useMemo(() => mapStepsToBlocks(journal, blocks), [journal, blocks]);
 
   const [selection, setSelection] = useState<Selection>(null);
+  const [view, setView] = useState<"detail" | "waterfall">("detail");
+  const { steps, totalMs, hasTiming } = useMemo(() => buildSteps(journal), [journal]);
 
   const selectedBlock =
     selection?.kind === "step" ? (mapping.stepToBlock[selection.stepId] ?? null) : null;
@@ -192,29 +197,72 @@ export default function ScriptRunDetailPage() {
         </div>
       </div>
 
-      <div className="flex flex-col gap-4 lg:flex-row">
-        <SourceView
-          source={run.source ?? ""}
-          blocks={blocks}
-          inputAnchor={anchors.input}
-          outputAnchor={anchors.output}
-          selectedBlock={selectedBlock}
-          selectedAnchor={selectedAnchor}
-          onSelectBlock={handleSelectBlock}
-          onSelectAnchor={(a) => setSelection(a ? { kind: a } : null)}
-          className="h-[72vh] lg:flex-[3]"
-        />
-        <TimelinePanel
-          journal={journal}
-          mapping={mapping}
-          runArgs={run.args ?? null}
-          runOutput={run.output}
-          hasOutput={run.output !== undefined}
-          selection={selection}
-          onSelect={setSelection}
-          className="h-[72vh] lg:flex-[2]"
-        />
-      </div>
+      <Tabs
+        value={view}
+        onValueChange={(v) => setView(v as "detail" | "waterfall")}
+        className="gap-3"
+      >
+        <TabsList variant="line">
+          <TabsTrigger value="detail">Detail</TabsTrigger>
+          <TabsTrigger value="waterfall">Waterfall</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="detail" className="flex flex-col gap-4 lg:flex-row">
+          <SourceView
+            source={run.source ?? ""}
+            blocks={blocks}
+            inputAnchor={anchors.input}
+            outputAnchor={anchors.output}
+            selectedBlock={selectedBlock}
+            selectedAnchor={selectedAnchor}
+            onSelectBlock={handleSelectBlock}
+            onSelectAnchor={(a) => setSelection(a ? { kind: a } : null)}
+            className="h-[72vh] lg:flex-[3]"
+          />
+          <TimelinePanel
+            journal={journal}
+            mapping={mapping}
+            runArgs={run.args ?? null}
+            runOutput={run.output}
+            hasOutput={run.output !== undefined}
+            selection={selection}
+            onSelect={setSelection}
+            className="h-[72vh] lg:flex-[2]"
+          />
+        </TabsContent>
+
+        <TabsContent value="waterfall">
+          <div className="flex h-[72vh] min-h-0 flex-col overflow-hidden rounded-lg border bg-card">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b px-4 py-2">
+              <h2 className="text-sm font-semibold">Waterfall</h2>
+              {hasTiming && (
+                <span className="font-mono text-xs tabular-nums text-muted-foreground">
+                  {formatDurationMs(totalMs)} total
+                </span>
+              )}
+              {selection && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setSelection(null)}
+                  className="ml-auto h-7 text-xs"
+                >
+                  Clear
+                </Button>
+              )}
+            </div>
+            <WaterfallView
+              steps={steps}
+              totalMs={totalMs}
+              hasTiming={hasTiming}
+              mapping={mapping}
+              selection={selection}
+              onSelect={setSelection}
+              hasOutput={run.output !== undefined}
+            />
+          </div>
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/ui/src/pages/script-runs/[id]/page.tsx
+++ b/ui/src/pages/script-runs/[id]/page.tsx
@@ -1,18 +1,17 @@
-import {
-  ArrowLeft,
-  Bot,
-  Braces,
-  CheckCircle2,
-  CircleAlert,
-  FileCode2,
-  RefreshCw,
-  Workflow,
-} from "lucide-react";
+import { ArrowLeft, Check, Copy, RefreshCw } from "lucide-react";
+import { type ReactNode, useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useScriptRun } from "@/api/hooks/use-script-runs";
 import type { ScriptRunJournalEntry } from "@/api/types";
-import { CollapsibleSection } from "@/components/shared/collapsible-section";
-import { JsonViewer } from "@/components/shared/json-viewer";
+import {
+  mapStepsToBlocks,
+  parseRunAnchors,
+  parseStepBlocks,
+  type Selection,
+} from "@/components/script-runs/source-map";
+import { SourceView } from "@/components/script-runs/source-view";
+import { TimelinePanel } from "@/components/script-runs/timeline-panel";
+import { AgentLink } from "@/components/shared/agent-link";
 import { StatusBadge } from "@/components/shared/status-badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -21,100 +20,89 @@ import { PageHeader } from "@/components/ui/page-header";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn, formatElapsed, formatSmartTime } from "@/lib/utils";
 
-function stepIcon(stepType: string) {
-  if (stepType === "swarm-script") return FileCode2;
-  if (stepType === "raw-llm") return Braces;
-  if (stepType === "agent-task") return Bot;
-  return Workflow;
-}
-
-function stepTypeClass(stepType: string): string {
-  if (stepType === "swarm-script") return "border-status-active/30 text-status-active-strong";
-  if (stepType === "raw-llm") return "border-status-info/30 text-status-info-strong";
-  if (stepType === "agent-task") return "border-status-success/30 text-status-success-strong";
-  return "border-border text-muted-foreground";
-}
-
-function duration(startedAt: string, completedAt?: string): string {
-  if (!completedAt) return "—";
-  return formatElapsed(startedAt, completedAt);
-}
-
-function JournalEntry({ entry }: { entry: ScriptRunJournalEntry }) {
-  const Icon = stepIcon(entry.stepType);
-  const ok = entry.status === "completed";
-
+function Fact({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <div className="rounded-lg border bg-card">
-      <div className="flex flex-wrap items-start gap-3 border-b px-4 py-3">
-        <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md border bg-background">
-          <Icon className="h-4 w-4 text-muted-foreground" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <div className="flex min-w-0 flex-wrap items-center gap-2">
-            <h3 className="truncate font-mono text-sm font-semibold">{entry.stepKey}</h3>
-            <Badge
-              variant="outline"
-              className={cn("h-5 rounded-md text-[10px]", stepTypeClass(entry.stepType))}
-            >
-              {entry.stepType}
-            </Badge>
-            <Badge
-              variant="outline"
-              className={cn(
-                "h-5 rounded-md text-[10px]",
-                ok ? "text-status-success-strong" : "text-status-error-strong",
-              )}
-            >
-              {ok ? (
-                <CheckCircle2 className="mr-1 h-3 w-3" />
-              ) : (
-                <CircleAlert className="mr-1 h-3 w-3" />
-              )}
-              {entry.status}
-            </Badge>
-          </div>
-          <div className="mt-1 flex flex-wrap gap-3 text-xs text-muted-foreground">
-            <span>{formatSmartTime(entry.startedAt)}</span>
-            <span>{duration(entry.startedAt, entry.completedAt)}</span>
-          </div>
-        </div>
-      </div>
-
-      {entry.error && (
-        <Alert variant="destructive" className="m-3">
-          <AlertDescription className="whitespace-pre-wrap font-mono text-xs">
-            {entry.error}
-          </AlertDescription>
-        </Alert>
-      )}
-
-      <div className="space-y-2 p-3">
-        <CollapsibleSection title="Config" defaultOpen={false}>
-          <JsonViewer data={entry.config} />
-        </CollapsibleSection>
-        {entry.result !== undefined && (
-          <CollapsibleSection title="Result" defaultOpen={false}>
-            <JsonViewer data={entry.result} />
-          </CollapsibleSection>
-        )}
-      </div>
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </span>
+      <span className="text-sm">{children}</span>
     </div>
   );
+}
+
+function RunId({ id }: { id: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    navigator.clipboard.writeText(id).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    });
+  };
+  return (
+    <Fact label="Run ID">
+      <button
+        type="button"
+        onClick={copy}
+        className="group inline-flex items-center gap-1.5 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground"
+        aria-label={copied ? "Copied" : "Copy run ID"}
+      >
+        <span className="break-all">{id}</span>
+        {copied ? (
+          <Check className="h-3 w-3 shrink-0 text-status-success-strong" />
+        ) : (
+          <Copy className="h-3 w-3 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
+        )}
+      </button>
+    </Fact>
+  );
+}
+
+function stepCounts(journal: ScriptRunJournalEntry[]) {
+  let scripts = 0;
+  let llm = 0;
+  let tasks = 0;
+  for (const e of journal) {
+    if (e.stepType === "swarm-script") scripts++;
+    else if (e.stepType === "raw-llm") llm++;
+    else if (e.stepType === "agent-task") tasks++;
+  }
+  return { scripts, llm, tasks };
 }
 
 export default function ScriptRunDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { data, isLoading, refetch, isFetching } = useScriptRun(id ?? "");
   const run = data?.run;
-  const journal = data?.journal ?? [];
+  const journal = useMemo(() => data?.journal ?? [], [data]);
+
+  const counts = useMemo(() => stepCounts(journal), [journal]);
+  const blocks = useMemo(() => (run?.source ? parseStepBlocks(run.source) : []), [run?.source]);
+  const anchors = useMemo(
+    () => (run?.source ? parseRunAnchors(run.source) : { input: null, output: null }),
+    [run?.source],
+  );
+  const mapping = useMemo(() => mapStepsToBlocks(journal, blocks), [journal, blocks]);
+
+  const [selection, setSelection] = useState<Selection>(null);
+
+  const selectedBlock =
+    selection?.kind === "step" ? (mapping.stepToBlock[selection.stepId] ?? null) : null;
+  const selectedAnchor =
+    selection?.kind === "input" ? "input" : selection?.kind === "output" ? "output" : null;
+
+  const handleSelectBlock = (index: number | null) => {
+    if (index === null) return setSelection(null);
+    const stepId = mapping.blockToStepIds[index]?.[0];
+    setSelection(stepId ? { kind: "step", stepId } : null);
+  };
 
   if (isLoading) {
     return (
       <div className="space-y-4">
         <Skeleton className="h-8 w-56" />
-        <Skeleton className="h-32 w-full" />
-        <Skeleton className="h-64 w-full" />
+        <Skeleton className="h-16 w-full" />
+        <Skeleton className="h-72 w-full" />
       </div>
     );
   }
@@ -124,13 +112,14 @@ export default function ScriptRunDetailPage() {
   }
 
   const runDuration = run.finishedAt ? formatElapsed(run.startedAt, run.finishedAt) : null;
+  const live = run.status === "running" || run.status === "paused";
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4">
+    <div className="flex-1 min-h-0 space-y-4 overflow-y-auto">
       <div className="space-y-3">
         <Link
           to="/script-runs"
-          className="flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
         >
           <ArrowLeft className="h-4 w-4" /> Back to Script Runs
         </Link>
@@ -167,64 +156,63 @@ export default function ScriptRunDetailPage() {
         </Alert>
       )}
 
-      <div className="grid gap-3 md:grid-cols-4">
-        <div className="rounded-lg border bg-card p-3">
-          <div className="text-xs text-muted-foreground">Run ID</div>
-          <div className="mt-1 truncate font-mono text-xs">{run.id}</div>
-        </div>
-        <div className="rounded-lg border bg-card p-3">
-          <div className="text-xs text-muted-foreground">Agent</div>
-          <div className="mt-1 truncate font-mono text-xs">{run.agentId}</div>
-        </div>
-        <div className="rounded-lg border bg-card p-3">
-          <div className="text-xs text-muted-foreground">Heartbeat</div>
-          <div className="mt-1 text-sm">
-            {run.lastHeartbeatAt ? formatSmartTime(run.lastHeartbeatAt) : "—"}
-          </div>
-        </div>
-        <div className="rounded-lg border bg-card p-3">
-          <div className="text-xs text-muted-foreground">Journal</div>
-          <div className="mt-1 text-sm">
-            {journal.length} step{journal.length === 1 ? "" : "s"}
-          </div>
-        </div>
-      </div>
-
-      <div className="grid gap-3 lg:grid-cols-2">
-        <CollapsibleSection title="Args" defaultOpen={false} variant="card">
-          <JsonViewer data={run.args ?? null} />
-        </CollapsibleSection>
-        {run.output !== undefined && (
-          <CollapsibleSection title="Output" defaultOpen={false} variant="card">
-            <JsonViewer data={run.output} />
-          </CollapsibleSection>
-        )}
-      </div>
-
-      <section className="flex min-h-0 flex-1 flex-col gap-3">
-        <div className="flex items-center justify-between">
-          <h2 className="text-sm font-semibold">Journal</h2>
-          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-            <span>
-              {journal.filter((entry) => entry.stepType === "swarm-script").length} scripts
+      <div className="flex flex-wrap items-start gap-x-8 gap-y-3 rounded-lg border bg-card px-4 py-3">
+        <Fact label="Agent">
+          <AgentLink agentId={run.agentId} />
+        </Fact>
+        <Fact label="Started">
+          <span className="font-mono text-xs">{formatSmartTime(run.startedAt)}</span>
+        </Fact>
+        <Fact label="Duration">
+          <span className="font-mono text-xs tabular-nums">{runDuration ?? "running…"}</span>
+        </Fact>
+        {live && (
+          <Fact label="Heartbeat">
+            <span className="font-mono text-xs">
+              {run.lastHeartbeatAt ? formatSmartTime(run.lastHeartbeatAt) : "—"}
             </span>
-            <span>{journal.filter((entry) => entry.stepType === "raw-llm").length} LLM</span>
-            <span>{journal.filter((entry) => entry.stepType === "agent-task").length} tasks</span>
-          </div>
-        </div>
-
-        {journal.length === 0 ? (
-          <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
-            No journal entries yet.
-          </div>
-        ) : (
-          <div className="space-y-3">
-            {journal.map((entry) => (
-              <JournalEntry key={entry.id} entry={entry} />
-            ))}
-          </div>
+          </Fact>
         )}
-      </section>
+        <Fact label="Steps">
+          <span className="text-xs">
+            {journal.length}
+            {journal.length > 0 && (
+              <span className="text-muted-foreground">
+                {" · "}
+                {counts.scripts} script{counts.scripts === 1 ? "" : "s"} · {counts.llm} llm ·{" "}
+                {counts.tasks} task{counts.tasks === 1 ? "" : "s"}
+              </span>
+            )}
+          </span>
+        </Fact>
+        <div className="ml-auto">
+          <RunId id={run.id} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-4 lg:flex-row">
+        <SourceView
+          source={run.source ?? ""}
+          blocks={blocks}
+          inputAnchor={anchors.input}
+          outputAnchor={anchors.output}
+          selectedBlock={selectedBlock}
+          selectedAnchor={selectedAnchor}
+          onSelectBlock={handleSelectBlock}
+          onSelectAnchor={(a) => setSelection(a ? { kind: a } : null)}
+          className="h-[72vh] lg:flex-[3]"
+        />
+        <TimelinePanel
+          journal={journal}
+          mapping={mapping}
+          runArgs={run.args ?? null}
+          runOutput={run.output}
+          hasOutput={run.output !== undefined}
+          selection={selection}
+          onSelect={setSelection}
+          className="h-[72vh] lg:flex-[2]"
+        />
+      </div>
     </div>
   );
 }

--- a/ui/src/pages/script-runs/page.tsx
+++ b/ui/src/pages/script-runs/page.tsx
@@ -3,9 +3,10 @@ import { FileClock, Search } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useScriptRuns } from "@/api/hooks/use-script-runs";
-import type { ScriptRun, ScriptRunStatus } from "@/api/types";
+import type { ScriptRun, ScriptRunKind, ScriptRunStatus } from "@/api/types";
 import { AgentLink } from "@/components/shared/agent-link";
 import { DataGrid } from "@/components/shared/data-grid";
+import { ScriptRunKindBadge } from "@/components/shared/script-run-kind-badge";
 import { StatusBadge } from "@/components/shared/status-badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -67,6 +68,13 @@ export default function ScriptRunsPage() {
               <TooltipContent className="font-mono text-xs">{params.value}</TooltipContent>
             </Tooltip>
           ) : null,
+      },
+      {
+        field: "kind",
+        headerName: "Type",
+        width: 120,
+        cellRenderer: (params: { value?: ScriptRunKind }) =>
+          params.value ? <ScriptRunKindBadge kind={params.value} /> : null,
       },
       {
         field: "status",

--- a/ui/src/pages/script-runs/page.tsx
+++ b/ui/src/pages/script-runs/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useScriptRuns } from "@/api/hooks/use-script-runs";
 import type { ScriptRun, ScriptRunStatus } from "@/api/types";
+import { AgentLink } from "@/components/shared/agent-link";
 import { DataGrid } from "@/components/shared/data-grid";
 import { StatusBadge } from "@/components/shared/status-badge";
 import { Button } from "@/components/ui/button";
@@ -16,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatElapsed, formatSmartTime } from "@/lib/utils";
 
 const STATUS_OPTIONS: Array<ScriptRunStatus | "all"> = [
@@ -43,17 +45,28 @@ export default function ScriptRunsPage() {
     () => [
       {
         field: "scriptName",
-        headerName: "Run",
-        minWidth: 220,
+        headerName: "Name",
+        minWidth: 200,
         flex: 1,
-        cellRenderer: (params: { data?: ScriptRun; value?: string }) => (
-          <div className="flex min-w-0 flex-col">
-            <span className="truncate font-medium">{params.value || "One-off script"}</span>
-            <span className="truncate font-mono text-[11px] text-muted-foreground">
-              {params.data?.id}
-            </span>
-          </div>
+        cellRenderer: (params: { value?: string }) => (
+          <span className="truncate font-medium">{params.value || "One-off script"}</span>
         ),
+      },
+      {
+        field: "id",
+        headerName: "Run ID",
+        width: 170,
+        cellRenderer: (params: { value?: string }) =>
+          params.value ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="block truncate font-mono text-xs text-muted-foreground">
+                  {params.value}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="font-mono text-xs">{params.value}</TooltipContent>
+            </Tooltip>
+          ) : null,
       },
       {
         field: "status",
@@ -66,9 +79,12 @@ export default function ScriptRunsPage() {
         field: "agentId",
         headerName: "Agent",
         width: 230,
-        cellRenderer: (params: { value?: string }) => (
-          <span className="font-mono text-xs text-muted-foreground">{params.value || "—"}</span>
-        ),
+        cellRenderer: (params: { value?: string }) =>
+          params.value ? (
+            <AgentLink agentId={params.value} onClick={(e) => e.stopPropagation()} />
+          ) : (
+            <span className="text-xs text-muted-foreground">—</span>
+          ),
       },
       {
         field: "startedAt",
@@ -89,7 +105,12 @@ export default function ScriptRunsPage() {
         minWidth: 220,
         cellRenderer: (params: { value?: string }) =>
           params.value ? (
-            <span className="truncate text-xs text-status-error">{params.value}</span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="block truncate text-xs text-status-error">{params.value}</span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-md">{params.value}</TooltipContent>
+            </Tooltip>
           ) : null,
       },
     ],
@@ -98,6 +119,11 @@ export default function ScriptRunsPage() {
 
   const onRowClicked = useCallback(
     (event: RowClickedEvent<ScriptRun>) => {
+      // Don't hijack clicks on interactive cell content (e.g. the agent link) —
+      // AG Grid's native row listener fires before React's stopPropagation, so
+      // guard on the click target instead.
+      const target = event.event?.target as HTMLElement | null;
+      if (target?.closest("a, button")) return;
       if (event.data) navigate(`/script-runs/${event.data.id}`);
     },
     [navigate],


### PR DESCRIPTION
## Summary

Overhauls the **Script Runs** experience end-to-end: a redesigned list + detail, persistence of one-off (inline) runs, and a timeline waterfall. (Folds in #667.)

## 1. Detail redesign (base)

- Script Runs **list + detail** redesigned around a **code ↔ timeline** view.
- **Real per-step timing**: the runtime now records measured wall-clock `durationMs` per journal step (migration `084_script_run_journal_duration`), so the timeline reflects truthful durations rather than estimates.

## 2. Inline script-run persistence (#667)

- `POST /api/scripts/run` (the `script_run` MCP tool) now **persists each run** in `script_runs` as an already-terminal row — previously only durable workflow runs (`POST /api/script-runs`) were recorded.
- New **`kind` discriminator** (`'inline' | 'workflow'`, migration `085_script_runs_kind`) so the two execution paths coexist in one table. Inline runs carry **no journal** and don't use the `idempotencyKey` column (inline idempotency stays in `kv`).
- Best-effort recording (never fails the actual run); `output`/`error` scrubbed before storage.
- UI: a **Type** column on the list + an **`INLINE` / `WORKFLOW`** badge on the detail header. Journal empty-state is kind-aware.

## 3. Waterfall timeline (#667)

- The detail **Timeline** panel is now tabbed: **Steps** (the expandable list) + **Waterfall** (a cascading Gantt — time ruler, bars offset by cumulative start and sized by measured `durationMs`, Input/Output boundary markers, gridlines, hover tooltips). Selection stays synced with the source view.

## Migrations

- `084_script_run_journal_duration` — `durationMs` on `script_run_journal`.
- `085_script_runs_kind` — `kind` discriminator on `script_runs`.

## Testing

- Backend: `tsc:check`, `lint`, db/api-key boundary, `bun test src/tests/scripts-*` / `script-runs-*` all green (incl. new inline-persistence coverage).
- UI: `tsc -b`, `lint`, `check:tokens` all green. Manually QA'd against seeded inline + workflow runs (see #667).
