### PR TITLE
fix(opencode): raise server-start timeout to 30s (env-overridable)

### DIFF
--- a/src/providers/opencode-adapter.ts
+++ b/src/providers/opencode-adapter.ts
@@ -111,6 +111,11 @@ function defaultOpencodeSkillsDir(): string {
   return join(process.env.HOME ?? "/home/worker", ".opencode", "skills");
 }
 const MODEL_CACHE_REFRESH_TIMEOUT_MS = 15_000;
+// opencode cold-start on E2B disk regularly exceeds the SDK's 5s default
+// server-start timeout (@opencode-ai/sdk dist/server.js), failing the spawn with
+// "Timeout waiting for server to start after 5000ms". Override via
+// OPENCODE_SERVER_TIMEOUT_MS.
+const DEFAULT_SERVER_START_TIMEOUT_MS = 30_000;
 
 function isOpenRouterModel(model: string | undefined): boolean {
   return Boolean(model?.toLowerCase().startsWith("openrouter/"));
@@ -720,6 +725,7 @@ export class OpencodeAdapter implements ProviderAdapter {
       ({ client, server } = await createOpencode({
         hostname: "127.0.0.1",
         port: 0,
+        timeout: Number(process.env.OPENCODE_SERVER_TIMEOUT_MS) || DEFAULT_SERVER_START_TIMEOUT_MS,
         config: opencodeConfig,
       }));
     } finally {


### PR DESCRIPTION
opencode cold-start on E2B sandbox disks regularly exceeds the SDK's 5s default server-start timeout, failing the spawn with "Timeout waiting for server to start after 5000ms" — observed on **83% of opencode eval attempts** in E2B sandboxes (agent-swarm evals, round 5 finding).

Pass an explicit `timeout` to `createOpencode()`: `OPENCODE_SERVER_TIMEOUT_MS` when set, else 30s.

Cherry-picked from `feat/evals-subproject` (where it has been exercised across ~50 eval runs) so the fix reaches the released worker image + E2B templates without waiting for #737. With #754 merged, the next release's `-latest` templates will genuinely carry it.