### PR TITLE
fix(ci): PR-based README→Pages sync + regenerate stale docs/index.md

### DIFF
--- a/.github/workflows/pages-sync-readme.yml
+++ b/.github/workflows/pages-sync-readme.yml
@@ -89,4 +89,9 @@ jobs:
               --body "Automated docs/index.md regeneration from README.md by pages-sync-readme.yml." \
               --head bot/sync-pages-readme
           fi
-          gh pr merge bot/sync-pages-readme --auto --squash
+
+          # "Allow auto-merge" is disabled repo-wide, so wait for the PR checks
+          # (docs-only → everything skips, ~2 min) and hand it to the merge queue.
+          gh pr checks bot/sync-pages-readme --watch --fail-fast || true
+          gh pr merge bot/sync-pages-readme --squash ||
+            echo "::warning::Could not enqueue the sync PR automatically — merge it manually."

--- a/.github/workflows/pages-sync-readme.yml
+++ b/.github/workflows/pages-sync-readme.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   sync:
@@ -18,8 +19,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Main is protected by rulesets + merge queue, so this workflow can no longer
+      # push to main directly (GH013). It opens an auto-merge PR instead, which needs
+      # a fine-grained PAT (contents + pull-requests: write) — PRs created with the
+      # default GITHUB_TOKEN do not trigger merge-gate, so they would never merge.
+      - name: Check SYNC_PAT is configured
+        env:
+          SYNC_PAT: ${{ secrets.SYNC_PAT }}
+        run: |
+          if [ -z "$SYNC_PAT" ]; then
+            echo "::error::SYNC_PAT secret is not configured. Create a fine-grained PAT with contents:write + pull_requests:write on this repo and add it as the SYNC_PAT actions secret."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.SYNC_PAT }}
 
       - name: Generate Pages index
         run: |
@@ -48,7 +64,9 @@ jobs:
           writeFileSync("docs/index.md", `${header}${readme}`);
           NODE
 
-      - name: Commit updated page
+      - name: Open auto-merge PR with updated page
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
         run: |
           if git diff --quiet -- docs/index.md; then
             echo "docs/index.md is already up to date."
@@ -57,6 +75,18 @@ jobs:
 
           git config user.name "desplega-bot"
           git config user.email "bot@desplega.ai"
+          git checkout -B bot/sync-pages-readme
           git add docs/index.md
           git commit -m "docs: sync github pages readme"
-          git push
+          git push -f origin bot/sync-pages-readme
+
+          # Reuse the open sync PR if one exists; otherwise create it. Then hand it to
+          # the merge queue once merge-gate reports (docs-only change → jobs skip fast).
+          EXISTING=$(gh pr list --head bot/sync-pages-readme --state open --json number --jq '.[0].number // empty')
+          if [ -z "$EXISTING" ]; then
+            gh pr create \
+              --title "docs: sync github pages readme" \
+              --body "Automated docs/index.md regeneration from README.md by pages-sync-readme.yml." \
+              --head bot/sync-pages-readme
+          fi
+          gh pr merge bot/sync-pages-readme --auto --squash

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ title: Agent Swarm
 
 > **Agent Swarm is your Company's Compounding Intelligence Layer. A system of AI agents that remember, reason, act and get better with every task.**
 
-> AI-Native · Compounds · Presence · Harness & LLM-Agnostic · Your Infra · Your Memory ·
+> AI-Native · Compounds · Presence · Harness & LLM-Agnostic · Your Infra · Your Memory · 
 
 ## What it does
 
