### PR TITLE
feat(cli): allow codex-login slots above 9

### DIFF
--- a/src/commands/codex-login.ts
+++ b/src/commands/codex-login.ts
@@ -182,7 +182,7 @@ Usage:
 Options:
   --api-url <url>    Swarm API URL (default: MCP_BASE_URL or http://localhost:3013)
   --api-key <key>    Swarm API key (default: API_KEY or 123123)
-  --slot <n>         Credential pool slot (0-9, default: next free slot)
+  --slot <n>         Credential pool slot (0-31, default: next free slot)
   -h, --help         Show this help
 
 Without flags, the command prompts interactively for the target API URL and
@@ -198,7 +198,7 @@ Deployed Codex workers automatically restore these credentials at boot.
 `);
 }
 
-const MAX_SLOT = 9;
+const MAX_SLOT = 31;
 
 export async function runCodexLogin(args: string[], deps: RunCodexLoginDeps = {}): Promise<void> {
   const resolveConfig = deps.resolveConfig ?? resolveCodexLoginConfig;

--- a/src/commands/codex-login.ts
+++ b/src/commands/codex-login.ts
@@ -182,7 +182,7 @@ Usage:
 Options:
   --api-url <url>    Swarm API URL (default: MCP_BASE_URL or http://localhost:3013)
   --api-key <key>    Swarm API key (default: API_KEY or 123123)
-  --slot <n>         Credential pool slot (0-31, default: next free slot)
+  --slot <n>         Credential pool slot (0-100, default: next free slot)
   -h, --help         Show this help
 
 Without flags, the command prompts interactively for the target API URL and
@@ -198,7 +198,7 @@ Deployed Codex workers automatically restore these credentials at boot.
 `);
 }
 
-const MAX_SLOT = 31;
+const MAX_SLOT = 100;
 
 export async function runCodexLogin(args: string[], deps: RunCodexLoginDeps = {}): Promise<void> {
   const resolveConfig = deps.resolveConfig ?? resolveCodexLoginConfig;

--- a/src/tests/codex-login.test.ts
+++ b/src/tests/codex-login.test.ts
@@ -246,7 +246,7 @@ describe("runCodexLogin", () => {
       resolveConfig: async () => ({
         apiUrl: "http://localhost:3013",
         apiKey: "test-key",
-        slot: 32,
+        slot: 101,
       }),
       login: mock(async () => {
         throw new Error("should not start oauth");
@@ -259,7 +259,7 @@ describe("runCodexLogin", () => {
     });
 
     expect(error).toHaveBeenCalledWith(
-      expect.stringContaining("--slot must be an integer between 0 and 31"),
+      expect.stringContaining("--slot must be an integer between 0 and 100"),
     );
     expect(exit).toHaveBeenCalledWith(1);
     expect(store).not.toHaveBeenCalled();
@@ -297,8 +297,8 @@ describe("runCodexLogin", () => {
     const error = mock(() => {});
     const exit = mock(() => {});
 
-    // All 32 slots occupied (0-31)
-    const allSlots = Array.from({ length: 32 }, (_, i) => ({
+    // All 101 slots occupied (0-100)
+    const allSlots = Array.from({ length: 101 }, (_, i) => ({
       slot: i,
       creds: { access: "", refresh: "", expires: 0, accountId: "" },
     }));

--- a/src/tests/codex-login.test.ts
+++ b/src/tests/codex-login.test.ts
@@ -246,7 +246,7 @@ describe("runCodexLogin", () => {
       resolveConfig: async () => ({
         apiUrl: "http://localhost:3013",
         apiKey: "test-key",
-        slot: 15,
+        slot: 32,
       }),
       login: mock(async () => {
         throw new Error("should not start oauth");
@@ -259,18 +259,46 @@ describe("runCodexLogin", () => {
     });
 
     expect(error).toHaveBeenCalledWith(
-      expect.stringContaining("--slot must be an integer between 0 and 9"),
+      expect.stringContaining("--slot must be an integer between 0 and 31"),
     );
     expect(exit).toHaveBeenCalledWith(1);
     expect(store).not.toHaveBeenCalled();
+  });
+
+  it("accepts slot 10 (previously rejected by the old 0-9 cap)", async () => {
+    let storedSlot: number | undefined;
+    const store = mock(async (_apiUrl: string, _apiKey: string, _creds: unknown, slot?: number) => {
+      storedSlot = slot;
+    });
+
+    await runCodexLogin([], {
+      resolveConfig: async () => ({
+        apiUrl: "http://localhost:3013",
+        apiKey: "test-key",
+        slot: 10,
+      }),
+      login: mock(async () => ({
+        access: "at_test",
+        refresh: "rt_test",
+        expires: Date.now() + 3600000,
+        accountId: "acc-test",
+      })),
+      store,
+      loadAllSlots: mock(async () => []),
+      log: () => {},
+      error: () => {},
+      exit: () => {},
+    });
+
+    expect(storedSlot).toBe(10);
   });
 
   it("errors when all slots are occupied", async () => {
     const error = mock(() => {});
     const exit = mock(() => {});
 
-    // All 10 slots occupied
-    const allSlots = Array.from({ length: 10 }, (_, i) => ({
+    // All 32 slots occupied (0-31)
+    const allSlots = Array.from({ length: 32 }, (_, i) => ({
       slot: i,
       creds: { access: "", refresh: "", expires: 0, accountId: "" },
     }));


### PR DESCRIPTION
## Summary

- Raises `MAX_SLOT` from `9` to `100` in `src/commands/codex-login.ts`, lifting the artificial ceiling on `--slot N` for `codex-login`.
- Updates `--help` text from `(0-9, ...)` to `(0-100, ...)` and the validation error message accordingly.
- Updates the out-of-range test (slot 101 now rejects), adds a new test asserting slot 10 is accepted, and expands the "all slots occupied" fixture to 101 slots.

## Why 100 and not unbounded?

`MAX_SLOT` serves double duty: it bounds the explicit-`--slot` validation (typo guard) and the auto-pick "next free slot" loop. Removing it entirely would require separating those two concerns. Raising to 100 is a minimal change that unblocks sandbox pool expansion while preserving the safety guard against fat-finger values like `--slot 10000`. This can be raised again trivially if the pool grows beyond 100 slots.

## Downstream caps found

None. Verified by grep across the full source:

- `src/providers/codex-oauth/storage.ts`: storage key `codex_oauth_${slot}`, discovery regex `/^codex_oauth_(\d+)$/` — unbounded.
- `src/commands/runner.ts`: enumerates slots via `loadAllCodexOAuthSlots`, `totalKeys = slots.length` — dynamic.
- `src/http/api-keys.ts` (`/api/keys/available`): returns dynamic indices — no upper bound.
- `src/providers/codex-adapter.ts`: reads `config.codexSlot ?? 0` — no bound check.
- DB migrations: no slot count constraint.

## Planning artifacts

- Research: agent-fs `thoughts/research/2026-06-22-codex-login-slot-cap.md`
- Plan: agent-fs `thoughts/0c1678c2-2d2a-4005-b911-a88abb9807b5/plans/2026-06-22-codex-login-higher-slots.md`

## Test plan

```bash
# Unit tests:
bun test src/tests/codex-login.test.ts
# Expected: 13 pass, 0 fail

# Lint + typecheck:
bun run lint && bun run tsc:check
```
