### PR TITLE
fix(harness-provider): credential-aware fallback instead of unconditional claude

### DIFF
--- a/src/tests/harness-provider-resolution.test.ts
+++ b/src/tests/harness-provider-resolution.test.ts
@@ -111,6 +111,45 @@ describe("resolveHarnessProvider", () => {
   test("trims whitespace before validating", () => {
     expect(resolveHarnessProvider({ HARNESS_PROVIDER: "  codex  " }, {})).toBe("codex");
   });
+
+  test("prefers 'pi' when unset and only an OpenRouter key is present (fallbackEnv)", () => {
+    expect(resolveHarnessProvider({}, { OPENROUTER_API_KEY: "sk-or-v1-xxx" })).toBe("pi");
+  });
+
+  test("prefers 'pi' when unset and only an OpenRouter key is present (resolvedEnv)", () => {
+    expect(resolveHarnessProvider({ OPENROUTER_API_KEY: "sk-or-v1-xxx" }, {})).toBe("pi");
+  });
+
+  test("prefers 'pi' when invalid and only an OpenRouter key is present", () => {
+    expect(
+      resolveHarnessProvider(
+        { HARNESS_PROVIDER: "not-a-provider" },
+        { OPENROUTER_API_KEY: "sk-or-v1-xxx" },
+      ),
+    ).toBe("pi");
+  });
+
+  test("keeps 'claude' when both an OpenRouter key and an Anthropic API key are present", () => {
+    expect(
+      resolveHarnessProvider(
+        {},
+        { OPENROUTER_API_KEY: "sk-or-v1-xxx", ANTHROPIC_API_KEY: "sk-ant-xxx" },
+      ),
+    ).toBe("claude");
+  });
+
+  test("keeps 'claude' when both an OpenRouter key and a Claude Code OAuth token are present", () => {
+    expect(
+      resolveHarnessProvider(
+        {},
+        { OPENROUTER_API_KEY: "sk-or-v1-xxx", CLAUDE_CODE_OAUTH_TOKEN: "token-xxx" },
+      ),
+    ).toBe("claude");
+  });
+
+  test("keeps 'claude' when no credentials are present at all", () => {
+    expect(resolveHarnessProvider({}, {})).toBe("claude");
+  });
 });
 
 // ─── validateConfigValue ─────────────────────────────────────────────────────

--- a/src/utils/harness-provider.ts
+++ b/src/utils/harness-provider.ts
@@ -2,6 +2,33 @@ import { type ProviderName, ProviderNameSchema } from "../types";
 
 const SUPPORTED_PROVIDERS = ProviderNameSchema.options;
 
