### PR TITLE
refactor: invert be/db→github via task-started event (cycle-break #4)

### DIFF
--- a/src/be/db.ts
+++ b/src/be/db.ts
@@ -1,7 +1,6 @@
 import { Database } from "bun:sqlite";
 import { parseProviderMeta } from "@/utils/provider-metadata.ts";
 import pkg from "../../package.json";
-import { addEyesReactionOnTaskStart } from "../github/task-reactions";
 import { type ModelTier, parseModelTier } from "../model-tiers";
 import { configureDbResolver } from "../prompts/resolver";
 import { telemetry } from "../telemetry";
@@ -111,6 +110,7 @@ import { normalizeDate, normalizeDateRequired } from "./date-utils";
 import { runMigrations } from "./migrations/runner";
 import { seedDefaultTemplates } from "./seed-prompt-templates";
 import { isReservedConfigKey, reservedKeyError } from "./swarm-config-guard";
+import { emitTaskStarted } from "./task-lifecycle-events";
 
 let db: Database | null = null;
 let sqliteVecAvailable = false;
@@ -1375,9 +1375,9 @@ export function startTask(taskId: string): AgentTask | null {
     } catch {}
   }
   const result = row ? rowToAgentTask(row) : null;
-  // Fire-and-forget: add eyes reaction for GitHub-sourced tasks
+  // Fire-and-forget: notify lifecycle subscribers (e.g. GitHub eyes reaction)
   if (result && oldTask.status !== "in_progress") {
-    addEyesReactionOnTaskStart(result).catch(() => {});
+    emitTaskStarted(result);
   }
   return result;
 }
@@ -3305,9 +3305,9 @@ export function claimTask(taskId: string, agentId: string): AgentTask | null {
   }
 
   const result = row ? rowToAgentTask(row) : null;
-  // Fire-and-forget: add eyes reaction for GitHub-sourced tasks
+  // Fire-and-forget: notify lifecycle subscribers (e.g. GitHub eyes reaction)
   if (result) {
-    addEyesReactionOnTaskStart(result).catch(() => {});
+    emitTaskStarted(result);
   }
   return result;
 }

--- a/src/be/task-lifecycle-events.ts
+++ b/src/be/task-lifecycle-events.ts
@@ -1,0 +1,42 @@
+import type { AgentTask } from "../types";
+
+/**
+ * Minimal in-process task-lifecycle event emitter.
+ *
+ * This exists to invert a layering dependency: the data layer (`be/db`) used to
+ * import a GitHub integration (`github/task-reactions`) so it could add an 👀
+ * reaction when a task started. Instead, `be/db` now emits a `task-started`
+ * event and the GitHub integration subscribes at API-server boot. The data layer
+ * no longer depends on any integration.
+ *
+ * Handlers run synchronously in registration order. Each is wrapped in try/catch
+ * so a throwing handler never breaks task processing. Handlers may return a
+ * promise; it is ignored (fire-and-forget), but any async rejection is swallowed
+ * so it never surfaces as an unhandled rejection. This preserves the original
+ * `addEyesReactionOnTaskStart(result).catch(() => {})` semantics exactly.
+ */
+
+type TaskStartedHandler = (task: AgentTask) => void | Promise<void>;
+
+const taskStartedHandlers: TaskStartedHandler[] = [];
+
+/** Register a handler invoked whenever a task transitions to `in_progress`. */
+export function onTaskStarted(handler: TaskStartedHandler): void {
+  taskStartedHandlers.push(handler);
+}
+
+/** Emit the task-started event. Never throws. */
+export function emitTaskStarted(task: AgentTask): void {
+  for (const handler of taskStartedHandlers) {
+    try {
+      const result = handler(task);
+      // Fire-and-forget: ignore the returned promise but swallow async
+      // rejections so a failing handler never crashes the process.
+      if (result && typeof (result as Promise<void>).catch === "function") {
+        (result as Promise<void>).catch(() => {});
+      }
+    } catch {
+      // A throwing handler must never break task processing.
+    }
+  }
+}

--- a/src/github/task-reactions.ts
+++ b/src/github/task-reactions.ts
@@ -1,3 +1,4 @@
+import { onTaskStarted } from "../be/task-lifecycle-events";
 import type { AgentTask } from "../types";
 import {
   addGraphQLReaction,
@@ -63,4 +64,24 @@ export async function addEyesReactionOnTaskStart(task: AgentTask): Promise<void>
     // Never fail the task start due to a reaction error
     console.error("[GitHub] Failed to add eyes reaction on task start:", error);
   }