@@ -129,12 +129,16 @@ Check [our templates](https://templates.agent-swarm.dev) for a quick start.
 
 - **Lead/worker orchestration in Docker** — isolated dev environments, priority queues, pause/resume across deploys. [Architecture →](https://docs.agent-swarm.dev/docs/architecture/overview)
 - **Compounding memory & persistent identity** — agents remember past sessions and evolve their own persona, expertise, and notes. [Memory →](https://docs.agent-swarm.dev/docs/architecture/memory) · [Agents →](https://docs.agent-swarm.dev/docs/architecture/agents)
+- **Hybrid memory recall + in-place edits** — memory retrieval can blend vector and full-text ranking, and agents can correct an existing memory without losing its ID or history. [Memory →](https://docs.agent-swarm.dev/docs/architecture/memory) · [MCP tools →](https://docs.agent-swarm.dev/docs/reference/mcp-tools#memory-tools)
 - **Multi-channel inputs** — Slack, GitHub, GitLab, email, WhatsApp, Linear, Jira, and the HTTP API all create tasks. [Integrations](#integrations)
 - **Workflow engine with Human-in-the-Loop** — DAG-based automation with approval gates, retries, and structured I/O. [Workflows →](https://docs.agent-swarm.dev/docs/concepts/workflows)
-- **Scheduled & recurring tasks** — cron-based automation for standing work. [Scheduling →](https://docs.agent-swarm.dev/docs/concepts/scheduling)
+- **Scheduled & recurring tasks** — cron-based automation for standing work, with schedules that can target agent tasks, workflows, or catalog scripts. [Scheduling →](https://docs.agent-swarm.dev/docs/concepts/scheduling)
 - **Durable script workflows** — launch background script runs, inspect their journals, and track them from the dashboard when a one-shot `script-run` is too small. [Guide →](https://docs.agent-swarm.dev/docs/guides/script-workflow-runs)
+- **Scripts as external APIs** — expose a saved script as a public `POST /api/x/script/<id>` endpoint with optional bearer auth, typed input validation, and per-endpoint usage tracking. [Guide →](https://docs.agent-swarm.dev/docs/guides/scripts-external-apis)
+- **Typed script API connections** — lead-managed OpenAPI connections let scripts call approved external APIs through generated `ctx.api.*` clients while credential bindings keep raw secrets out of source and args. [Guide →](https://docs.agent-swarm.dev/docs/guides/scripts-credential-broker)
 - **E2B-backed eval harness** — run a scenario × harness-config matrix against real swarm stacks, capture transcripts/artifacts, and grade outcomes with deterministic checks plus LLM or agentic judges. [Guide →](https://docs.agent-swarm.dev/docs/guides/evals-harness)
-- **Harness & LLM agnostic** — run with Claude Code, Claude Bridge, OpenAI Codex, pi-mono (Anthropic, OpenRouter, or Amazon Bedrock), Devin, Claude Managed Agents, raw LLMs, or opencode. Tasks, schedules, and workflow agent-task nodes can use portable `modelTier` intent (`smol`, `regular`, `smart`, `ultra`) and resolve it per worker/provider at run time. [Harness config →](https://docs.agent-swarm.dev/docs/guides/harness-configuration) · [Add a new provider →](https://docs.agent-swarm.dev/docs/guides/harness-providers)
+- **Harness & LLM agnostic** — run with Claude Code, Claude Bridge, OpenAI Codex, pi-mono (Anthropic, OpenRouter, or Amazon Bedrock), Devin, Claude Managed Agents, raw LLMs, or opencode. Tasks, schedules, and workflow agent-task nodes can use portable `modelTier` intent (`smol`, `regular`, `smart`, `ultra`), and operators can set per-agent reasoning effort (`off` → `xhigh`) without changing task payloads. [Harness config →](https://docs.agent-swarm.dev/docs/guides/harness-configuration) · [Add a new provider →](https://docs.agent-swarm.dev/docs/guides/harness-providers)
+- **OpenTelemetry traces plus OTLP cost/token metrics** — export API + worker traces and finalized session cost/token counters through the same OTLP pipeline for dashboarding in SigNoz, Datadog, Tempo, or another compatible backend. [Observability →](https://docs.agent-swarm.dev/docs/guides/observability-opentelemetry)
 - **Follow-up continuity across all harnesses** — child tasks inherit a bounded prior-task context preamble built from the task chain, so continuity survives restarts and works the same across every provider. [Task lifecycle →](https://docs.agent-swarm.dev/docs/concepts/task-lifecycle)
 - **Skills & MCP servers** — reusable procedural knowledge, bundled skill reference files, and per-agent MCP servers with scope cascade. [MCP tools →](https://docs.agent-swarm.dev/docs/reference/mcp-tools)
 - **External tool-router access** — the `x` command and `swarm_x` MCP tool let humans and agents execute approved third-party routes such as Composio without baking bespoke MCP servers first. [CLI →](https://docs.agent-swarm.dev/docs/reference/cli) · [Composio →](https://docs.agent-swarm.dev/docs/integrations/composio)


### PR DESCRIPTION
The merge queue's branch rules reject direct workflow pushes to main (GH013), which broke `pages-sync-readme.yml` on the #884 merge. The workflow now pushes to `bot/sync-pages-readme` and opens an auto-merge PR instead.

**Requires one manual step:** create a fine-grained PAT (this repo, contents:write + pull-requests:write) and add it as the `SYNC_PAT` actions secret — PRs created with the default `GITHUB_TOKEN` never trigger merge-gate, so they'd be stuck in the queue. Until the secret exists the workflow fails with a clear error message.

Also regenerates `docs/index.md` (stale since the rejected sync run).

https://claude.ai/code/session_01WZGQGM4knGUh4MJttKi3nh