### PR TITLE
fix(pi-mono): surface AWS SDK runtime errors via structured pi events

### DIFF
--- a/docs-site/content/docs/(documentation)/guides/harness-providers.mdx
+++ b/docs-site/content/docs/(documentation)/guides/harness-providers.mdx
@@ -119,7 +119,16 @@ pi-mono routes to Amazon Bedrock when `MODEL_OVERRIDE=amazon-bedrock/<model-id>`
 
 `AWS_REGION` (or `AWS_DEFAULT_REGION`) is required by the SDK and must be a Bedrock-enabled region.
 
-**Failure mode.** No `credential-wait` parking — the worker claims tasks immediately. If creds are missing, the first Bedrock inference call fails with the AWS SDK's own error (e.g. `CredentialsProviderError: Could not load credentials from any providers`), which surfaces in the session log via the existing error path (scrubbed through `scrubSecrets`). Treat this the same way you treat a stale codex `auth.json`: the underlying SDK is the source of truth.
+**Failure mode.** No `credential-wait` parking — the worker claims tasks immediately. If Bedrock fails at runtime, pi-mono captures the structured pi-coding-agent terminal event and emits a normalized `error` `ProviderEvent`; `waitForCompletion()` returns `exitCode: 1`, `isError: true`, and the same `errorCategory` / `failureReason`, so the task fails with the session-chat error box instead of only leaving an SDK exception in the session log. Raw stderr/log events are still scrubbed through `scrubSecrets` at egress.
+
+AWS SDK errors are classified before they reach the runner:
+
+- `aws-auth` — missing, expired, invalid, or unresolvable AWS credentials (for example `CredentialsProviderError`, `ExpiredToken`, invalid signatures, or unrecognized clients). Refresh credentials with `aws sso login` or `aws configure`, then retry.
+- `aws-throttle` — Bedrock rate limits, too many requests, or service quota exhaustion. Retry after backoff or request a quota increase.
+- `aws-access` — IAM authorization denied for Bedrock invocation. Verify the role/user can call `bedrock:InvokeModel` for the target model ARN and region.
+- `aws-model` — invalid model IDs, unavailable models, region mismatches, model timeout, or model-not-ready responses. Verify `MODEL_OVERRIDE` and the AWS region.
+
+Treat these the same way you treat a stale codex `auth.json`: the underlying SDK is the source of truth, but the adapter now turns known AWS SDK failures into structured task failures.
 
 This is intentionally the same pattern codex uses for OAuth credentials (`codexAuthFileExists` → `presenceCheckOk` in [`src/commands/provider-credentials.ts`](https://github.com/desplega-ai/agent-swarm/blob/main/src/commands/provider-credentials.ts)) — presence-only gate, runtime validation owned by the adapter/SDK, no upstream call from agent-swarm. pi-ai does not currently expose a Bedrock-specific credential check we could call; if it does in the future, the live-test branch can be upgraded without touching the boot gate.
 

--- a/runbooks/harness-providers.md
+++ b/runbooks/harness-providers.md
@@ -58,7 +58,8 @@ When `MODEL_OVERRIDE=amazon-bedrock/<model-id>` (e.g. `amazon-bedrock/anthropic.
 - Any source the AWS SDK accepts works: `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (+ optional `AWS_SESSION_TOKEN`), `AWS_PROFILE` + `~/.aws/credentials`, SSO sessions in `~/.aws/config`, EC2 IMDS / ECS task role, web-identity / OIDC, `credential_process`, assume-role chains.
 - `AWS_REGION` (or `AWS_DEFAULT_REGION`) is required by the SDK and must be a Bedrock-enabled region.
 - The boot credential gate (`checkPiMonoCredentials`) short-circuits to `satisfiedBy: "sdk-delegated"` without inspecting any AWS env var or file. The worker does **not** park in `credential-wait` for Bedrock — even with no creds visible to agent-swarm, it claims tasks.
-- Credential errors surface at the first Bedrock inference call as an AWS SDK error in the session log (scrubbed via `scrubSecrets` at egress). Treat this the same as a codex `auth.json` failure: the adapter/SDK is the source of truth, not the boot gate.
+- Bedrock runtime failures surface as structured task failures. pi-mono captures the pi-coding-agent terminal event and emits a normalized `error` `ProviderEvent`; `waitForCompletion()` returns `exitCode: 1`, `isError: true`, and the same `errorCategory` / `failureReason`.
+- AWS SDK failures are categorized as `aws-auth` (missing/expired/invalid credentials), `aws-throttle` (rate limits or quota), `aws-access` (IAM denial), or `aws-model` (invalid/unavailable model, region mismatch, timeout, or model-not-ready). Treat these the same as a codex `auth.json` failure: the adapter/SDK is the source of truth, not the boot gate.
 - This is the closest precedent to codex's "presence-only" pattern (`codexAuthFileExists` → `presenceCheckOk`). If pi-ai later exposes a `validateBedrockCredentials` helper, the live-test branch in `validateProviderCredentials` can be upgraded without touching the boot gate.
 
 ## Native session resume is deprecated (2026-05-28)

--- a/src/providers/pi-mono-adapter.ts
+++ b/src/providers/pi-mono-adapter.ts
@@ -25,6 +25,7 @@ import {
   SessionManager,
 } from "@earendil-works/pi-coding-agent";
 import { type TSchema, Type } from "typebox";
+import { classifyAwsSdkError } from "../utils/aws-error-classifier";
 import { scrubSecrets } from "../utils/secret-scrubber";
 import { readPkgVersion } from "./harness-version";
 import { createSwarmHooksExtension } from "./pi-mono-extension";
@@ -361,6 +362,18 @@ export class PiMonoSession implements ProviderSession {
    * surface it directly.
    */
   private prevOutputTokens = 0;
+  /**
+   * Terminal error message captured from structured pi-coding-agent events.
+   *
+   * Set by `message_end` (assistant turn with `stopReason==='error'` — covers
+   * NON-retryable failures, including AWS auth which never enters pi's retry
+   * loop) and by `auto_retry_end` with `success:false` (the definitive terminal
+   * failure after the retryable class — throttle / 5xx / timeout — exhausts).
+   * Cleared on recovery: a successful `message_end` or an `auto_retry_end` with
+   * `success:true` resets it to null, so a recovered error never surfaces as a
+   * false failure. Evaluated once at session end in `runSession()`.
+   */
+  private terminalError: string | null = null;
 
   constructor(agentSession: AgentSession, config: ProviderSessionConfig, createdSymlink: boolean) {
     this.agentSession = agentSession;
@@ -425,6 +438,25 @@ export class PiMonoSession implements ProviderSession {
     switch (event.type) {
       case "message_end": {
         // Pi emits message_end for user, assistant, and tool-result messages.
+        // An assistant turn that ended in `stopReason==='error'` is a failed
+        // turn — track it as the (so far) terminal error. This is the ONLY
+        // structured signal for NON-retryable failures (AWS auth: ExpiredToken
+        // / CredentialsProviderError), which never enter pi's retry loop.
+        const endMsg = event.message as {
+          role?: string;
+          stopReason?: string;
+          errorMessage?: string;
+        };
+        if (endMsg.role === "assistant") {
+          if (endMsg.stopReason === "error") {
+            // Candidate terminal failure. May still be cleared by a successful
+            // retry (auto_retry_end success / a later good message_end).
+            this.terminalError = endMsg.errorMessage ?? this.terminalError ?? "Unknown error";
+            break;
+          }
+          // A successful assistant turn means any prior error has recovered.
+          this.terminalError = null;
+        }
         // Only assistant text should be printed or used as fallback output.
         const text = extractPiAssistantText(event.message);
         if (text) {
@@ -518,12 +550,18 @@ export class PiMonoSession implements ProviderSession {
           result: event.result,
         });
         break;
-      case "auto_retry_start":
-        this.emit({
-          type: "raw_stderr",
-          content: `[pi-mono] Auto-retry attempt ${event.attempt}/${event.maxAttempts}: ${event.errorMessage}\n`,
-        });
+      case "auto_retry_end": {
+        // Definitive terminal signal for the RETRYABLE error class
+        // (throttle / 5xx / timeout). pi-coding-agent emits success:false with
+        // `finalError` only after every retry attempt is exhausted; success:true
+        // means the turn recovered, so clear any tracked error.
+        if (event.success) {
+          this.terminalError = null;
+        } else {
+          this.terminalError = event.finalError ?? this.terminalError ?? "Unknown error";
+        }
         break;
+      }
     }
   }
 
@@ -541,6 +579,26 @@ export class PiMonoSession implements ProviderSession {
       const stats = this.agentSession.getSessionStats();
       const cost = this.buildCostData(stats);
 
+      // A structured terminal error from pi-coding-agent events is failure by
+      // definition (the agent already exhausted retries or hit a non-retryable
+      // error). Surface it so the session-chat red box fires and the task fails,
+      // exactly like sibling adapters. AWS errors get a categorized, actionable
+      // message; anything else surfaces its raw error text.
+      if (this.terminalError) {
+        const classification = classifyAwsSdkError(this.terminalError);
+        const message = classification?.message ?? this.terminalError;
+        const category = classification?.category;
+        this.emit({ type: "error", message, category });
+        return {
+          exitCode: 1,
+          sessionId: this._sessionId,
+          cost,
+          isError: true,
+          errorCategory: category,
+          failureReason: message,
+        };
+      }
+
       this.emit({
         type: "result",
         cost,
@@ -556,13 +614,26 @@ export class PiMonoSession implements ProviderSession {
       };
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
+      // Defense-in-depth: AWS SDK failures surface as structured events (handled
+      // above in runSession), not thrown exceptions, so this catch is for genuine
+      // unexpected throws (MCP / transport / etc). Still classify in case an AWS
+      // signature ever reaches here, so the red box fires like sibling adapters.
+      const awsCatchError = classifyAwsSdkError(errorMessage);
+      if (awsCatchError) {
+        this.emit({
+          type: "error",
+          message: awsCatchError.message,
+          category: awsCatchError.category,
+        });
+      }
       this.emit({ type: "raw_stderr", content: `[pi-mono] Error: ${errorMessage}\n` });
 
       return {
         exitCode: 1,
         sessionId: this._sessionId,
         isError: true,
-        failureReason: errorMessage,
+        errorCategory: awsCatchError?.category,
+        failureReason: awsCatchError?.message ?? errorMessage,
       };
     } finally {
       await this.logFileHandle.end();

--- a/src/tests/aws-error-classifier.test.ts
+++ b/src/tests/aws-error-classifier.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for `classifyAwsSdkError` in `src/utils/aws-error-classifier.ts`.
+ *
+ * Exercises all four error categories and the no-match path.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { classifyAwsSdkError } from "../utils/aws-error-classifier";
+
+describe("classifyAwsSdkError — aws-auth", () => {
+  test("ExpiredTokenException", () => {
+    const r = classifyAwsSdkError(
+      "ExpiredTokenException: The security token included in the request is expired",
+    );
+    expect(r).not.toBeNull();
+    expect(r!.category).toBe("aws-auth");
+    expect(r!.message).toContain("aws sso login");
+  });
+
+  test("ExpiredToken (without Exception suffix)", () => {
+    const r = classifyAwsSdkError("ExpiredToken: token expired");
+    expect(r?.category).toBe("aws-auth");
+  });
+
+  test("CredentialsProviderError", () => {
+    const r = classifyAwsSdkError("CredentialsProviderError: Could not load credentials");
+    expect(r?.category).toBe("aws-auth");
+  });
+
+  test("Unable to locate credentials", () => {
+    const r = classifyAwsSdkError(
+      'Unable to locate credentials. You can configure credentials by running "aws configure".',
+    );
+    expect(r?.category).toBe("aws-auth");
+  });
+
+  test("security token ... expired (lower-case)", () => {
+    const r = classifyAwsSdkError("The security token included in the request is expired");
+    expect(r?.category).toBe("aws-auth");
+  });
+
+  test("InvalidSignatureException", () => {
+    const r = classifyAwsSdkError(
+      "InvalidSignatureException: The request signature we calculated does not match the signature you provided",
+    );
+    expect(r?.category).toBe("aws-auth");
+  });
+
+  test("UnrecognizedClientException", () => {
+    const r = classifyAwsSdkError(
+      "UnrecognizedClientException: The security token included in the request is invalid",
+    );
+    expect(r?.category).toBe("aws-auth");
+  });
+});
+
+describe("classifyAwsSdkError — aws-throttle", () => {
+  test("ThrottlingException", () => {
+    const r = classifyAwsSdkError("ThrottlingException: Rate exceeded");
+    expect(r?.category).toBe("aws-throttle");
+    expect(r!.message).toContain("quota");
+  });
+
+  test("TooManyRequestsException", () => {
+    const r = classifyAwsSdkError("TooManyRequestsException: Too many requests");
+    expect(r?.category).toBe("aws-throttle");
+  });
+
+  test("ServiceQuotaExceededException", () => {
+    const r = classifyAwsSdkError(
+      "ServiceQuotaExceededException: You have exceeded your request quota for this service",
+    );
+    expect(r?.category).toBe("aws-throttle");
+  });
+
+  test("Rate exceeded (standalone phrase)", () => {
+    const r = classifyAwsSdkError("Rate exceeded. Reduce your request rate.");
+    expect(r?.category).toBe("aws-throttle");
+  });
+});
+
+describe("classifyAwsSdkError — aws-access", () => {
+  test("AccessDeniedException with bedrock:InvokeModel", () => {
+    const r = classifyAwsSdkError(
+      "AccessDeniedException: User: arn:aws:iam::123:user/dev is not authorized to perform: bedrock:InvokeModel on resource: arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2",
+    );
+    expect(r?.category).toBe("aws-access");
+    expect(r!.message).toContain("bedrock:InvokeModel");
+  });
+
+  test("not authorized to perform (phrase match)", () => {
+    const r = classifyAwsSdkError("User is not authorized to perform: bedrock:InvokeModel");
+    expect(r?.category).toBe("aws-access");
+  });
+});
+
+describe("classifyAwsSdkError — aws-model", () => {
+  test("ValidationException", () => {
+    const r = classifyAwsSdkError(
+      "ValidationException: Invocation of model ID anthropic.claude-v99 with on-demand throughput isn't supported",
+    );
+    expect(r?.category).toBe("aws-model");
+    expect(r!.message).toContain("MODEL_OVERRIDE");
+  });
+
+  test("ResourceNotFoundException", () => {
+    const r = classifyAwsSdkError("ResourceNotFoundException: Could not find model");
+    expect(r?.category).toBe("aws-model");
+  });
+
+  test("ModelTimeoutException", () => {
+    const r = classifyAwsSdkError(
+      "ModelTimeoutException: The model timed out processing your request",
+    );
+    expect(r?.category).toBe("aws-model");
+  });
+
+  test("ModelNotReadyException", () => {
+    const r = classifyAwsSdkError("ModelNotReadyException: The model is not ready for inference");
+    expect(r?.category).toBe("aws-model");
+  });
+});
+
+describe("classifyAwsSdkError — priority ordering", () => {
+  test("aws-auth wins over aws-model when both match (ExpiredToken + ValidationException)", () => {
+    // Should not happen in practice, but priority must be deterministic
+    const r = classifyAwsSdkError("ExpiredTokenException and also ValidationException");
+    expect(r?.category).toBe("aws-auth");
+  });
+});
+
+describe("classifyAwsSdkError — no-match", () => {
+  test("returns null for empty string", () => {
+    expect(classifyAwsSdkError("")).toBeNull();
+  });
+
+  test("returns null for unrelated error", () => {
+    expect(classifyAwsSdkError("TypeError: Cannot read property 'foo' of undefined")).toBeNull();
+  });
+
+  test("returns null for generic network error", () => {
+    expect(classifyAwsSdkError("ECONNREFUSED 127.0.0.1:3013")).toBeNull();
+  });
+
+  test("returns null for Claude API error (not AWS)", () => {
+    expect(classifyAwsSdkError("401 Unauthorized: Invalid API key")).toBeNull();
+  });
+});

--- a/src/tests/pi-mono-adapter.test.ts
+++ b/src/tests/pi-mono-adapter.test.ts
@@ -350,3 +350,322 @@ describe("Cost aggregation from SessionStats", () => {
     expect(cost.numTurns).toBe(0);
   });
 });
+
+// ============================================================================
+// AWS SDK error detection — event-driven PiMonoSession + classifyAwsSdkError
+//
+// Redesign (2026-06): detection is driven entirely by structured
+// pi-coding-agent events, NOT stderr scraping or auto_retry_start inference:
+//   - `message_end` with an assistant `stopReason:'error'` → the ONLY signal
+//     for NON-retryable failures, critically AWS auth (ExpiredToken /
+//     CredentialsProviderError), which never enter pi's _isRetryableError loop.
+//   - `auto_retry_end` with `success:false` + `finalError` → the definitive
+//     terminal failure for the RETRYABLE class (throttle / 5xx / timeout).
+//   - recovery (`message_end` success, or `auto_retry_end` success:true) clears
+//     the tracked error so a recovered turn never surfaces as a false failure.
+// ============================================================================
+
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import { PiMonoSession } from "../providers/pi-mono-adapter";
+import type { ProviderEvent, ProviderResult, ProviderSessionConfig } from "../providers/types";
+import { classifyAwsSdkError } from "../utils/aws-error-classifier";
+
+function makeSessionConfig(logFile: string): ProviderSessionConfig {
+  return {
+    prompt: "test prompt",
+    systemPrompt: "",
+    model: "amazon-bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
+    role: "worker",
+    agentId: "test-agent-id",
+    taskId: "test-task-id",
+    apiUrl: "http://localhost:3013",
+    apiKey: "test-key",
+    cwd: "/tmp",
+    logFile,
+    iteration: 1,
+  };
+}
+
+type AgentSessionEvent = Parameters<Parameters<AgentSession["subscribe"]>[0]>[0];
+
+/** Build a `message_end` event for an assistant turn that ended in error. */
+function errorMessageEnd(errorMessage: string): AgentSessionEvent {
+  return {
+    type: "message_end",
+    message: {
+      role: "assistant",
+      content: [],
+      stopReason: "error",
+      errorMessage,
+    },
+  } as unknown as AgentSessionEvent;
+}
+
+/** Build a `message_end` event for a successful assistant turn. */
+function successMessageEnd(text: string): AgentSessionEvent {
+  return {
+    type: "message_end",
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text }],
+      stopReason: "stop",
+    },
+  } as unknown as AgentSessionEvent;
+}
+
+/** Build an `auto_retry_end` event (terminal retryable failure / recovery). */
+function autoRetryEnd(success: boolean, finalError?: string): AgentSessionEvent {
+  return {
+    type: "auto_retry_end",
+    success,
+    attempt: 3,
+    ...(finalError ? { finalError } : {}),
+  } as unknown as AgentSessionEvent;
+}
+
+/**
+ * Mock AgentSession that replays a fixed list of structured events to its
+ * subscribers when `prompt()` is called, then resolves (no throw). This mirrors
+ * the real pi-coding-agent: AWS failures arrive as DATA via events, there is no
+ * exception to catch at the agent-swarm layer.
+ */
+function makeMockAgentSession(opts: {
+  events?: AgentSessionEvent[];
+  throwError?: string;
+}): AgentSession {
+  const listeners: Array<(event: AgentSessionEvent) => void> = [];
+  return {
+    sessionId: "mock-session-id",
+    isStreaming: false,
+    model: undefined,
+    subscribe(listener: (event: AgentSessionEvent) => void) {
+      listeners.push(listener);
+      return () => {
+        const idx = listeners.indexOf(listener);
+        if (idx >= 0) listeners.splice(idx, 1);
+      };
+    },
+    async prompt() {
+      for (const event of opts.events ?? []) {
+        for (const l of listeners) l(event);
+      }
+      if (opts.throwError) throw new Error(opts.throwError);
+    },
+    getContextUsage: () => null,
+    getSessionStats: () => ({
+      tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      cost: 0,
+      userMessages: 0,
+      assistantMessages: 0,
+    }),
+    abort: async () => {},
+    dispose: () => {},
+  } as unknown as AgentSession;
+}
+
+const tmpLogDir = `/tmp/pi-mono-aws-test-${Date.now()}`;
+
+beforeAll(() => {
+  mkdirSync(tmpLogDir, { recursive: true });
+});
+
+afterAll(() => {
+  rmSync(tmpLogDir, { recursive: true, force: true });
+});
+
+async function runWithEvents(events: AgentSessionEvent[]): Promise<{
+  events: ProviderEvent[];
+  result: ProviderResult;
+}> {
+  const logFile = join(tmpLogDir, `evt-${Date.now()}-${Math.random().toString(36).slice(2)}.log`);
+  const session = new PiMonoSession(
+    makeMockAgentSession({ events }),
+    makeSessionConfig(logFile),
+    false,
+  );
+  const emitted: ProviderEvent[] = [];
+  session.onEvent((e) => emitted.push(e));
+  const result = await session.waitForCompletion();
+  return { events: emitted, result };
+}
+
+function findError(events: ProviderEvent[]): Extract<ProviderEvent, { type: "error" }> | undefined {
+  return events.find((e) => e.type === "error") as
+    | Extract<ProviderEvent, { type: "error" }>
+    | undefined;
+}
+
+describe("PiMonoSession — NON-retryable AWS auth via message_end stopReason:'error'", () => {
+  // ORIGINAL-BUG REGRESSION TEST. AWS auth errors (ExpiredToken /
+  // CredentialsProviderError) are non-retryable: pi's _isRetryableError regex
+  // matches throttle/429/5xx/timeout but NOT auth tokens, so they never enter
+  // the retry loop. The ONLY structured signal is a `message_end` assistant
+  // turn with stopReason:'error'. This is the Commander's original silent-fail.
+  test("ExpiredToken stopReason:'error' → type:error category aws-auth + terminal isError", async () => {
+    const { events, result } = await runWithEvents([
+      errorMessageEnd(
+        "ExpiredTokenException: The security token included in the request is expired",
+      ),
+    ]);
+    const errorEvent = findError(events);
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent?.category).toBe("aws-auth");
+    expect(errorEvent?.message).toContain("aws sso login");
+    expect(result.isError).toBe(true);
+    expect(result.errorCategory).toBe("aws-auth");
+    expect(result.exitCode).toBe(1);
+    expect(result.failureReason).toContain("aws sso login");
+  });
+
+  test("CredentialsProviderError stopReason:'error' → aws-auth terminal failure", async () => {
+    const { events, result } = await runWithEvents([
+      errorMessageEnd("CredentialsProviderError: Could not load credentials from any providers"),
+    ]);
+    expect(findError(events)?.category).toBe("aws-auth");
+    expect(result.errorCategory).toBe("aws-auth");
+    expect(result.isError).toBe(true);
+  });
+
+  test("AccessDeniedException stopReason:'error' → aws-access terminal failure", async () => {
+    const { events, result } = await runWithEvents([
+      errorMessageEnd("AccessDeniedException: not authorized to perform: bedrock:InvokeModel"),
+    ]);
+    expect(findError(events)?.category).toBe("aws-access");
+    expect(result.errorCategory).toBe("aws-access");
+  });
+
+  test("ValidationException stopReason:'error' → aws-model terminal failure", async () => {
+    const { events, result } = await runWithEvents([
+      errorMessageEnd(
+        "ValidationException: Invocation of model ID x with on-demand throughput isn't supported",
+      ),
+    ]);
+    expect(findError(events)?.category).toBe("aws-model");
+    expect(result.errorCategory).toBe("aws-model");
+  });
+
+  test("non-AWS stopReason:'error' → still terminal failure, no AWS category", async () => {
+    const { events, result } = await runWithEvents([
+      errorMessageEnd("Some unrecognized provider failure"),
+    ]);
+    const errorEvent = findError(events);
+    // A terminal stopReason:'error' is a genuine failure by definition — it must
+    // surface (no silent green), but it carries no AWS category.
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent?.category).toBeUndefined();
+    expect(errorEvent?.message).toContain("Some unrecognized provider failure");
+    expect(result.isError).toBe(true);
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCategory).toBeUndefined();
+  });
+});
+
+describe("PiMonoSession — RETRYABLE failure via auto_retry_end success:false", () => {
+  test("throttle finalError after exhausted retries → aws-throttle terminal failure", async () => {
+    const { events, result } = await runWithEvents([
+      // Each retry attempt also produces an errored message_end before retrying;
+      // the definitive terminal marker is auto_retry_end success:false.
+      errorMessageEnd("ThrottlingException: Rate exceeded"),
+      autoRetryEnd(false, "ThrottlingException: Rate exceeded"),
+    ]);
+    const errorEvent = findError(events);
+    expect(errorEvent?.category).toBe("aws-throttle");
+    expect(result.errorCategory).toBe("aws-throttle");
+    expect(result.isError).toBe(true);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("5xx finalError (non-AWS) → terminal failure surfaced, no AWS category", async () => {
+    const { events, result } = await runWithEvents([
+      autoRetryEnd(false, "provider returned error: 503 service unavailable"),
+    ]);
+    expect(findError(events)).toBeDefined();
+    expect(result.isError).toBe(true);
+    expect(result.errorCategory).toBeUndefined();
+  });
+});
+
+describe("PiMonoSession — recovery clears the tracked error (no false failure)", () => {
+  // The never-cleared-on-recovery false-fail bug the redesign eliminates.
+  test("errored turn then successful auto_retry_end → success, output, no error", async () => {
+    const { events, result } = await runWithEvents([
+      errorMessageEnd("ThrottlingException: Rate exceeded"),
+      autoRetryEnd(true),
+      successMessageEnd("Recovered answer"),
+    ]);
+    expect(findError(events)).toBeUndefined();
+    expect(result.isError).toBe(false);
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toBe("Recovered answer");
+  });
+
+  test("errored turn then a later successful message_end → success, no error", async () => {
+    const { events, result } = await runWithEvents([
+      errorMessageEnd("ExpiredTokenException: token expired"),
+      successMessageEnd("Final answer after creds refreshed"),
+    ]);
+    expect(findError(events)).toBeUndefined();
+    expect(result.isError).toBe(false);
+    expect(result.output).toBe("Final answer after creds refreshed");
+  });
+
+  test("clean success path emits a result event and no error", async () => {
+    const { events, result } = await runWithEvents([successMessageEnd("All done")]);
+    expect(findError(events)).toBeUndefined();
+    expect(events.some((e) => e.type === "result")).toBe(true);
+    expect(result.isError).toBe(false);
+    expect(result.output).toBe("All done");
+  });
+});
+
+describe("PiMonoSession — thrown-exception catch path (defense-in-depth)", () => {
+  // AWS failures arrive as events, not throws, but a genuine unexpected throw
+  // (MCP/transport) must still fail the task; an AWS signature that reaches the
+  // catch is still classified.
+  async function runWithThrow(message: string) {
+    const logFile = join(
+      tmpLogDir,
+      `throw-${Date.now()}-${Math.random().toString(36).slice(2)}.log`,
+    );
+    const session = new PiMonoSession(
+      makeMockAgentSession({ throwError: message }),
+      makeSessionConfig(logFile),
+      false,
+    );
+    const emitted: ProviderEvent[] = [];
+    session.onEvent((e) => emitted.push(e));
+    const result = await session.waitForCompletion();
+    return { events: emitted, result };
+  }
+
+  test("thrown ExpiredToken → aws-auth error event + terminal failure", async () => {
+    const { events, result } = await runWithThrow(
+      "ExpiredTokenException: The security token is expired",
+    );
+    expect(findError(events)?.category).toBe("aws-auth");
+    expect(result.isError).toBe(true);
+    expect(result.errorCategory).toBe("aws-auth");
+  });
+
+  test("thrown non-AWS error → no AWS category, still terminal failure", async () => {
+    const { events, result } = await runWithThrow("ECONNREFUSED 127.0.0.1:3013");
+    expect(findError(events)).toBeUndefined();
+    expect(result.isError).toBe(true);
+    expect(result.errorCategory).toBeUndefined();
+  });
+});
+
+describe("classifyAwsSdkError — all 4 categories (quick summary)", () => {
+  test("all four categories are reachable", () => {
+    const cases: Array<[string, string]> = [
+      ["ExpiredTokenException: token expired", "aws-auth"],
+      ["ThrottlingException: rate exceeded", "aws-throttle"],
+      ["AccessDeniedException: no permission", "aws-access"],
+      ["ValidationException: bad model", "aws-model"],
+    ];
+    for (const [msg, expected] of cases) {
+      const r = classifyAwsSdkError(msg);
+      expect(r?.category).toBe(expected);
+    }
+  });
+});

--- a/src/utils/aws-error-classifier.ts
+++ b/src/utils/aws-error-classifier.ts
@@ -1,0 +1,97 @@
+/**
+ * AWS SDK error classifier for the pi-mono/Bedrock path.
+ *
+ * Provides a single shared matcher (`classifyAwsSdkError`) consumed by:
+ *   - `src/providers/pi-mono-adapter.ts`  — emits ProviderEvent {type:'error'} mid-stream
+ *   - `src/commands/runner.ts`            — backstop in the no-schema/no-progress branch
+ *
+ * The regex set lives here exactly once so the two sites never diverge.
+ */
+
+export type AwsErrorCategory = "aws-auth" | "aws-throttle" | "aws-access" | "aws-model";
+
+export interface AwsErrorClassification {
+  category: AwsErrorCategory;
+  /** Human-readable, actionable error message for the session-chat red box and task failureReason. */
+  message: string;
+}
+
+interface AwsErrorRule {
+  patterns: RegExp[];
+  category: AwsErrorCategory;
+  message: string;
+}
+
+/**
+ * Priority-ordered rules.  The first matching rule wins, so the most critical
+ * category (auth) takes precedence over the more generic ones (model errors).
+ */
+const AWS_ERROR_RULES: AwsErrorRule[] = [
+  {
+    // Expired / missing / invalid credentials
+    patterns: [
+      /ExpiredToken(?:Exception)?/,
+      /CredentialsProviderError/,
+      /Unable to locate credentials/,
+      /security token.*expired/i,
+      /expired.*security token/i,
+      /InvalidSignatureException/,
+      /UnrecognizedClientException/,
+    ],
+    category: "aws-auth",
+    message:
+      "AWS credentials have expired or are missing. " +
+      "Run `aws sso login` (or refresh your credentials via `aws configure`) and retry.",
+  },
+  {
+    // Rate limits and quota exceeded
+    patterns: [
+      /ThrottlingException/,
+      /TooManyRequestsException/,
+      /ServiceQuotaExceededException/,
+      /Rate exceeded/,
+    ],
+    category: "aws-throttle",
+    message:
+      "AWS Bedrock request was throttled (rate limit or quota exceeded). " +
+      "Wait and retry, or request a quota increase in the AWS Service Quotas console.",
+  },
+  {
+    // IAM / authorization denials
+    patterns: [/AccessDeniedException/, /not authorized to perform/i],
+    category: "aws-access",
+    message:
+      "AWS authorization denied for Bedrock. " +
+      "Verify the IAM role/user has the `bedrock:InvokeModel` permission for the target model ARN and region.",
+  },
+  {
+    // Bad model ID, region mismatch, model not ready
+    patterns: [
+      /ValidationException/,
+      /ResourceNotFoundException/,
+      /ModelTimeoutException/,
+      /ModelNotReadyException/,
+    ],
+    category: "aws-model",
+    message:
+      "AWS Bedrock model error: the model ID may be invalid, unavailable in this region, or not yet ready. " +
+      "Verify MODEL_OVERRIDE and the AWS region in your environment.",
+  },
+];
+
+/**
+ * Classify an error message string against known AWS SDK error patterns.
+ *
+ * Returns the first matching `{category, message}` pair (priority order:
+ * aws-auth → aws-throttle → aws-access → aws-model), or `null` if no
+ * known AWS SDK signature is found in `text`.
+ */
+export function classifyAwsSdkError(text: string): AwsErrorClassification | null {
+  if (!text) return null;
+  for (const rule of AWS_ERROR_RULES) {
+    if (rule.patterns.some((re) => re.test(text))) {
+      return { category: rule.category, message: rule.message };
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
AWS SDK auth/throttle/access/model failures from the Bedrock path were silently swallowed: the pi-mono provider exited 0 with no output, the runner laundered that into "completed (no output captured)", and the task turned green — most dangerously for AWS auth errors (ExpiredToken / CredentialsProviderError).

The AWS SDK exception is caught and converted to structured data two layers down in @earendil-works/pi-ai's amazon-bedrock provider (it sets `stopReason:'error'` + `errorMessage` and pushes a `{type:'error'}` part), so there is no exception to catch at the agent-swarm layer. Detection is therefore event-driven off pi-coding-agent's terminal signals.

`PiMonoSession` tracks a single `terminalError`, set/cleared by two structured events and evaluated once at session end:
  - `message_end` with an assistant turn `stopReason:'error'` — the only signal for non-retryable failures, notably AWS auth: pi's `_isRetryableError` matches throttle/429/5xx/timeout but not auth tokens, so auth never enters the retry loop.
  - `auto_retry_end` with `success:false` + `finalError` — the terminal failure for the retryable class once retries are exhausted.
  - a successful `message_end`, or `auto_retry_end` with `success:true`, clears the tracked error so a recovered transient failure does not fail the task.

On a terminal error, `classifyAwsSdkError` runs over the bounded `errorMessage`/`finalError`, the session emits `{type:'error', message, category}`, and returns `isError` + `errorCategory` + `failureReason` — the same output contract as the sibling adapters, so the session-chat error box and the task status agree.

- src/utils/aws-error-classifier.ts — shared matcher for the four categories (aws-auth / aws-throttle / aws-access / aws-model), unit-tested.
- src/providers/pi-mono-adapter.ts — terminalError tracking and emission.
- Tests: pi-mono-adapter.test.ts covers the event-driven paths, including a non-retryable AWS-auth case (ExpiredToken via stopReason:'error' resolving to category aws-auth + a failed task).