+function hasEnvValue(
+  key: string,
+  resolvedEnv: Record<string, string | undefined>,
+  fallbackEnv: Record<string, string | undefined>,
+): boolean {
+  return !!(resolvedEnv[key]?.trim() || fallbackEnv[key]?.trim());
+}
+
+/**
+ * Credential-aware default for when HARNESS_PROVIDER is unset or invalid.
+ * Unconditionally defaulting to "claude" leaves an OpenRouter-only swarm —
+ * e.g. every auto-deployed swarm, which is provisioned with
+ * OPENROUTER_API_KEY and NEVER an Anthropic credential — unable to
+ * authenticate at all. Prefer "pi" when an OpenRouter key is present and no
+ * Claude credential is; otherwise keep the original "claude" default.
+ */
+function credentialAwareDefault(
+  resolvedEnv: Record<string, string | undefined>,
+  fallbackEnv: Record<string, string | undefined>,
+): ProviderName {
+  const hasOpenRouterKey = hasEnvValue("OPENROUTER_API_KEY", resolvedEnv, fallbackEnv);
+  const hasClaudeCredential =
+    hasEnvValue("ANTHROPIC_API_KEY", resolvedEnv, fallbackEnv) ||
+    hasEnvValue("CLAUDE_CODE_OAUTH_TOKEN", resolvedEnv, fallbackEnv);
+  return hasOpenRouterKey && !hasClaudeCredential ? "pi" : "claude";
+}
+
 /**
  * Resolve the effective `HARNESS_PROVIDER` for a worker.
  *
@@ -9,24 +36,26 @@ const SUPPORTED_PROVIDERS = ProviderNameSchema.options;
  *   1. `resolvedEnv.HARNESS_PROVIDER` — value coming from `swarm_config`
  *      (overlay produced by `fetchResolvedEnv`, scoped repo > agent > global).
  *   2. `fallbackEnv.HARNESS_PROVIDER` — raw `process.env`.
- *   3. `"claude"` — final default.
+ *   3. Credential-aware default — "pi" when an OpenRouter key is present and
+ *      no Anthropic credential is (see `credentialAwareDefault`), else
+ *      `"claude"`.
  *
  * Invalid values (anything outside `ProviderNameSchema`) log a warning and
- * fall back to `"claude"` rather than throwing — boot must not be killed
- * by a typo'd swarm_config row.
+ * fall through to the credential-aware default rather than throwing — boot
+ * must not be killed by a typo'd swarm_config row.
  */
 export function resolveHarnessProvider(
   resolvedEnv: Record<string, string | undefined>,
   fallbackEnv: Record<string, string | undefined> = process.env,
 ): ProviderName {
   const candidate = resolvedEnv.HARNESS_PROVIDER?.trim() || fallbackEnv.HARNESS_PROVIDER?.trim();
-  if (!candidate) return "claude";
+  if (!candidate) return credentialAwareDefault(resolvedEnv, fallbackEnv);
   const parsed = ProviderNameSchema.safeParse(candidate);
   if (!parsed.success) {
     console.warn(
-      `[harness-provider] Invalid HARNESS_PROVIDER="${candidate}" (must be one of: ${SUPPORTED_PROVIDERS.join(", ")}); falling back to "claude"`,
+      `[harness-provider] Invalid HARNESS_PROVIDER="${candidate}" (must be one of: ${SUPPORTED_PROVIDERS.join(", ")}); falling back to credential-aware default`,
     );
-    return "claude";
+    return credentialAwareDefault(resolvedEnv, fallbackEnv);
   }
   return parsed.data;
 }


### PR DESCRIPTION
## Summary
- Auto-deployed swarms (agent-swarm-internal's card-free self-serve + register-flow paths) are provisioned with `OPENROUTER_API_KEY` only — never an Anthropic credential.
- `resolveHarnessProvider`'s unconditional `"claude"` fallback (when `HARNESS_PROVIDER` is unset or invalid) would leave such a swarm unable to authenticate at all if the pushed `HARNESS_PROVIDER` value ever failed to land (a bug, a race, a reconciliation delay).
- The control plane already guarantees `HARNESS_PROVIDER=pi` is explicitly pushed for every auto-deployed swarm, so this is **defense-in-depth**, not a fix for an active bug: when the value is missing/invalid, check which credentials are actually present and prefer `"pi"` when only an OpenRouter key is available. Falls through to the original `"claude"` default in every other case.
- Purely additive — no existing test sets `OPENROUTER_API_KEY`, so every existing assertion still passes unchanged. Added 6 new tests covering the credential-aware branch.
- `registerAgent()`'s separate inline fallback (`runner.ts:2147`) was intentionally NOT touched — confirmed both real call sites already pass `harnessProvider` explicitly, so that fallback is unreachable dead code today.

## Test plan
- [x] `tsc:check` clean
- [x] `lint` clean (biome, 1046 files)
- [x] Targeted test: `harness-provider-resolution.test.ts` 29/29
- [x] Broader regression sweep: every other `HARNESS_PROVIDER`-touching test file in the repo (status, agents-harness-provider, runner-fallback-output, e2b-dispatch, entrypoint-config-env-export, claude-managed-adapter, claude-adapter-binary, provider-adapter) — 255 tests total, 0 failures
- [x] Pre-commit hooks (biome, tsc, unit tests, DB boundary check) passed automatically

Claude-Session: https://claude.ai/code/session_01QHQtJNZEd5qNsfB7Zv8LYn