### PR TITLE
fix(claude): gate claude-bridge on OAuth token; bump bridge to 0.2.2 (fixes $0/0/0 metrics)

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -238,7 +238,7 @@ RUN mkdir -p /opt/global-deps && cat > /opt/global-deps/package.json <<'EOF'
     "@desplega.ai/wts": "0.2.3",
     "@desplega.ai/localtunnel": "2.2.0",
     "@desplega.ai/qa-use": "2.19.0",
-    "@desplega.ai/claude-bridge": "0.2.1",
+    "@desplega.ai/claude-bridge": "0.2.2",
     "@desplega.ai/agent-fs": "0.9.0"
   },
   "overrides": {

--- a/docs-site/content/docs/(documentation)/guides/claude-bridge-experimental.mdx
+++ b/docs-site/content/docs/(documentation)/guides/claude-bridge-experimental.mdx
@@ -64,7 +64,8 @@ In-flight task sessions stay on the binary they spawned with; new spawns pick up
 - **Bun `>= 1.1`.** The npm package is `@desplega.ai/claude-bridge`; the published bin uses `#!/usr/bin/env bun`.
 - **`tmux` on `PATH`.** The bridge starts interactive Claude Code in a detached tmux pane. The swarm fail-fasts at session-create when `tmux` is missing.
 - **`claude` on `PATH`, version `>= 2.1.80`.** The bridge launches the local Claude CLI.
-- **Auth: unchanged.** The normal Claude harness credential check still applies: `CLAUDE_CODE_OAUTH_TOKEN` is preferred, with `ANTHROPIC_API_KEY` as the alternate accepted by the swarm. The bridge itself relies on the spawned `claude` process auth.
+- **Auth: an OAuth token is required.** The bridge authenticates the spawned `claude` from `CLAUDE_CODE_OAUTH_TOKEN` only — it deliberately strips `ANTHROPIC_*` from the launched process. Bridge mode is therefore gated on an OAuth token: if `SWARM_USE_CLAUDE_BRIDGE` is set but no `CLAUDE_CODE_OAUTH_TOKEN` is present, the adapter logs a warning and falls back to stock `claude` (which Claude Code authenticates fine from `ANTHROPIC_API_KEY`). API-key billing is identical headless vs interactive, so the bridge buys nothing there.
+- **Claude's on-disk transcript must stay enabled.** The bridge reconstructs *all* of its output — cost/token/duration metrics **and** the streamed assistant/tool-use events — by reshaping Claude Code's session transcript (`~/.claude/projects/<slug>/<sessionId>.jsonl`). Anything that suppresses that file breaks the bridge: notably `CLAUDE_CODE_SKIP_PROMPT_HISTORY=1` makes Claude Code emit only `init` + a null-metrics `result` ($0 / 0 tokens / 0ms), with answer text only via the inline `last_assistant_message`. The swarm's Claude runtime guardrails set that var; claude-bridge `>= 0.2.2` strips it from the launched `claude` so the transcript persists.
 
 ## Prompt pre-clear
 

--- a/src/providers/claude-adapter.ts
+++ b/src/providers/claude-adapter.ts
@@ -144,15 +144,46 @@ export function resolveClaudeBridgeEnabled(
   return parseClaudeBridgeEnabled(candidate);
 }
 
-function resolveClaudeBinaryArgv(
+/**
+ * Resolve the claude binary argv, gating claude-bridge on an OAuth token.
+ *
+ * claude-bridge exists to keep subscription/OAuth billing correct by driving
+ * the real interactive Claude TUI in tmux. It authenticates the child claude
+ * from `CLAUDE_CODE_OAUTH_TOKEN` only — it deliberately strips `ANTHROPIC_*`
+ * from the launched process — so it cannot run on an Anthropic API key. And
+ * API-key billing is identical headless vs interactive, so there's no reason to
+ * pay the bridge's complexity/footguns when only an API key is available.
+ *
+ * Therefore: only route through claude-bridge when an OAuth token is present.
+ * If the bridge is requested (`SWARM_USE_CLAUDE_BRIDGE`) but no OAuth token is
+ * set, fall back to stock `claude`, which Claude Code authenticates fine from
+ * the API key. `bridgeRequestedWithoutOAuth` lets the caller log why.
+ *
+ * Exported for unit testing.
+ */
+export function resolveClaudeBinaryArgv(
   resolvedEnv: Record<string, string | undefined>,
   fallbackEnv: Record<string, string | undefined> = process.env,
-): { raw: string; argv: string[]; useClaudeBridge: boolean } {
-  const useClaudeBridge = resolveClaudeBridgeEnabled(resolvedEnv, fallbackEnv);
+): {
+  raw: string;
+  argv: string[];
+  useClaudeBridge: boolean;
+  bridgeRequestedWithoutOAuth: boolean;
+} {
+  const bridgeRequested = resolveClaudeBridgeEnabled(resolvedEnv, fallbackEnv);
+  const hasOAuthToken = Boolean(
+    (resolvedEnv.CLAUDE_CODE_OAUTH_TOKEN ?? fallbackEnv.CLAUDE_CODE_OAUTH_TOKEN)?.trim(),
+  );
+  const useClaudeBridge = bridgeRequested && hasOAuthToken;
   const raw = useClaudeBridge
     ? CLAUDE_BRIDGE_BINARY
     : resolveClaudeBinary(resolvedEnv, fallbackEnv);
-  return { raw, argv: parseClaudeBinary(raw), useClaudeBridge };
+  return {
+    raw,
+    argv: parseClaudeBinary(raw),
+    useClaudeBridge,
+    bridgeRequestedWithoutOAuth: bridgeRequested && !hasOAuthToken,
+  };
 }
 
 function isLegacyClaudeBridgeCompatBinary(raw: string): boolean {
@@ -898,7 +929,13 @@ export class ClaudeAdapter implements ProviderAdapter {
       raw: claudeBinaryRaw,
       argv: claudeBinaryArgv,
       useClaudeBridge,
+      bridgeRequestedWithoutOAuth,
     } = resolveClaudeBinaryArgv(sourceEnv);
+    if (bridgeRequestedWithoutOAuth) {
+      console.warn(
+        `\x1b[33m[claude]\x1b[0m SWARM_USE_CLAUDE_BRIDGE is set but no CLAUDE_CODE_OAUTH_TOKEN is present — falling back to stock 'claude'. claude-bridge requires a subscription/OAuth token (it forwards only the OAuth token to claude and strips ANTHROPIC_*); API-key billing is identical headless vs interactive, so the bridge isn't needed.`,
+      );
+    }
     const isLegacyBridgeCompat = isLegacyClaudeBridgeCompatBinary(claudeBinaryRaw);
     const effectiveClaudeBinaryArgv = useClaudeBridge
       ? withClaudeBridgeAuthArgs(claudeBinaryArgv, sourceEnv)

--- a/src/tests/claude-adapter-binary.test.ts
+++ b/src/tests/claude-adapter-binary.test.ts
@@ -34,6 +34,7 @@ import {
   parseClaudeBridgeEnabled,
   preseedClaudeTrustDialog,
   resolveClaudeBinary,
+  resolveClaudeBinaryArgv,
   resolveClaudeBridgeEnabled,
 } from "../providers/claude-adapter";
 import type { ProviderSessionConfig } from "../providers/types";
@@ -214,6 +215,59 @@ describe("SWARM_USE_CLAUDE_BRIDGE boolean parsing", () => {
         { SWARM_USE_CLAUDE_BRIDGE: "true" },
       ),
     ).toBe(true);
+  });
+});
+
+describe("resolveClaudeBinaryArgv — claude-bridge requires an OAuth token", () => {
+  test("bridge requested + OAuth token present → routes to claude-bridge", () => {
+    const r = resolveClaudeBinaryArgv(
+      { SWARM_USE_CLAUDE_BRIDGE: "true", CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-x" },
+      {},
+    );
+    expect(r.useClaudeBridge).toBe(true);
+    expect(r.argv).toEqual(["claude-bridge"]);
+    expect(r.bridgeRequestedWithoutOAuth).toBe(false);
+  });
+
+  test("bridge requested + no OAuth (only API key) → falls back to stock claude", () => {
+    const r = resolveClaudeBinaryArgv(
+      { SWARM_USE_CLAUDE_BRIDGE: "true", ANTHROPIC_API_KEY: "sk-ant-api" },
+      {},
+    );
+    expect(r.useClaudeBridge).toBe(false);
+    expect(r.argv).toEqual(["claude"]);
+    expect(r.bridgeRequestedWithoutOAuth).toBe(true);
+  });
+
+  test("bridge requested + no creds at all → stock claude, flag set", () => {
+    const r = resolveClaudeBinaryArgv({ SWARM_USE_CLAUDE_BRIDGE: "1" }, {});
+    expect(r.useClaudeBridge).toBe(false);
+    expect(r.bridgeRequestedWithoutOAuth).toBe(true);
+  });
+
+  test("OAuth token from fallbackEnv (container env) also enables the bridge", () => {
+    const r = resolveClaudeBinaryArgv(
+      { SWARM_USE_CLAUDE_BRIDGE: "true" },
+      { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-fallback" },
+    );
+    expect(r.useClaudeBridge).toBe(true);
+    expect(r.bridgeRequestedWithoutOAuth).toBe(false);
+  });
+
+  test("whitespace-only OAuth token does not count as present", () => {
+    const r = resolveClaudeBinaryArgv(
+      { SWARM_USE_CLAUDE_BRIDGE: "true", CLAUDE_CODE_OAUTH_TOKEN: "   " },
+      {},
+    );
+    expect(r.useClaudeBridge).toBe(false);
+    expect(r.bridgeRequestedWithoutOAuth).toBe(true);
+  });
+
+  test("bridge not requested → never flagged, stock claude", () => {
+    const r = resolveClaudeBinaryArgv({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-x" }, {});
+    expect(r.useClaudeBridge).toBe(false);
+    expect(r.bridgeRequestedWithoutOAuth).toBe(false);
+    expect(r.argv).toEqual(["claude"]);
   });
 });
 
@@ -580,6 +634,26 @@ describe("CLAUDE_BINARY env override", () => {
     );
 
     expect(spawnedArgs[0][0]).toBe("claude");
+  });
+
+  test("SWARM_USE_CLAUDE_BRIDGE=true without OAuth token falls back to stock claude", async () => {
+    const origApiKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+    process.env.SWARM_USE_CLAUDE_BRIDGE = "true";
+    try {
+      const adapter = new ClaudeAdapter();
+      await adapter.createSession(makeConfig());
+      // No OAuth token → bridge is skipped, stock claude is used (Claude Code
+      // authenticates fine from ANTHROPIC_API_KEY; the bridge can't).
+      expect(spawnedArgs[0][0]).toBe("claude");
+    } finally {
+      if (origApiKey === undefined) {
+        delete process.env.ANTHROPIC_API_KEY;
+      } else {
+        process.env.ANTHROPIC_API_KEY = origApiKey;
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Two related Claude-harness changes + a doc note. Together they fix the **$0 cost / 0 tokens / 0ms** that every `claude-bridge` task has reported since #644, and make bridge selection safe.

### 1. Gate `claude-bridge` on an OAuth token
`claude-bridge` drives the real interactive Claude TUI to keep **subscription/OAuth billing** correct. It authenticates the spawned `claude` from `CLAUDE_CODE_OAUTH_TOKEN` only (it strips `ANTHROPIC_*`), so it can't run on an Anthropic API key — and API-key billing is identical headless vs interactive, so the bridge buys nothing there.

Now, when `SWARM_USE_CLAUDE_BRIDGE` is set but **no `CLAUDE_CODE_OAUTH_TOKEN`** is present, the adapter logs a warning and falls back to stock `claude` (Claude Code authenticates fine from `ANTHROPIC_API_KEY`). Previously it routed to the bridge regardless, yielding a broken-auth session unless the local-auth path happened to fire.

### 2. Bump `@desplega.ai/claude-bridge` 0.2.1 → 0.2.2 — fixes the $0/0/0 bug
The bridge reconstructs **all** of its output — metrics *and* streamed assistant/tool events — by reshaping Claude Code's on-disk transcript (`~/.claude/projects/<slug>/<sessionId>.jsonl`). #644's `buildClaudeCodeRuntimeEnv` sets `CLAUDE_CODE_SKIP_PROMPT_HISTORY=1`, which makes Claude Code **stop writing that transcript** → the bridge emits only `init` + a null-metrics `result` (answer text via the inline `last_assistant_message`).

Bridge **0.2.2** (desplega-ai/claude-bridge#14) strips `CLAUDE_CODE_SKIP_PROMPT_HISTORY` from the launched `claude` so the transcript persists. The guardrail is left intact for **non-bridge** (stock `claude`) sessions, which derive metrics from `claude -p`'s own result event and don't need the transcript.

### 3. Docs
The Claude Bridge guide now documents both: the OAuth requirement and the transcript dependency.

## Verification
- `bun test src/tests/claude-adapter-binary.test.ts` → 57 pass / 0 fail (7 new gate tests).
- `bun tsc:check` clean; biome clean on changed files.
- **End-to-end** in a Docker full-flow swarm (real OAuth worker, bridge 0.2.2 behavior): a real task went from `$0/0/0/0` → `cost $0.023148, 2 in / 33 out, 23133ms`; transcript persists; hooks fire and task progress/output are stored.

## Ordering
Pins `@desplega.ai/claude-bridge@0.2.2`, so **claude-bridge#14 must publish before this merges** (otherwise the worker image build can't install it).

## Supersedes #786
#786 isolated the Stop-hook summarizer's cwd — but that isn't the cause. With no transcript, the summary hook returns early (`hook.ts` transcript-length guard) and the summarizer never spawns. Closing #786 in favor of this.

https://claude.ai/code/session_01SWyoA9yp8RrkLQte66AxeG
