### PR TITLE
fix(migrations): self-heal seed-as-090 history + forbid mutating applied migrations

### DIFF
--- a/.github/workflows/migration-conflict-check.yml
+++ b/.github/workflows/migration-conflict-check.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          # Full history so the script can diff migrations against the base branch.
+          fetch-depth: 0
 
-      - name: Check for duplicate migration numbers
+      - name: Check for duplicate and mutated migration numbers
         run: bash scripts/check-migration-conflicts.sh
+        env:
+          MIGRATION_BASE_REF: origin/${{ github.base_ref }}

--- a/scripts/check-migration-conflicts.sh
+++ b/scripts/check-migration-conflicts.sh
@@ -11,7 +11,16 @@
 # (PR merged into base), so both a base-vs-branch collision and a within-PR
 # duplicate surface as two files sharing one NNN — no diff-against-main needed.
 #
+# It also fails if a migration that exists on the base branch was renamed,
+# renumbered, modified, or deleted. Migrations on main may already be applied
+# in production; the runner tracks them by numeric version, so renumbering an
+# applied file makes the runner silently skip the new file that took its number
+# (incident 2026-06-10: 090_model_tiers skipped after 090→091 renumber).
+#
 # Runnable locally too: bash scripts/check-migration-conflicts.sh
+# Base ref for the immutability check defaults to origin/main; override with
+# MIGRATION_BASE_REF. Skipped (with a notice) when the base ref is missing or
+# is not an ancestor of HEAD — CI enforces it on the PR merge ref.
 
 set -euo pipefail
 
@@ -54,9 +63,54 @@ if [ -n "$CONFLICTS" ]; then
     echo "  $prefix: ${PREFIX_FILES[$prefix]}"
   done < <(echo -e "$CONFLICTS" | sort -u)
   echo ""
-  echo "Fix: renumber your migration to the next unused prefix and update any"
-  echo "references to its filename."
+  echo "Fix: renumber YOUR NEW migration to the next unused prefix and update"
+  echo "any references to its filename. NEVER renumber the migration that is"
+  echo "already on main — it may be applied in production databases."
   exit 1
 fi
 
 echo "Migration numbering check passed: all NNN prefixes are unique."
+
+# Immutability check: migrations present on the base branch must exist in the
+# working tree with identical content.
+BASE_REF="${MIGRATION_BASE_REF:-origin/main}"
+
+if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+  echo "NOTE: base ref ${BASE_REF} not available — skipping migration immutability check."
+  exit 0
+fi
+
+if ! git merge-base --is-ancestor "$BASE_REF" HEAD 2>/dev/null; then
+  echo "NOTE: HEAD does not contain ${BASE_REF} (stale local branch?) — skipping"
+  echo "migration immutability check. CI enforces it on the PR merge ref."
+  exit 0
+fi
+
+VIOLATIONS=""
+while read -r _mode _type base_hash base_path; do
+  case "$base_path" in
+    *.sql) ;;
+    *) continue ;;
+  esac
+  if [ ! -f "$base_path" ]; then
+    VIOLATIONS="${VIOLATIONS}  removed or renamed: ${base_path}\n"
+  elif [ "$(git hash-object "$base_path")" != "$base_hash" ]; then
+    VIOLATIONS="${VIOLATIONS}  modified: ${base_path}\n"
+  fi
+done < <(git ls-tree -r "$BASE_REF" -- "$MIGRATIONS_DIR")
+
+if [ -n "$VIOLATIONS" ]; then
+  echo "ERROR: applied migrations were renamed, modified, or deleted!"
+  echo ""
+  echo "These migrations exist on ${BASE_REF} and may already be applied in"
+  echo "production databases. The migration runner tracks applied migrations by"
+  echo "numeric version, so renumbering or editing one makes the runner silently"
+  echo "skip or mismatch it. Migrations are forward-only and immutable once merged."
+  echo ""
+  echo -e "$VIOLATIONS"
+  echo "Fix: restore these files exactly as they are on ${BASE_REF} and put your"
+  echo "changes in a NEW migration with the next unused NNN prefix."
+  exit 1
+fi
+
+echo "Migration immutability check passed: no base-branch migrations were changed."

--- a/src/be/migrations/runner.ts
+++ b/src/be/migrations/runner.ts
@@ -36,6 +36,56 @@ const BASELINE_TABLES = [
   "context_versions",
 ];
 
