### PR TITLE
fix(github): surface inline PR review comments so they aren't dropped

### DIFF
--- a/src/github/handlers.ts
+++ b/src/github/handlers.ts
@@ -3,6 +3,7 @@ import { findUserByExternalId } from "../be/users";
 import { resolveTemplate } from "../prompts/resolver";
 import { githubContextKey } from "../tasks/context-key";
 import { createTaskWithSiblingAwareness } from "../tasks/sibling-awareness";
+import { getInstallationToken } from "./app";
 import {
   detectMention,
   extractMentionContext,
@@ -936,6 +937,58 @@ export async function handleComment(
   return { created: true, taskId: task.id };
 }
 
+interface ReviewInlineComment {
+  id: number;
+  path: string;
+  line: number | null;
+  body: string;
+  html_url: string;
+  diff_hunk: string;
+}
+
+async function fetchReviewComments(
+  repo: string,
+  prNumber: number,
+  reviewId: number,
+  installationId: number,
+): Promise<ReviewInlineComment[]> {
+  const token = await getInstallationToken(installationId);
+  if (!token) {
+    return [];
+  }
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments`,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${token}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+    );
+    if (!response.ok) {
+      console.error(`[GitHub] Failed to fetch review inline comments: ${response.status}`);
+      return [];
+    }
+    const data = (await response.json()) as ReviewInlineComment[];
+    return Array.isArray(data) ? data : [];
+  } catch (error) {
+    console.error("[GitHub] Error fetching review inline comments:", error);
+    return [];
+  }
+}
+
+function buildInlineCommentsSection(comments: ReviewInlineComment[]): string {
+  if (comments.length === 0) return "";
+  const items = comments.map((c) => {
+    const loc = c.line ? `${c.path}:${c.line}` : c.path;
+    const hunk = c.diff_hunk ? `\n\`\`\`diff\n${c.diff_hunk.slice(0, 300)}\n\`\`\`` : "";
+    return `- **${loc}**${hunk}\n  > ${c.body}`;
+  });
+  return `\n\n## Inline review comments (${comments.length})\n\n${items.join("\n\n")}`;
+}
+
 /**
  * Handle pull_request_review events (submitted, edited, dismissed)
  *
@@ -963,15 +1016,21 @@ export async function handlePullRequestReview(
     return { created: false };
   }
 
-  // Skip "commented" reviews that are empty - these are often just line comments
-  // without an overall review body
-  if (review.state === "commented" && !review.body) {
+  // Deduplicate before making any API calls
+  const eventKey = `pr-review:${repository.full_name}:${pr.number}:${review.id}`;
+  if (isDuplicate(eventKey)) {
     return { created: false };
   }
 
-  // Deduplicate
-  const eventKey = `pr-review:${repository.full_name}:${pr.number}:${review.id}`;
-  if (isDuplicate(eventKey)) {
+  // Fetch inline comments now so we can decide whether to skip and include them in the task.
+  // Returns [] when no installation credentials are available (graceful degradation).
+  const inlineComments = installation?.id
+    ? await fetchReviewComments(repository.full_name, pr.number, review.id, installation.id)
+    : [];
+
+  // Skip "commented" reviews only when there is neither an overall body nor any inline
+  // comments — a body-less review with inline comments carries real reviewer feedback.
+  if (review.state === "commented" && !review.body && inlineComments.length === 0) {
     return { created: false };
   }
 
@@ -992,15 +1051,21 @@ export async function handlePullRequestReview(
 
   // Build task description
   const reviewBodySection = review.body ? `\n\nReview Comment:\n${review.body}` : "";
+  const inlineCommentsSection = buildInlineCommentsSection(inlineComments);
   const relatedTaskSection = existingTask
     ? `Related task: ${existingTask.id}\n🔀 Consider routing to the same agent working on the related task.\n`
     : "";
-  const reviewSuggestions =
+
+  const hasInlineComments = inlineComments.length > 0;
+  const baseReviewSuggestion =
     review.state === "approved"
       ? "💡 Suggested: Merge the PR or wait for additional reviews"
       : review.state === "changes_requested"
         ? "💡 Suggested: Address the requested changes and update the PR"
         : "💡 Suggested: Review the feedback and respond if needed";
+  const reviewSuggestions = hasInlineComments
+    ? `${baseReviewSuggestion}\n💬 Address EVERY inline comment. After pushing fixes, reply to and resolve each inline review thread on GitHub so the reviewer sees visible confirmation.`
+    : baseReviewSuggestion;
 
   const result = resolveTemplate(
     "github.pull_request.review_submitted",
@@ -1013,6 +1078,7 @@ export async function handlePullRequestReview(
       repo_full_name: repository.full_name,
       review_url: review.html_url,
       review_body_section: reviewBodySection,
+      inline_comments_section: inlineCommentsSection,
       related_task_section: relatedTaskSection,
       review_suggestions: reviewSuggestions,
     },

--- a/src/github/handlers.ts
+++ b/src/github/handlers.ts
@@ -946,6 +946,12 @@ interface ReviewInlineComment {
   diff_hunk: string;
 }
 
+function parseNextPageLink(linkHeader: string | null): string | null {
+  if (!linkHeader) return null;
+  const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+  return match ? (match[1] ?? null) : null;
+}
+
 async function fetchReviewComments(
   repo: string,
   prNumber: number,
@@ -956,26 +962,31 @@ async function fetchReviewComments(
   if (!token) {
     return [];
   }
+  const headers = {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const allComments: ReviewInlineComment[] = [];
+  let url: string | null =
+    `https://api.github.com/repos/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments?per_page=100`;
   try {
-    const response = await fetch(
-      `https://api.github.com/repos/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments`,
-      {
-        headers: {
-          Accept: "application/vnd.github+json",
-          Authorization: `Bearer ${token}`,
-          "X-GitHub-Api-Version": "2022-11-28",
-        },
-      },
-    );
-    if (!response.ok) {
-      console.error(`[GitHub] Failed to fetch review inline comments: ${response.status}`);
-      return [];
+    while (url) {
+      const response = await fetch(url, { headers });
+      if (!response.ok) {
+        console.error(`[GitHub] Failed to fetch review inline comments: ${response.status}`);
+        return allComments;
+      }
+      const page = (await response.json()) as ReviewInlineComment[];
+      if (Array.isArray(page)) {
+        allComments.push(...page);
+      }
+      url = parseNextPageLink(response.headers.get("link"));
     }
-    const data = (await response.json()) as ReviewInlineComment[];
-    return Array.isArray(data) ? data : [];
+    return allComments;
   } catch (error) {
     console.error("[GitHub] Error fetching review inline comments:", error);
-    return [];
+    return allComments;
   }
 }
 

--- a/src/github/templates.ts
+++ b/src/github/templates.ts
@@ -350,7 +350,7 @@ registerTemplate({
   defaultBody: `PR: {{pr_title}}
 Reviewer: {{sender_login}}
 Repo: {{repo_full_name}}
-URL: {{review_url}}{{review_body_section}}
+URL: {{review_url}}{{review_body_section}}{{inline_comments_section}}
 
 ---
 {{related_task_section}}{{@template[common.delegation_instruction]}}
@@ -363,7 +363,11 @@ URL: {{review_url}}{{review_body_section}}
     { name: "sender_login", description: "Reviewer login" },
     { name: "repo_full_name", description: "Repository full name (owner/repo)" },
     { name: "review_url", description: "Review HTML URL" },
-    { name: "review_body_section", description: "Review comment section or empty string" },
+    { name: "review_body_section", description: "Review overall body section or empty string" },
+    {
+      name: "inline_comments_section",
+      description: "Formatted inline review comments section or empty string",
+    },
     { name: "related_task_section", description: "Related task info or empty string" },
     { name: "review_suggestions", description: "Context-appropriate review suggestion" },
   ],

--- a/src/tests/github-handlers-inline-comments.test.ts
+++ b/src/tests/github-handlers-inline-comments.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for inline PR review comment surfacing in handlePullRequestReview.
+ *
+ * Covers:
+ * - CHANGES_REQUESTED review with inline comments → task description includes them
+ * - commented-no-body-with-inline-comments → task is created (not skipped)
+ * - commented-no-body-no-inline-comments → task is skipped (existing behavior preserved)
+ * - commented-no-body-no-installation → graceful fallback, task is skipped
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { unlink } from "node:fs/promises";
+import { closeDb, createAgent, getDb, initDb } from "../be/db";
+import { handleComment, handlePullRequestReview } from "../github/handlers";
+import { GITHUB_BOT_NAME } from "../github/mentions";
+import type { CommentEvent, PullRequestReviewEvent } from "../github/types";
+
+// Mock GitHub App credentials so fetchReviewComments can obtain a token
+// without a real RSA key. Must come before the handlers import is evaluated.
+mock.module("../github/app", () => ({
+  getInstallationToken: async (installationId: number) => {
+    if (installationId > 0) return "mock-token-for-tests";
+    return null;
+  },
+  isReactionsEnabled: () => false,
+  initGitHub: () => true,
+  resetGitHub: () => {},
+  getWebhookSecret: () => null,
+  isGitHubEnabled: () => true,
+  verifyWebhookSignature: async () => false,
+}));
+
+const TEST_DB_PATH = "./test-github-handlers-inline.sqlite";
+
+beforeAll(async () => {
+  await unlink(TEST_DB_PATH).catch(() => {});
+  await unlink(`${TEST_DB_PATH}-wal`).catch(() => {});
+  await unlink(`${TEST_DB_PATH}-shm`).catch(() => {});
+  initDb(TEST_DB_PATH);
+  createAgent({
+    id: "lead-inline-test",
+    name: "InlineTestLead",
+    status: "idle",
+    isLead: true,
+  });
+});
+
+afterAll(async () => {
+  closeDb();
+  await unlink(TEST_DB_PATH).catch(() => {});
+  await unlink(`${TEST_DB_PATH}-wal`).catch(() => {});
+  await unlink(`${TEST_DB_PATH}-shm`).catch(() => {});
+});
+
+beforeEach(() => {
+  getDb().prepare("DELETE FROM agent_tasks").run();
+});
+
+// ── Helpers ──
+
+const BASE_REPO = { full_name: "test/repo", html_url: "https://github.com/test/repo" };
+
+let reviewIdCounter = 9000;
+
+function makeReviewEvent(opts: {
+  state: "changes_requested" | "commented";
+  body: string | null;
+  installationId?: number;
+  prUserLogin?: string;
+}): PullRequestReviewEvent {
+  const id = ++reviewIdCounter;
+  return {
+    action: "submitted",
+    review: {
+      id,
+      body: opts.body,
+      state: opts.state,
+      html_url: `https://github.com/test/repo/pull/99#pullrequestreview-${id}`,
+      user: { login: "reviewer" },
+      submitted_at: "2026-01-01T00:00:00Z",
+    },
+    pull_request: {
+      number: 99,
+      title: "Bot PR",
+      body: null,
+      html_url: "https://github.com/test/repo/pull/99",
+      user: { login: opts.prUserLogin ?? GITHUB_BOT_NAME },
+      head: { ref: "feature" },
+      base: { ref: "main" },
+    },
+    repository: BASE_REPO,
+    sender: { login: "reviewer" },
+    ...(opts.installationId !== undefined ? { installation: { id: opts.installationId } } : {}),
+  };
+}
+
+const SAMPLE_INLINE_COMMENTS = [
+  {
+    id: 1001,
+    path: "src/domain_tables.go",
+    line: 77,
+    body: "This logic looks wrong — should use a map instead.",
+    html_url: "https://github.com/test/repo/pull/99#discussion_r1001",
+    diff_hunk: "@@ -75,6 +75,8 @@ func buildTable() {",
+  },
+  {
+    id: 1002,
+    path: "config/table-renderers.json",
+    line: 7,
+    body: "Why is this hardcoded? Should come from config.",
+    html_url: "https://github.com/test/repo/pull/99#discussion_r1002",
+    diff_hunk: "@@ -5,7 +5,9 @@ {",
+  },
+];
+
+function mockFetchWithComments(
+  comments: typeof SAMPLE_INLINE_COMMENTS | [],
+): ReturnType<typeof spyOn> {
+  return spyOn(globalThis, "fetch").mockImplementationOnce(
+    async () =>
+      new Response(JSON.stringify(comments), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  );
+}
+
+function getLastTaskText(): string | undefined {
+  const row = getDb()
+    .prepare<{ task: string }, never>("SELECT task FROM agent_tasks ORDER BY rowid DESC LIMIT 1")
+    .get();
+  return row?.task;
+}
+
+// ── Tests ──
+
+describe("inline review comment surfacing", () => {
+  test("CHANGES_REQUESTED review with inline comments: task includes path:line and bodies", async () => {
+    const fetchSpy = mockFetchWithComments(SAMPLE_INLINE_COMMENTS);
+
+    const event = makeReviewEvent({
+      state: "changes_requested",
+      body: "CI is not green",
+      installationId: 123,
+    });
+    const result = await handlePullRequestReview(event);
+
+    fetchSpy.mockRestore();
+
+    expect(result.created).toBe(true);
+    const text = getLastTaskText();
+    expect(text).toBeDefined();
+    expect(text).toContain("src/domain_tables.go:77");
+    expect(text).toContain("This logic looks wrong");
+    expect(text).toContain("config/table-renderers.json:7");
+    expect(text).toContain("Why is this hardcoded?");
+    expect(text).toContain("Inline review comments");
+    expect(text).toContain("reply to and resolve each inline review thread");
+  });
+
+  test("commented review with no body but with inline comments: task is created, not skipped", async () => {
+    const fetchSpy = mockFetchWithComments([SAMPLE_INLINE_COMMENTS[0]]);
+
+    const event = makeReviewEvent({ state: "commented", body: null, installationId: 123 });
+    const result = await handlePullRequestReview(event);
+
+    fetchSpy.mockRestore();
+
+    expect(result.created).toBe(true);
+  });
+
+  test("commented review with no body and no inline comments: task is skipped", async () => {
+    const fetchSpy = mockFetchWithComments([]);
+
+    const event = makeReviewEvent({ state: "commented", body: null, installationId: 123 });
+    const result = await handlePullRequestReview(event);
+
+    fetchSpy.mockRestore();
+
+    expect(result.created).toBe(false);
+  });
+
+  test("commented review with no body and no installation: graceful fallback, task is skipped", async () => {
+    const event = makeReviewEvent({ state: "commented", body: null });
+    const result = await handlePullRequestReview(event);
+    expect(result.created).toBe(false);
+  });
+
+  test("review comments fetch failure: task still created (graceful degradation)", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementationOnce(
+      async () => new Response("Internal Server Error", { status: 500 }),
+    );
+
+    const event = makeReviewEvent({
+      state: "changes_requested",
+      body: "Needs work",
+      installationId: 123,
+    });
+    const result = await handlePullRequestReview(event);
+
+    fetchSpy.mockRestore();
+
+    // Task should still be created even if the inline comments fetch fails
+    expect(result.created).toBe(true);
+    const text = getLastTaskText();
+    expect(text).toContain("Needs work");
+    // No inline comments section when fetch failed
+    expect(text).not.toContain("Inline review comments");
+  });
+
+  test("no-double-spawn: review-attached inline comment via pull_request_review_comment event does not create a second task", async () => {
+    // Step 1: submitted review creates exactly ONE bundle task
+    const fetchSpy = mockFetchWithComments(SAMPLE_INLINE_COMMENTS);
+    const reviewEvent = makeReviewEvent({
+      state: "changes_requested",
+      body: "Please address my comments",
+      installationId: 123,
+    });
+    const reviewResult = await handlePullRequestReview(reviewEvent);
+    fetchSpy.mockRestore();
+
+    expect(reviewResult.created).toBe(true);
+    const taskCountAfterReview = getDb()
+      .prepare<{ n: number }, never>("SELECT COUNT(*) AS n FROM agent_tasks")
+      .get()!.n;
+    expect(taskCountAfterReview).toBe(1);
+
+    // Step 2: GitHub also delivers the same inline comments as individual
+    // pull_request_review_comment events (no @agent-swarm mention). These
+    // must NOT spawn additional tasks — the mention gate in handleComment blocks them.
+    const inlineCommentEvent: CommentEvent = {
+      action: "created",
+      comment: {
+        id: SAMPLE_INLINE_COMMENTS[0].id,
+        body: SAMPLE_INLINE_COMMENTS[0].body, // no @agent-swarm mention
+        html_url: SAMPLE_INLINE_COMMENTS[0].html_url,
+        user: { login: "reviewer" },
+      },
+      pull_request: {
+        number: 99,
+        title: "Bot PR",
+        html_url: "https://github.com/test/repo/pull/99",
+      },
+      repository: BASE_REPO,
+      sender: { login: "reviewer" },
+    };
+    const commentResult = await handleComment(inlineCommentEvent, "pull_request_review_comment");
+    expect(commentResult.created).toBe(false);
+
+    // Total tasks must still be exactly 1 — no double-spawn
+    const taskCountAfter = getDb()
+      .prepare<{ n: number }, never>("SELECT COUNT(*) AS n FROM agent_tasks")
+      .get()!.n;
+    expect(taskCountAfter).toBe(1);
+  });
+});

--- a/src/tests/github-handlers-inline-comments.test.ts
+++ b/src/tests/github-handlers-inline-comments.test.ts
@@ -13,6 +13,16 @@ import { closeDb, createAgent, getDb, initDb } from "../be/db";
 import { handleComment, handlePullRequestReview } from "../github/handlers";
 import { GITHUB_BOT_NAME } from "../github/mentions";
 import type { CommentEvent, PullRequestReviewEvent } from "../github/types";
+import { getTemplateDefinition } from "../prompts/registry";
+
+// Side-effect import: registers all GitHub templates on first load
+import "../github/templates";
+
+async function ensureTemplatesRegistered(): Promise<void> {
+  if (getTemplateDefinition("github.pull_request.review_submitted")) return;
+  const ts = Date.now();
+  await import(`../github/templates?t=${ts}`);
+}
 
 // Mock GitHub App credentials so fetchReviewComments can obtain a token
 // without a real RSA key. Must come before the handlers import is evaluated.
@@ -51,7 +61,8 @@ afterAll(async () => {
   await unlink(`${TEST_DB_PATH}-shm`).catch(() => {});
 });
 
-beforeEach(() => {
+beforeEach(async () => {
+  await ensureTemplatesRegistered();
   getDb().prepare("DELETE FROM agent_tasks").run();
 });
 

--- a/src/tests/github-handlers-inline-comments.test.ts
+++ b/src/tests/github-handlers-inline-comments.test.ts
@@ -207,6 +207,48 @@ describe("inline review comment surfacing", () => {
     expect(text).not.toContain("Inline review comments");
   });
 
+  test("pagination: two-page review comment response surfaces all comments from both pages", async () => {
+    const page1 = [SAMPLE_INLINE_COMMENTS[0]];
+    const page2 = [SAMPLE_INLINE_COMMENTS[1]];
+    const nextUrl =
+      "https://api.github.com/repos/test/repo/pulls/99/reviews/9001/comments?per_page=100&page=2";
+
+    const fetchSpy = spyOn(globalThis, "fetch")
+      .mockImplementationOnce(
+        async () =>
+          new Response(JSON.stringify(page1), {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+              Link: `<${nextUrl}>; rel="next", <${nextUrl}>; rel="last"`,
+            },
+          }),
+      )
+      .mockImplementationOnce(
+        async () =>
+          new Response(JSON.stringify(page2), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      );
+
+    const event = makeReviewEvent({
+      state: "changes_requested",
+      body: "Multi-page review",
+      installationId: 123,
+    });
+    const result = await handlePullRequestReview(event);
+    fetchSpy.mockRestore();
+
+    expect(result.created).toBe(true);
+    const text = getLastTaskText();
+    expect(text).toBeDefined();
+    // Both pages of inline comments must appear in the task
+    expect(text).toContain("src/domain_tables.go:77"); // page 1 comment
+    expect(text).toContain("config/table-renderers.json:7"); // page 2 comment
+    expect(text).toContain("Inline review comments (2)");
+  });
+
   test("no-double-spawn: review-attached inline comment via pull_request_review_comment event does not create a second task", async () => {
     // Step 1: submitted review creates exactly ONE bundle task
     const fetchSpy = mockFetchWithComments(SAMPLE_INLINE_COMMENTS);


### PR DESCRIPTION
## Summary

- **Root cause**: `handlePullRequestReview` only read `review.body` to build the addressing task. Inline comments (delivered by GitHub as separate `pull_request_review_comment` events batched under the review) were never fetched, so workers never saw them. A `commented`-state review with no overall body but with 15 inline comments (PR #29197) was dropped entirely at L968.
- **Fetch inline comments** before the skip decision: `GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments` using the same installation-token pattern as `addReaction`.
- **Fix the early-return**: skip only when *both* `review.body` is empty *and* there are zero inline comments (fixes #29197 / #29287 cases).
- **Append a formatted section** to the task description: `path:line` + diff hunk (truncated to 300 chars) + body for every inline comment so the worker sees the full review.
- **Instruction update**: `review_suggestions` now explicitly says "reply to and resolve each inline review thread on GitHub" when inline comments are present, so workers don't just push code silently.
- **Template update**: `github.pull_request.review_submitted` gets the new `{{inline_comments_section}}` variable.
- **Pagination fix**: `fetchReviewComments` now requests `per_page=100` and follows `rel="next"` Link headers until exhausted — reviews with more than one page of inline comments no longer drop the overflow.
- **7 tests** in `github-handlers-inline-comments.test.ts` (mock.module + spyOn fetch): CHANGES_REQUESTED with inline comments, commented-no-body-with-inline (created), commented-no-body-empty (skipped), no-installation fallback, fetch-500 graceful degradation, **no-double-spawn invariant**, **two-page pagination regression guard**.

## Standalone inline comments — design decision (resolved 2026-06-18)

**Resolved by Daniel 2026-06-18**: work-creation is scoped to submitted reviews. The review body + all its inline comments are bundled into a single addressing task. Standalone inline comments outside a formal review still require an `@agent-swarm` mention (no one-task-per-line-comment), and review-attached line comments are handled via the bundle only to avoid double-spawning.

**Why the `handleComment` mention gate (L854) stays intact**:
- GitHub delivers a submitted review's inline comments as *both* a batch under the review *and* as individual `pull_request_review_comment` events. If the mention gate were relaxed, every reviewed line would create a duplicate task on top of the bundle.
- The bundle-at-review-level design avoids the per-comment-task spam tradeoff while guaranteeing workers see every inline comment.
- The no-double-spawn invariant is explicitly tested (see test 6 below).

## Planning artifacts

- [Research — bug root cause & where in the handler it was lost](https://live.agent-fs.dev/file/~/4fdbb8e2-f63b-4977-95be-6e18019f0e86/99d03b30-1ffd-4ddd-b332-1244b511b230/thoughts/5fd166b4-7d41-40ce-852f-9a3c2ea191a3/research/2026-06-18-inline-pr-review-comments.md)
- [Implementation plan — fetch approach, pagination, skip guard, tests, design decision](https://live.agent-fs.dev/file/~/4fdbb8e2-f63b-4977-95be-6e18019f0e86/99d03b30-1ffd-4ddd-b332-1244b511b230/thoughts/5fd166b4-7d41-40ce-852f-9a3c2ea191a3/plans/2026-06-18-inline-pr-review-comments.md)

## Test plan

- [x] `bun test src/tests/github-handlers.test.ts` — 12/12 pass (all existing)
- [x] `bun test src/tests/github-handlers-inline-comments.test.ts` — 7/7 pass (6 existing + 1 new pagination test)
- [x] `bun run lint` — clean
- [x] `bun run tsc:check` — no errors
- [x] `bun run check:db-boundary` — pass

Fixes: Capchase/client-monorepo #29197, #29249, #29287 review comments being dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)