### PR TITLE
feat(pi-mono): surface Bedrock probe status in the agent credentials UI

### DIFF
--- a/docs-site/content/docs/(documentation)/guides/harness-providers.mdx
+++ b/docs-site/content/docs/(documentation)/guides/harness-providers.mdx
@@ -168,6 +168,14 @@ Ids are matched exactly and the pi-ai id is stored/displayed (the id the harness
 
 The worker reports the intersected list to the API via the existing `PUT /api/agents/:id/credential-status` channel as an optional `bedrock` block inside `cred_status` (no new DB column — rides the migration 055 JSON column). The block carries: `{ region, probedAt, ready, models: [{id, name}], error? }`. It refreshes at boot and on a throttled ~5-minute interval, so access enabled after boot appears without a worker restart.
 
+#### Bedrock probe card (Credentials tab)
+
+A dedicated `AWS Bedrock` card appears in the Credentials tab for all pi-harness agents. It renders a read-only ready/blocked/pending classification with parity to the main credentials card, plus region, probe timestamp, usable model count, and error text when blocked.
+
+- 🟢 **Ready** — SDK credential chain valid; models enumerated.
+- 🔴 **Blocked** — probe failed; error text shown; worker is parked at `credential-wait`.
+- ⚫ **Pending** — worker hasn't reported yet (booting, or Bedrock mode not active).
+
 The dashboard model picker for the `pi` harness:
 - **Prefers the live list** when the worker has reported it.
 - **Falls back to the static `modelsdev-cache.json` snapshot** until the first worker report arrives.

--- a/runbooks/harness-providers.md
+++ b/runbooks/harness-providers.md
@@ -105,6 +105,16 @@ The dashboard's pi harness model picker prefers the worker-reported live list wh
 - The `validateProviderCredentials` live-test arm for `pi` + Bedrock is a pass-through (`presenceCheckOk`) — the real check is the probe above, not a second SDK call.
 - The API binary never imports `@aws-sdk/client-bedrock`; all SDK work is worker-side.
 
+### Bedrock probe card (Credentials tab)
+
+A dedicated **AWS Bedrock** card appears in the Credentials tab for all `pi`-harness agents. It renders a read-only ready/blocked/pending classification at parity with the main credentials card, plus region, probe timestamp, usable model count, and error text when blocked. Implemented in `ui/src/pages/agents/[id]/credentials-panel.tsx` (`BedrockProbeCard`).
+
+| Dot color | State | Meaning |
+|-----------|-------|---------|
+| Green | `ready` | SDK credential chain is valid; models enumerated. |
+| Red | `blocked` | Probe failed; error text shown. Worker is parked at `credential-wait`. |
+| Grey | `pending` | Worker hasn't reported yet (booting, or Bedrock mode not active). |
+
 ## Native session resume is deprecated (2026-05-28)
 
 The runner no longer asks any harness to resume a prior session. Follow-up continuity flows entirely through the bounded context preamble (`src/commands/context-preamble.ts`), which is rebuilt deterministically from the parent-task chain held in the API DB and survives worker-container restarts. The earlier path — `claude --resume <UUID>` / `codex.resumeThread(id)` / managed-cloud `events.list` replay — depended on an on-disk transcript that disappears on deploy/OOM/autoscaler reschedule; when it died, users perceived the agent as having forgotten the conversation.

--- a/src/tests/bedrock-model-groups.test.ts
+++ b/src/tests/bedrock-model-groups.test.ts
@@ -133,3 +133,4 @@ describe("modelGroupsForHarness — Bedrock group for pi harness", () => {
     expect(providerNames).toContain("Amazon Bedrock");
   });
 });
+

--- a/ui/src/pages/agents/[id]/credentials-panel.tsx
+++ b/ui/src/pages/agents/[id]/credentials-panel.tsx
@@ -1,4 +1,4 @@
-import type { Agent, AgentCredStatus } from "@/api/types";
+import type { Agent, AgentBedrockStatus, AgentCredStatus } from "@/api/types";
 import { HarnessCell } from "@/components/shared/harness-cell";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
@@ -61,10 +61,100 @@ function formatRelative(ms: number): string {
   return `${d}d ago`;
 }
 