+// 090 was renumbered after being applied in production (2026-06-10): PR #722
+// shipped the metrics seed as 090_seed_swarm_operations_metrics; PR #719 then
+// took 090 for model tiers and renumbered the seed to 091. Databases that
+// applied seed-as-090 recorded version 90 with the seed's checksum, so the
+// runner skipped 090_model_tiers forever and task inserts crashed on the
+// missing modelTier column. Detect that exact history and repair it in place:
+// apply the missing ALTERs and repoint row 90 at 090_model_tiers. No-op on
+// fresh databases and on histories where 090_model_tiers applied normally.
+const SEED_APPLIED_AS_090_CHECKSUM =
+  "8ca4a05263b42d115b419f468bf5113caa5b7ee4363177568897513549224b01";
+
+function repairRenumberedModelTiers(db: Database, migrations: Migration[]): void {
+  const modelTiers = migrations.find((m) => m.name === "090_model_tiers");
+  if (!modelTiers) return;
+
+  const row = db
+    .prepare<AppliedMigration, []>(
+      "SELECT version, name, checksum FROM _migrations WHERE version = 90",
+    )
+    .get();
+  if (
+    !row ||
+    row.name !== "090_seed_swarm_operations_metrics" ||
+    row.checksum !== SEED_APPLIED_AS_090_CHECKSUM
+  ) {
+    return;
+  }
+
+  console.warn(
+    "[migrations] Repairing renumbered migration 090: applying 090_model_tiers over seed-as-090 history",
+  );
+
+  db.transaction(() => {
+    for (const table of ["agent_tasks", "scheduled_tasks"]) {
+      const hasColumn = db
+        .prepare<{ n: number }, [string]>(
+          "SELECT COUNT(*) AS n FROM pragma_table_info(?) WHERE name = 'modelTier'",
+        )
+        .get(table);
+      if (!hasColumn?.n) {
+        db.run(`ALTER TABLE ${table} ADD COLUMN modelTier TEXT`);
+      }
+    }
+    db.run("UPDATE _migrations SET name = ?, checksum = ? WHERE version = 90", [
+      modelTiers.name,
+      modelTiers.checksum,
+    ]);
+  })();
+}
+
 function shouldBootstrapInitialMigration(db: Database): boolean {
   const rows = db
     .prepare<{ name: string }, []>(
@@ -106,6 +156,8 @@ export function runMigrations(db: Database): void {
   if (migrations.length === 0) {
     return;
   }
+
+  repairRenumberedModelTiers(db, migrations);
 
   // 3. Get applied migrations
   const applied = new Map<number, AppliedMigration>();

--- a/src/tests/migration-runner-regressions.test.ts
+++ b/src/tests/migration-runner-regressions.test.ts
@@ -2,9 +2,11 @@ import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
 import { unlink } from "node:fs/promises";
 import { closeDb, initDb } from "../be/db";
+import { runMigrations } from "../be/migrations/runner";
 
 const INCOMPLETE_DB_PATH = "./test-migration-incomplete.sqlite";
 const FRESH_DB_PATH = "./test-migration-fresh.sqlite";
+const REPAIR_DB_PATH = "./test-migration-repair.sqlite";
 
 async function removeDbFiles(dbPath: string): Promise<void> {
   for (const suffix of ["", "-wal", "-shm"]) {
@@ -22,6 +24,7 @@ afterEach(async () => {
   closeDb();
   await removeDbFiles(INCOMPLETE_DB_PATH);
   await removeDbFiles(FRESH_DB_PATH);
+  await removeDbFiles(REPAIR_DB_PATH);
 });
 
 describe("migration regressions", () => {
@@ -97,5 +100,71 @@ describe("migration regressions", () => {
     const requestedByFk = fkList.find((fk) => fk.from === "requestedByUserId");
     expect(requestedByFk?.table).toBe("users");
     expect(requestedByFk?.to).toBe("id");
+  });
+
+  test("repairs seed-as-090 history so 090_model_tiers is never skipped", () => {
+    // 2026-06-10 incident: PR #722 shipped the metrics seed as migration 090
+    // and production applied it; PR #719 then renumbered the seed to 091 and
+    // took 090 for model tiers. The runner keys applied migrations on version,
+    // so those databases skipped 090_model_tiers and crashed on the missing
+    // modelTier column. repairRenumberedModelTiers() in the runner must detect
+    // that history and fix it on boot.
+    const SEED_NAME = "090_seed_swarm_operations_metrics";
+    const SEED_CHECKSUM = "8ca4a05263b42d115b419f468bf5113caa5b7ee4363177568897513549224b01";
+
+    // Raw Database + runMigrations directly: initDb()'s test-template fast
+    // path skips the runner entirely, and the repair lives in the runner.
+    const database = new Database(REPAIR_DB_PATH, { create: true });
+    runMigrations(database);
+
+    // Reconstruct the divergent history: modelTier columns absent, version 90
+    // recorded as the seed migration.
+    database.run("ALTER TABLE agent_tasks DROP COLUMN modelTier");
+    database.run("ALTER TABLE scheduled_tasks DROP COLUMN modelTier");
+    database.run("UPDATE _migrations SET name = ?, checksum = ? WHERE version = 90", [
+      SEED_NAME,
+      SEED_CHECKSUM,
+    ]);
+
+    // Next boot repairs the history.
+    runMigrations(database);
+
+    for (const table of ["agent_tasks", "scheduled_tasks"]) {
+      const columns = database
+        .prepare<{ name: string }, []>(`PRAGMA table_info(${table})`)
+        .all()
+        .map((column) => column.name);
+      expect(columns).toContain("modelTier");
+    }
+
+    const row = database
+      .prepare<{ name: string; checksum: string }, []>(
+        "SELECT name, checksum FROM _migrations WHERE version = 90",
+      )
+      .get();
+    expect(row?.name).toBe("090_model_tiers");
+    expect(row?.checksum).not.toBe(SEED_CHECKSUM);
+
+    // The original failure mode: inserting a task with a modelTier value.
+    const now = new Date().toISOString();
+    expect(() => {
+      database.run(
+        `INSERT INTO agent_tasks (id, task, status, source, modelTier, createdAt, lastUpdatedAt)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [crypto.randomUUID(), "boot triage", "pending", "system", "regular", now, now],
+      );
+    }).not.toThrow();
+
+    // Healthy histories are untouched: booting again is a no-op.
+    runMigrations(database);
+    const rowAfter = database
+      .prepare<{ name: string; checksum: string }, []>(
+        "SELECT name, checksum FROM _migrations WHERE version = 90",
+      )
+      .get();
+    expect(rowAfter?.name).toBe("090_model_tiers");
+    expect(rowAfter?.checksum).toBe(row?.checksum);
+
+    database.close();
   });
 });


### PR DESCRIPTION
## Incident (2026-06-10)

PR #722 shipped the metrics seed as migration `090_seed_swarm_operations_metrics` and production applied it at 18:52 UTC. PR #719 then took `090` for model tiers and renumbered the already-applied seed to `091`. The runner tracks applied migrations by **version number**, so on the next deploy it saw v90 "already applied", logged only a checksum-mismatch warning, and never ran `090_model_tiers` — every task insert then crashed with `SQLiteError: table agent_tasks has no column named modelTier` (surfaced via `createBootTriageTask` in the heartbeat).

Prod on swarm-new was hand-repaired already; this PR makes every other deployment (ext-swarm, swarm-cloud-aurica, external installs that pulled `:latest` in the 18:38–20:24 UTC window) auto-heal on next boot, and prevents the failure class from recurring.

## Changes

- **`src/be/migrations/runner.ts`** — `repairRenumberedModelTiers()`: on boot, if `_migrations` v90 matches the seed's name+checksum, add the missing `modelTier` columns (idempotent, guarded by `pragma_table_info`) and repoint v90 at `090_model_tiers`. No-op on fresh databases and healthy histories.
- **`scripts/check-migration-conflicts.sh`** — new immutability guard: fails if any migration that exists on the base branch was renamed, renumbered, modified, or deleted. The old duplicate-prefix check caught the #719 collision, but its fix advice led to renumbering the wrong (already-applied) file; the error text now says to renumber the *new* migration only.
- **`.github/workflows/migration-conflict-check.yml`** — `fetch-depth: 0` + `MIGRATION_BASE_REF=origin/${{ github.base_ref }}` so the guard can diff against the PR base. Skips gracefully (with a notice) on stale local branches.

## Verification

- `bun test src/tests/migration-runner-regressions.test.ts` — new regression test reconstructs the divergent history (drops the columns, rewrites v90 to the seed identity), reboots, and asserts the repair: columns restored, v90 repointed, task insert with `modelTier` succeeds, third boot is a no-op.
- Full `bun test`: 5150 pass / 0 fail. `bun run lint`, `bun run tsc:check`, `check-db-boundary.sh` all green.
- Guard tested locally: clean tree passes; a tampered `089` and a renamed `091` both fail with actionable errors.