### PR TITLE
fix(hooks): isolate Stop-hook claude -p sub-sessions so claude-bridge metrics/transcripts survive

### DIFF
--- a/src/be/memory/raters/llm-client.ts
+++ b/src/be/memory/raters/llm-client.ts
@@ -127,13 +127,20 @@ export class ClaudeCliLlmRaterClient implements LlmRaterClient {
   async rate(input: LlmRaterInput): Promise<LlmRaterResult | null> {
     const prompt = buildPrompt(input);
     const tmpFile = `/tmp/llm-rater-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`;
+    // Isolate the inner `claude` into a throwaway cwd (inherited from bash) so
+    // it derives a distinct project slug instead of joining the agent's
+    // `~/.claude/projects/-workspace`. Defense-in-depth mirror of the fix in
+    // complete-structured.ts; this rater is dormant (off the live hook path).
+    const isolatedCwd = `${process.env.TMPDIR ?? "/tmp"}/llm-rater-cwd-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
     let stdout = "";
     try {
       await Bun.write(tmpFile, prompt);
+      await Bun.$`mkdir -p ${isolatedCwd}`.quiet().nothrow();
       const proc = Bun.spawn(
         ["bash", "-c", `cat "${tmpFile}" | claude -p --model ${this.model} --output-format json`],
         {
+          cwd: isolatedCwd,
           stdout: "pipe",
           stderr: "pipe",
           env: { ...process.env, SKIP_SESSION_SUMMARY: "1" },
@@ -151,6 +158,7 @@ export class ClaudeCliLlmRaterClient implements LlmRaterClient {
       } catch {
         // best-effort
       }
+      await Bun.$`rm -rf ${isolatedCwd}`.quiet().nothrow();
     }
 
     let envelope: ClaudeCliEnvelope;

--- a/src/utils/internal-ai/complete-structured.ts
+++ b/src/utils/internal-ai/complete-structured.ts
@@ -114,9 +114,19 @@ export async function defaultSpawnClaudeCli(
   // `runStopHookSessionSummary` honors this flag — same convention as the
   // `claude -p` shellout in `src/be/memory/raters/llm-client.ts`.
   env.SKIP_SESSION_SUMMARY = "1";
+  // Isolate this sub-session into a throwaway cwd so Claude Code derives a
+  // distinct project slug instead of joining `~/.claude/projects/-workspace`,
+  // where claude-bridge tails the main interactive session's transcript.
+  // Inheriting the hook's `/workspace` cwd forks/evicts that file, so real
+  // swarm tasks emit only system/init + a null-metrics result. Keeping the
+  // same $HOME/.claude.json (OAuth + pre-seeded trust) avoids any headless
+  // onboarding hang. Mirrors the temp-dir idiom in scripts/extract-schema.ts.
+  const isolatedCwd = `${process.env.TMPDIR ?? "/tmp"}/claude-summary-${crypto.randomUUID()}`;
+  await Bun.$`mkdir -p ${isolatedCwd}`.quiet().nothrow();
   const proc = Bun.spawn({
     cmd,
     env,
+    cwd: isolatedCwd,
     stdin: "pipe",
     stdout: "pipe",
     stderr: "pipe",
@@ -165,6 +175,7 @@ export async function defaultSpawnClaudeCli(
   } finally {
     clearTimeout(timeout);
     signal?.removeEventListener("abort", abortHandler);
+    await Bun.$`rm -rf ${isolatedCwd}`.quiet().nothrow();
   }
 }
 


### PR DESCRIPTION
## Problem

Every `claude-bridge` task (the Lead and all `claude`-provider workers) reports **$0 cost / 0 tokens / 0ms duration / 0 context** on the dashboard, and the session log shows **only `system/init` + `result`** — no intermediate assistant messages or tool calls. Non-bridge providers (codex/opencode/pi) are unaffected.

## Root cause

`claude-bridge` produces *everything* it streams to the swarm runner — the `assistant`/`tool_use`/`tool_result` events **and** the cost/token/duration metrics — by reshaping Claude's on-disk interactive transcript at `~/.claude/projects/<cwd-slug>/<sessionId>.jsonl`. For a task, cwd is `/workspace`, so the project slug is `-workspace`.

The agent-swarm **Stop hook** runs `runStopHookSessionSummary`, which shells out to `claude -p` sub-sessions:
- `src/utils/internal-ai/complete-structured.ts` (the live session-summarizer path)
- `src/be/memory/raters/llm-client.ts` (the LLM memory rater — currently dormant/off the live hook path, fixed here for defense-in-depth)

Neither `Bun.spawn` passes a `cwd`, so each sub-session **inherits the hook's `/workspace` cwd** and joins the **same `-workspace` Claude project** the main interactive session is writing to. The sub-session sharing that project forks/evicts the transcript file the bridge locked onto, so the bridge reads an empty/absent transcript and emits a null-metrics `result` with no streamed events. (The result *text* still arrives because the bridge falls back to the Stop hook's inline `last_assistant_message`.)

### Evidence

- In the prod Lead container, the `/workspace` transcript is absent even mid-run; 4 consecutive claude-bridge tasks recorded `$0 / 0 / 0`.
- **Proven lever:** running the bridge with `SKIP_SESSION_SUMMARY=1` (the existing recursion-guard that short-circuits `runStopHookSessionSummary` *before* the spawn) made the transcript **persist** and the metrics come through correctly (`cost $0.185, 14688 in / 7 out, 4456ms, model resolved`).
- The bridge itself is correct — in any cwd where the transcript survives it reshapes it fine (`hydrated … rows:18`).

## Fix

Give each hook-spawned `claude -p` sub-session a **throwaway cwd** (`/tmp/claude-summary-<uuid>`), so Claude derives a *distinct* project slug and never touches `~/.claude/projects/-workspace`. Created with `mkdir -p` before spawn, removed in the existing `finally` block — both best-effort `.nothrow()`.

Why `cwd`-isolation (not `CLAUDE_CONFIG_DIR`):
- Transcript content reaches the summarizer via **stdin**, so cwd never affects functionality.
- Keeps `$HOME/.claude.json` (OAuth + pre-seeded trust/onboarding), avoiding any headless trust/onboarding hang that a fresh `CLAUDE_CONFIG_DIR` could cause.
- The `SKIP_SESSION_SUMMARY` recursion guard and all summarizer/memory logic are **unchanged** — summarization and memory keep running, just out of the agent's project.

## Testing

- `bun tsc --noEmit`, `bun run lint` (biome), and the affected unit tests (`complete-structured`, memory-rater, `claude-stop-hook` — 64+9) all pass. Full suite passes 0-fail on a clean run (a couple of pre-existing env-dependent tests — codex-oauth/jira/github/skill-fs — flake intermittently and are unrelated to this change).
- Locally validated the fix's runtime behavior: `claude -p` (no `--dangerously-skip-permissions`, exactly as spawned) in a fresh untrusted temp cwd returns cleanly in ~4s with **no trust prompt/hang** and lands in a separate project dir — confirming the isolated cwd works and leaves `-workspace` untouched.

Note: the clobber is environment-specific to the prod Linux container and does not reproduce on macOS, so the definitive end-to-end confirmation (real task → non-zero metrics) is a post-deploy check; the causal proof above (`SKIP_SESSION_SUMMARY=1`) and the local isolation test cover the mechanism.

https://claude.ai/code/session_01SWyoA9yp8RrkLQte66AxeG