+// ---------------------------------------------------------------------------
+// BedrockProbeCard — renders pi-harness Bedrock probe status with parity to
+// the overall CredentialsPanel tone/dot pattern.
+// ---------------------------------------------------------------------------
+
+function BedrockProbeCard({ bedrock }: { bedrock: AgentBedrockStatus | null | undefined }) {
+  const dot =
+    bedrock == null ? "bg-status-neutral" : bedrock.ready ? "bg-status-success" : "bg-status-error";
+  const ring =
+    bedrock == null
+      ? "border-status-neutral/30"
+      : bedrock.ready
+        ? "border-status-success/30"
+        : "border-status-error/30";
+  const label =
+    bedrock == null
+      ? "AWS probe pending"
+      : bedrock.ready
+        ? "AWS Bedrock ready"
+        : "AWS Bedrock blocked";
+  const help =
+    bedrock == null
+      ? "Worker hasn't reported Bedrock status yet — still booting, not in Bedrock mode, or CRED_CHECK_DISABLE is set."
+      : bedrock.ready
+        ? "Probe succeeded — the SDK credential chain is valid for this region."
+        : "Probe failed. Worker is parked at credential-wait. Check AWS credentials and AWS_REGION.";
+
+  return (
+    <Card className={cn("border", ring)}>
+      <CardContent className="p-4 space-y-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <span className={cn("h-2 w-2 rounded-full", dot)} />
+            <span className="font-semibold text-sm">{label}</span>
+          </div>
+          <p className="text-xs text-muted-foreground max-w-prose">{help}</p>
+        </div>
+
+        {bedrock != null ? (
+          <DefinitionList>
+            <InfoRow label="Probe status">
+              {bedrock.ready ? (
+                <Badge
+                  variant="outline"
+                  size="tag"
+                  className="border-status-success/30 text-status-success-strong"
+                >
+                  ready
+                </Badge>
+              ) : (
+                <Badge
+                  variant="outline"
+                  size="tag"
+                  className="border-status-error/30 text-status-error-strong"
+                >
+                  blocked
+                </Badge>
+              )}
+            </InfoRow>
+            <InfoRow label="Region">
+              <code className="text-xs">{bedrock.region}</code>
+            </InfoRow>
+            {bedrock.error ? (
+              <InfoRow label="Probe error">
+                <pre className="bg-muted/50 p-2 rounded text-xs font-mono whitespace-pre-wrap break-words">
+                  {bedrock.error}
+                </pre>
+              </InfoRow>
+            ) : null}
+            <InfoRow label="Usable models">
+              {bedrock.models.length > 0 ? (
+                <span>
+                  {bedrock.models.length} model{bedrock.models.length === 1 ? "" : "s"}
+                </span>
+              ) : (
+                <span className="text-muted-foreground">none reported</span>
+              )}
+            </InfoRow>
+            <InfoRow label="Probed">{formatRelative(bedrock.probedAt)}</InfoRow>
+          </DefinitionList>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
 export function CredentialsPanel({ agent }: { agent: Agent }) {
   const cred = agent.credStatus ?? null;
   const health = classify(cred);
   const tone = TONE[health];
+
+  // Show Bedrock probe card for pi-harness agents — whether or not a probe
+  // has run yet (the "pending" state is also informative).
+  const showBedrockPanel = agent.harnessProvider === "pi";
 
   return (
     <div className="space-y-4">
@@ -168,6 +258,9 @@ export function CredentialsPanel({ agent }: { agent: Agent }) {
           </DefinitionList>
         </CardContent>
       </Card>
+
+      {/* Bedrock probe status — pi harness only, parity with the main cred panel */}
+      {showBedrockPanel ? <BedrockProbeCard bedrock={agent.credStatus?.bedrock} /> : null}
 
       {/* Legacy waiting-for-credentials column is preserved below for older
           workers that haven't started reporting cred_status JSON yet. */}


### PR DESCRIPTION
Renders the pi-mono Amazon Bedrock credential probe (ready / blocked / pending, with region, usable-model count, and failure reason) in the agent Credentials panel, at parity with the existing provider status card. Documents the status display in the harness-providers runbook and guide. Builds on the earlier Bedrock credential probe and model enumeration work.