+}
+
+let registered = false;
+
+/**
+ * Subscribe the GitHub eyes-reaction handler to the task-started lifecycle event.
+ *
+ * Call this once at API-server boot (from `createServer`). It is the API-side
+ * inverse of the old `be/db` → `github/task-reactions` import: the data layer now
+ * emits `task-started` and this integration reacts. Idempotent — `createServer`
+ * may run more than once per process, so repeated calls register only once.
+ *
+ * API-server only — never wire this on the worker side.
+ */
+export function registerGithubTaskReactions(): void {
+  if (registered) return;
+  registered = true;
+  onTaskStarted((task) => {
+    addEyesReactionOnTaskStart(task).catch(() => {});
+  });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import pkg from "../package.json";
 import { initDb } from "./be/db";
 import { startPricingRefreshLoop } from "./be/pricing-refresh";
 import { seedPricingFromModelsDev } from "./be/seed-pricing";
+import { registerGithubTaskReactions } from "./github/task-reactions";
 import { registerCancelTaskTool } from "./tools/cancel-task";
 import { registerContextDiffTool } from "./tools/context-diff";
 import { registerContextHistoryTool } from "./tools/context-history";
@@ -174,6 +175,10 @@ export function createServer() {
   // and the manual-override constants for runtime-fee / ACU pricing.
   seedPricingFromModelsDev();
   startPricingRefreshLoop();
+
+  // Subscribe API-side integrations to task-lifecycle events. Idempotent.
+  // (Inverts the old be/db → github/task-reactions import; see cycle-break #4.)
+  registerGithubTaskReactions();
 
   const server = new McpServer(
     {

--- a/src/tests/task-lifecycle-events.test.ts
+++ b/src/tests/task-lifecycle-events.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { emitTaskStarted, onTaskStarted } from "../be/task-lifecycle-events";
+import type { AgentTask } from "../types";
+
+function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    agentId: "11111111-2222-3333-4444-555555555555",
+    task: "Test task",
+    status: "in_progress",
+    source: "github",
+    priority: 50,
+    tags: [],
+    dependsOn: [],
+    wasPaused: false,
+    createdAt: new Date().toISOString(),
+    lastUpdatedAt: new Date().toISOString(),
+    ...overrides,
+  } as AgentTask;
+}
+
+describe("task-lifecycle-events", () => {
+  test("emitTaskStarted invokes a registered onTaskStarted handler with the task", () => {
+    const received: AgentTask[] = [];
+    onTaskStarted((task) => {
+      received.push(task);
+    });
+
+    const task = makeTask();
+    emitTaskStarted(task);
+
+    expect(received).toContain(task);
+  });
+
+  test("a throwing handler does not break emit and later handlers still run", () => {
+    let laterRan = false;
+    onTaskStarted(() => {
+      throw new Error("boom");
+    });
+    onTaskStarted(() => {
+      laterRan = true;
+    });
+
+    expect(() => emitTaskStarted(makeTask())).not.toThrow();
+    expect(laterRan).toBe(true);
+  });
+
+  test("a promise-rejecting handler is fire-and-forget and does not throw", () => {
+    onTaskStarted(() => Promise.reject(new Error("async boom")));
+
+    expect(() => emitTaskStarted(makeTask())).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Cycle-break #4 — invert be/db → github (event-based)

Inverts the data-layer→integration dependency so `src/be/db.ts` no longer imports the github integration.

- **New** `src/be/task-lifecycle-events.ts` — `onTaskStarted` / `emitTaskStarted` (handlers in try/catch, returned promises fire-and-forget; preserves the prior `.catch(()=>{})` semantics).
- `src/be/db.ts` — drops the `github/task-reactions` import; both call sites now `emitTaskStarted(result)`.
- `src/github/task-reactions.ts` — idempotent `registerGithubTaskReactions()`.
- `src/server.ts` — registers the github reaction once at API boot (API-side only).
- **New** `src/tests/task-lifecycle-events.test.ts`.

Prep for the future `@swarm/storage` extraction (the DB owner must not import an integration).

### Gates
tsc 0 · check-db-boundary pass · biome clean · task-lifecycle-events + task-reactions 17/0.

### Note
The originally-bundled cycle-break #2 (memory-raters hoist) was **dropped from this PR** — it only relocated the `utils→be` coupling rather than eliminating it, so it's deferred to the `@swarm/ai-llm` extraction phase (where `be/memory/raters/types.ts` folds in cleanly). The implemented hoist is preserved locally on `wip/raters-hoist-deferred`.
