### PR TITLE
Script run detail: full-width waterfall tab + source highlight/scroll fix

### DIFF
--- a/ui/src/components/script-runs/source-view.tsx
+++ b/ui/src/components/script-runs/source-view.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy } from "lucide-react";
+import { Check, Copy, WrapText } from "lucide-react";
 import { Highlight, themes } from "prism-react-renderer";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTheme } from "@/hooks/use-theme";
@@ -58,6 +58,7 @@ export function SourceView({
 }: SourceViewProps) {
   const { theme } = useTheme();
   const [copied, setCopied] = useState(false);
+  const [wrap, setWrap] = useState(false);
 
   const lineInfo = useMemo(() => {
     const map = new Map<
@@ -131,17 +132,32 @@ export function SourceView({
             </span>
           )}
         </div>
-        <button
-          type="button"
-          onClick={copy}
-          aria-label={copied ? "Copied" : "Copy source"}
-          className={cn(
-            "inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted-foreground/15 hover:text-foreground",
-            copied && "text-status-success-strong",
-          )}
-        >
-          {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setWrap((w) => !w)}
+            aria-label={wrap ? "Disable line wrap" : "Enable line wrap"}
+            aria-pressed={wrap}
+            title={wrap ? "Disable line wrap" : "Wrap long lines"}
+            className={cn(
+              "inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted-foreground/15 hover:text-foreground",
+              wrap && "bg-muted-foreground/15 text-foreground",
+            )}
+          >
+            <WrapText className="h-3 w-3" />
+          </button>
+          <button
+            type="button"
+            onClick={copy}
+            aria-label={copied ? "Copied" : "Copy source"}
+            className={cn(
+              "inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted-foreground/15 hover:text-foreground",
+              copied && "text-status-success-strong",
+            )}
+          >
+            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          </button>
+        </div>
       </div>
 
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
@@ -151,7 +167,15 @@ export function SourceView({
           theme={theme === "dark" ? themes.vsDark : themes.github}
         >
           {({ tokens, getLineProps, getTokenProps }) => (
-            <pre className="m-0 py-2 font-mono text-xs leading-relaxed">
+            <pre
+              className={cn(
+                "m-0 py-2 font-mono text-xs leading-relaxed",
+                // No-wrap: grow to the longest line (w-max) so row highlights/edges
+                // span the full scroll width when scrolled right. min-w-full keeps
+                // them filling the viewport when every line is short.
+                wrap ? "min-w-full" : "w-max min-w-full",
+              )}
+            >
               {tokens.map((line, i) => {
                 const info = lineInfo.get(i);
                 const region = info?.region;
@@ -172,6 +196,7 @@ export function SourceView({
                     onClick={region ? () => onRegionClick(region, selected) : undefined}
                     className={cn(
                       "flex border-l-2 border-l-transparent pr-3 transition-colors",
+                      wrap && "items-start",
                       region && "cursor-pointer",
                       meta?.codeBg,
                       meta?.rail,
@@ -186,7 +211,13 @@ export function SourceView({
                     <span className="w-10 shrink-0 select-none pr-3 text-right text-muted-foreground/40">
                       {i + 1}
                     </span>
-                    <span {...getLineProps({ line })} className="flex-1">
+                    <span
+                      {...getLineProps({ line })}
+                      className={cn(
+                        "flex-1",
+                        wrap ? "min-w-0 whitespace-pre-wrap break-words" : "whitespace-pre",
+                      )}
+                    >
                       {line.map((token, k) => (
                         <span key={k} {...getTokenProps({ token })} />
                       ))}

--- a/ui/src/components/script-runs/timeline-panel.tsx
+++ b/ui/src/components/script-runs/timeline-panel.tsx
@@ -5,12 +5,10 @@ import type { ScriptRunJournalEntry } from "@/api/types";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn, formatSmartTime } from "@/lib/utils";
 import { JsonView } from "./json-view";
 import type { Selection, StepBlockMapping } from "./source-map";
 import { buildSteps, formatDurationMs, stepTypeMeta, type TimelineStep } from "./step-shared";
-import { WaterfallView } from "./waterfall-view";
 
 function MetaItem({ label, children }: { label: string; children: ReactNode }) {
   return (
@@ -258,7 +256,6 @@ export function TimelinePanel({
 }: TimelinePanelProps) {
   const { steps, totalMs, maxMs, hasTiming } = useMemo(() => buildSteps(journal), [journal]);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
-  const [tab, setTab] = useState<"steps" | "waterfall">("steps");
   const rowRefs = useRef(new Map<string, HTMLDivElement>());
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -318,109 +315,82 @@ export function TimelinePanel({
     <div
       className={cn("flex min-h-0 flex-col overflow-hidden rounded-lg border bg-card", className)}
     >
-      <Tabs
-        value={tab}
-        onValueChange={(v) => setTab(v as "steps" | "waterfall")}
-        className="flex min-h-0 flex-1 flex-col gap-0"
-      >
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b px-4 py-2">
-          <h2 className="text-sm font-semibold">Timeline</h2>
-          {hasTiming && (
-            <span className="font-mono text-xs tabular-nums text-muted-foreground">
-              {formatDurationMs(totalMs)} total
-            </span>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b px-4 py-2">
+        <h2 className="text-sm font-semibold">Timeline</h2>
+        {hasTiming && (
+          <span className="font-mono text-xs tabular-nums text-muted-foreground">
+            {formatDurationMs(totalMs)} total
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-1">
+          {selection && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onSelect(null)}
+              className="h-7 text-xs"
+            >
+              Clear
+            </Button>
           )}
-          <div className="ml-auto flex items-center gap-2">
-            <TabsList variant="line">
-              <TabsTrigger value="steps">Steps</TabsTrigger>
-              <TabsTrigger value="waterfall">Waterfall</TabsTrigger>
-            </TabsList>
-            {selection && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => onSelect(null)}
-                className="h-7 text-xs"
-              >
-                Clear
-              </Button>
-            )}
-            {tab === "steps" && (
-              <Button variant="ghost" size="sm" onClick={toggleAll} className="h-7 text-xs">
-                {allExpanded ? "Collapse all" : "Expand all"}
-              </Button>
-            )}
-          </div>
+          <Button variant="ghost" size="sm" onClick={toggleAll} className="h-7 text-xs">
+            {allExpanded ? "Collapse all" : "Expand all"}
+          </Button>
         </div>
+      </div>
 
-        <TabsContent value="steps" className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
-            <IoRow
-              kind="input"
-              data={runArgs}
-              expanded={expanded.has("input")}
-              selected={selection?.kind === "input"}
-              onActivate={() => activateIo("input")}
-              rowRef={(el) => {
-                if (el) rowRefs.current.set("input", el);
-                else rowRefs.current.delete("input");
-              }}
-            />
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
+        <IoRow
+          kind="input"
+          data={runArgs}
+          expanded={expanded.has("input")}
+          selected={selection?.kind === "input"}
+          onActivate={() => activateIo("input")}
+          rowRef={(el) => {
+            if (el) rowRefs.current.set("input", el);
+            else rowRefs.current.delete("input");
+          }}
+        />
 
-            {steps.map((step) => (
-              <TimelineRow
-                key={step.entry.id}
-                step={step}
-                hasTiming={hasTiming}
-                maxMs={maxMs}
-                expanded={expanded.has(step.entry.id)}
-                selected={selection?.kind === "step" && selection.stepId === step.entry.id}
-                blockActive={
-                  selectedBlock !== undefined &&
-                  mapping.stepToBlock[step.entry.id] === selectedBlock
-                }
-                onActivate={() => activateStep(step.entry.id)}
-                rowRef={(el) => {
-                  if (el) rowRefs.current.set(step.entry.id, el);
-                  else rowRefs.current.delete(step.entry.id);
-                }}
-              />
-            ))}
-
-            {hasOutput && (
-              <IoRow
-                kind="output"
-                data={runOutput}
-                expanded={expanded.has("output")}
-                selected={selection?.kind === "output"}
-                onActivate={() => activateIo("output")}
-                rowRef={(el) => {
-                  if (el) rowRefs.current.set("output", el);
-                  else rowRefs.current.delete("output");
-                }}
-              />
-            )}
-          </div>
-
-          {!hasTiming && journal.length > 0 && (
-            <div className="border-t px-4 py-2 text-[11px] text-muted-foreground">
-              Per-step timing wasn&rsquo;t recorded for this run.
-            </div>
-          )}
-        </TabsContent>
-
-        <TabsContent value="waterfall" className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          <WaterfallView
-            steps={steps}
-            totalMs={totalMs}
+        {steps.map((step) => (
+          <TimelineRow
+            key={step.entry.id}
+            step={step}
             hasTiming={hasTiming}
-            mapping={mapping}
-            selection={selection}
-            onSelect={onSelect}
-            hasOutput={hasOutput}
+            maxMs={maxMs}
+            expanded={expanded.has(step.entry.id)}
+            selected={selection?.kind === "step" && selection.stepId === step.entry.id}
+            blockActive={
+              selectedBlock !== undefined && mapping.stepToBlock[step.entry.id] === selectedBlock
+            }
+            onActivate={() => activateStep(step.entry.id)}
+            rowRef={(el) => {
+              if (el) rowRefs.current.set(step.entry.id, el);
+              else rowRefs.current.delete(step.entry.id);
+            }}
           />
-        </TabsContent>
-      </Tabs>
+        ))}
+
+        {hasOutput && (
+          <IoRow
+            kind="output"
+            data={runOutput}
+            expanded={expanded.has("output")}
+            selected={selection?.kind === "output"}
+            onActivate={() => activateIo("output")}
+            rowRef={(el) => {
+              if (el) rowRefs.current.set("output", el);
+              else rowRefs.current.delete("output");
+            }}
+          />
+        )}
+      </div>
+
+      {!hasTiming && journal.length > 0 && (
+        <div className="border-t px-4 py-2 text-[11px] text-muted-foreground">
+          Per-step timing wasn&rsquo;t recorded for this run.
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/pages/script-runs/[id]/page.tsx
+++ b/ui/src/pages/script-runs/[id]/page.tsx
@@ -10,7 +10,9 @@ import {
   type Selection,
 } from "@/components/script-runs/source-map";
 import { SourceView } from "@/components/script-runs/source-view";
+import { buildSteps, formatDurationMs } from "@/components/script-runs/step-shared";
 import { TimelinePanel } from "@/components/script-runs/timeline-panel";
+import { WaterfallView } from "@/components/script-runs/waterfall-view";
 import { AgentLink } from "@/components/shared/agent-link";
 import { ScriptRunKindBadge } from "@/components/shared/script-run-kind-badge";
 import { StatusBadge } from "@/components/shared/status-badge";
@@ -19,6 +21,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/ui/page-header";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn, formatElapsed, formatSmartTime } from "@/lib/utils";
 
 function Fact({ label, children }: { label: string; children: ReactNode }) {
@@ -86,6 +89,8 @@ export default function ScriptRunDetailPage() {
   const mapping = useMemo(() => mapStepsToBlocks(journal, blocks), [journal, blocks]);
 
   const [selection, setSelection] = useState<Selection>(null);
+  const [view, setView] = useState<"detail" | "waterfall">("detail");
+  const { steps, totalMs, hasTiming } = useMemo(() => buildSteps(journal), [journal]);
 
   const selectedBlock =
     selection?.kind === "step" ? (mapping.stepToBlock[selection.stepId] ?? null) : null;
@@ -192,29 +197,72 @@ export default function ScriptRunDetailPage() {
         </div>
       </div>
 
-      <div className="flex flex-col gap-4 lg:flex-row">
-        <SourceView
-          source={run.source ?? ""}
-          blocks={blocks}
-          inputAnchor={anchors.input}
-          outputAnchor={anchors.output}
-          selectedBlock={selectedBlock}
-          selectedAnchor={selectedAnchor}
-          onSelectBlock={handleSelectBlock}
-          onSelectAnchor={(a) => setSelection(a ? { kind: a } : null)}
-          className="h-[72vh] lg:flex-[3]"
-        />
-        <TimelinePanel
-          journal={journal}
-          mapping={mapping}
-          runArgs={run.args ?? null}
-          runOutput={run.output}
-          hasOutput={run.output !== undefined}
-          selection={selection}
-          onSelect={setSelection}
-          className="h-[72vh] lg:flex-[2]"
-        />
-      </div>
+      <Tabs
+        value={view}
+        onValueChange={(v) => setView(v as "detail" | "waterfall")}
+        className="gap-3"
+      >
+        <TabsList variant="line">
+          <TabsTrigger value="detail">Detail</TabsTrigger>
+          <TabsTrigger value="waterfall">Waterfall</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="detail" className="flex flex-col gap-4 lg:flex-row">
+          <SourceView
+            source={run.source ?? ""}
+            blocks={blocks}
+            inputAnchor={anchors.input}
+            outputAnchor={anchors.output}
+            selectedBlock={selectedBlock}
+            selectedAnchor={selectedAnchor}
+            onSelectBlock={handleSelectBlock}
+            onSelectAnchor={(a) => setSelection(a ? { kind: a } : null)}
+            className="h-[72vh] lg:flex-[3]"
+          />
+          <TimelinePanel
+            journal={journal}
+            mapping={mapping}
+            runArgs={run.args ?? null}
+            runOutput={run.output}
+            hasOutput={run.output !== undefined}
+            selection={selection}
+            onSelect={setSelection}
+            className="h-[72vh] lg:flex-[2]"
+          />
+        </TabsContent>
+
+        <TabsContent value="waterfall">
+          <div className="flex h-[72vh] min-h-0 flex-col overflow-hidden rounded-lg border bg-card">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b px-4 py-2">
+              <h2 className="text-sm font-semibold">Waterfall</h2>
+              {hasTiming && (
+                <span className="font-mono text-xs tabular-nums text-muted-foreground">
+                  {formatDurationMs(totalMs)} total
+                </span>
+              )}
+              {selection && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setSelection(null)}
+                  className="ml-auto h-7 text-xs"
+                >
+                  Clear
+                </Button>
+              )}
+            </div>
+            <WaterfallView
+              steps={steps}
+              totalMs={totalMs}
+              hasTiming={hasTiming}
+              mapping={mapping}
+              selection={selection}
+              onSelect={setSelection}
+              hasOutput={run.output !== undefined}
+            />
+          </div>
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Two follow-up improvements to the Script Run **detail** page (on top of the merged redesign + waterfall). Targets `script-runs-detail-redesign` so it rides into #666.

## 1. Full-width Waterfall as a page-level tab

Previously the waterfall was a sub-tab squeezed into the narrow right Timeline column. Now the detail page has **page-level tabs**:

- **Detail** — the existing Source ↔ Timeline (Steps) split, with click-to-sync intact. The Timeline panel is back to Steps-only (its Waterfall sub-tab is removed).
- **Waterfall** — a **full-width** cascading Gantt (time ruler, bars offset by cumulative start + sized by measured `durationMs`, Input/Output markers, gridlines, hover tooltips). Selection is shared across tabs, so picking a bar then switching to Detail highlights its code block.

`buildSteps`/`TimelineStep` already live in `step-shared`, so both the Steps list and the Waterfall share one layout.

## 2. Source highlight fix on horizontal scroll + wrap toggle

The source viewer's per-line highlight (step-block tints, left rails, top/bottom edges, selection ring, input/output anchors) was clipped to the viewport: scrolling right past a long line revealed unstyled background.

- **Fix**: in no-wrap mode the `<pre>` is now `w-max min-w-full`, so rows grow to the longest line and highlights span the full scroll width.
- **Wrap toggle** (WrapText icon): switches to `whitespace-pre-wrap` + `break-words` with top-aligned line numbers, eliminating horizontal scroll for long lines entirely.

## Testing

- `pnpm exec tsc -b` ✓ · `pnpm lint` ✓ · `pnpm run check:tokens` ✓
- Verified live against the seeded `etl-pipeline-demo` workflow run: full-width waterfall, Detail split, source scroll + wrap all confirmed via screenshots.
