### PR TITLE
fix(github): never silently drop inline PR review comments

### DIFF
--- a/src/github/handlers.ts
+++ b/src/github/handlers.ts
@@ -1010,8 +1010,7 @@ async function fetchReviewScopedComments(
   reviewId: number,
   headers: Record<string, string>,
 ): Promise<FetchReviewCommentsResult> {
-  const url =
-    `https://api.github.com/repos/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments?per_page=100`;
+  const url = `https://api.github.com/repos/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments?per_page=100`;
 
   let result = await fetchPaginatedReviewComments(url, headers);
   if (result.degraded || result.comments.length > 0) {
@@ -1177,9 +1176,10 @@ export async function handlePullRequestReview(
       : review.state === "changes_requested"
         ? "💡 Suggested: Address the requested changes and update the PR"
         : "💡 Suggested: Review the feedback and respond if needed";
-  const reviewSuggestions = hasInlineComments || degraded
-    ? `${baseReviewSuggestion}\n💬 Address EVERY inline comment. After pushing fixes, reply to and resolve each inline review thread on GitHub so the reviewer sees visible confirmation.`
-    : baseReviewSuggestion;
+  const reviewSuggestions =
+    hasInlineComments || degraded
+      ? `${baseReviewSuggestion}\n💬 Address EVERY inline comment. After pushing fixes, reply to and resolve each inline review thread on GitHub so the reviewer sees visible confirmation.`
+      : baseReviewSuggestion;
 
   const result = resolveTemplate(
     "github.pull_request.review_submitted",

--- a/src/github/handlers.ts
+++ b/src/github/handlers.ts
@@ -944,6 +944,12 @@ interface ReviewInlineComment {
   body: string;
   html_url: string;
   diff_hunk: string;
+  pull_request_review_id?: number | null;
+}
+
+interface FetchReviewCommentsResult {
+  comments: ReviewInlineComment[];
+  degraded: boolean;
 }
 
 function parseNextPageLink(linkHeader: string | null): string | null {
@@ -952,30 +958,38 @@ function parseNextPageLink(linkHeader: string | null): string | null {
   return match ? (match[1] ?? null) : null;
 }
 
-async function fetchReviewComments(
-  repo: string,
-  prNumber: number,
-  reviewId: number,
-  installationId: number,
-): Promise<ReviewInlineComment[]> {
-  const token = await getInstallationToken(installationId);
-  if (!token) {
-    return [];
-  }
-  const headers = {
+const REVIEW_COMMENTS_EMPTY_RETRY_DELAYS_MS = [1_500, 3_000, 3_000];
+const defaultReviewCommentsRetryDelay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+let reviewCommentsRetryDelay: (ms: number) => Promise<void> | void =
+  defaultReviewCommentsRetryDelay;
+
+export function setReviewCommentsRetryDelayForTests(
+  delay?: (ms: number) => Promise<void> | void,
+): void {
+  reviewCommentsRetryDelay = delay ?? defaultReviewCommentsRetryDelay;
+}
+
+function buildReviewCommentsHeaders(token: string): Record<string, string> {
+  return {
     Accept: "application/vnd.github+json",
     Authorization: `Bearer ${token}`,
     "X-GitHub-Api-Version": "2022-11-28",
   };
+}
+
+async function fetchPaginatedReviewComments(
+  initialUrl: string,
+  headers: Record<string, string>,
+): Promise<FetchReviewCommentsResult> {
   const allComments: ReviewInlineComment[] = [];
-  let url: string | null =
-    `https://api.github.com/repos/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments?per_page=100`;
+  let url: string | null = initialUrl;
   try {
     while (url) {
       const response = await fetch(url, { headers });
       if (!response.ok) {
         console.error(`[GitHub] Failed to fetch review inline comments: ${response.status}`);
-        return allComments;
+        return { comments: allComments, degraded: true };
       }
       const page = (await response.json()) as ReviewInlineComment[];
       if (Array.isArray(page)) {
@@ -983,11 +997,93 @@ async function fetchReviewComments(
       }
       url = parseNextPageLink(response.headers.get("link"));
     }
-    return allComments;
+    return { comments: allComments, degraded: false };
   } catch (error) {
     console.error("[GitHub] Error fetching review inline comments:", error);
-    return allComments;
+    return { comments: allComments, degraded: true };
   }
+}
+
+async function fetchReviewScopedComments(
+  repo: string,
+  prNumber: number,
+  reviewId: number,
+  headers: Record<string, string>,
+): Promise<FetchReviewCommentsResult> {
+  const url =
+    `https://api.github.com/repos/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments?per_page=100`;
+
+  let result = await fetchPaginatedReviewComments(url, headers);
+  if (result.degraded || result.comments.length > 0) {
+    return result;
+  }
+
+  for (const delayMs of REVIEW_COMMENTS_EMPTY_RETRY_DELAYS_MS) {
+    await reviewCommentsRetryDelay(delayMs);
+    result = await fetchPaginatedReviewComments(url, headers);
+    if (result.degraded || result.comments.length > 0) {
+      return result;
+    }
+  }
+
+  return result;
+}
+
+async function fetchPrLevelReviewComments(
+  repo: string,
+  prNumber: number,
+  reviewId: number,
+  headers: Record<string, string>,
+): Promise<FetchReviewCommentsResult> {
+  const url = `https://api.github.com/repos/${repo}/pulls/${prNumber}/comments?per_page=100`;
+  const result = await fetchPaginatedReviewComments(url, headers);
+  return {
+    comments: result.comments.filter((comment) => comment.pull_request_review_id === reviewId),
+    degraded: result.degraded,
+  };
+}
+
+function dedupeReviewComments(comments: ReviewInlineComment[]): ReviewInlineComment[] {
+  const byId = new Map<number, ReviewInlineComment>();
+  for (const comment of comments) {
+    if (!byId.has(comment.id)) {
+      byId.set(comment.id, comment);
+    }
+  }
+  return [...byId.values()];
+}
+
+async function fetchReviewComments(
+  repo: string,
+  prNumber: number,
+  reviewId: number,
+  installationId: number,
+): Promise<FetchReviewCommentsResult> {
+  const token = await getInstallationToken(installationId);
+  if (!token) {
+    return { comments: [], degraded: true };
+  }
+
+  const headers = buildReviewCommentsHeaders(token);
+  const scopedResult = await fetchReviewScopedComments(repo, prNumber, reviewId, headers);
+  if (!scopedResult.degraded && scopedResult.comments.length > 0) {
+    return scopedResult;
+  }
+
+  const fallbackResult = await fetchPrLevelReviewComments(repo, prNumber, reviewId, headers);
+  const mergedComments = dedupeReviewComments([
+    ...scopedResult.comments,
+    ...fallbackResult.comments,
+  ]);
+
+  if (fallbackResult.comments.length > 0) {
+    return { comments: mergedComments, degraded: false };
+  }
+
+  return {
+    comments: mergedComments,
+    degraded: scopedResult.degraded || fallbackResult.degraded,
+  };
 }
 
 function buildInlineCommentsSection(comments: ReviewInlineComment[]): string {
@@ -998,6 +1094,13 @@ function buildInlineCommentsSection(comments: ReviewInlineComment[]): string {
     return `- **${loc}**${hunk}\n  > ${c.body}`;
   });
   return `\n\n## Inline review comments (${comments.length})\n\n${items.join("\n\n")}`;
+}
+
+function buildInlineCommentsDegradedSection(repo: string, prNumber: number): string {
+  return `\n\n## ⚠️ Inline comments could NOT be auto-fetched
+The automatic inline-comment fetch failed or was unverifiable while the reviewer submitted this review. Inline comments ARE the change requests. BEFORE scoping or dispatching this task you MUST fetch them yourself:
+\`gh api "repos/${repo}/pulls/${prNumber}/comments?per_page=100" --jq '.[] | {id,path,line,body}'\`
+Reply to and resolve EVERY unresolved inline thread. Do NOT dispatch off the review body alone.`;
 }
 
 /**
@@ -1033,15 +1136,13 @@ export async function handlePullRequestReview(
     return { created: false };
   }
 
-  // Fetch inline comments now so we can decide whether to skip and include them in the task.
-  // Returns [] when no installation credentials are available (graceful degradation).
-  const inlineComments = installation?.id
+  const { comments: inlineComments, degraded } = installation?.id
     ? await fetchReviewComments(repository.full_name, pr.number, review.id, installation.id)
-    : [];
+    : { comments: [], degraded: true };
 
   // Skip "commented" reviews only when there is neither an overall body nor any inline
   // comments — a body-less review with inline comments carries real reviewer feedback.
-  if (review.state === "commented" && !review.body && inlineComments.length === 0) {
+  if (review.state === "commented" && !review.body && inlineComments.length === 0 && !degraded) {
     return { created: false };
   }
 
@@ -1062,7 +1163,9 @@ export async function handlePullRequestReview(
 
   // Build task description
   const reviewBodySection = review.body ? `\n\nReview Comment:\n${review.body}` : "";
-  const inlineCommentsSection = buildInlineCommentsSection(inlineComments);
+  const inlineCommentsSection =
+    buildInlineCommentsSection(inlineComments) +
+    (degraded ? buildInlineCommentsDegradedSection(repository.full_name, pr.number) : "");
   const relatedTaskSection = existingTask
     ? `Related task: ${existingTask.id}\n🔀 Consider routing to the same agent working on the related task.\n`
     : "";
@@ -1074,7 +1177,7 @@ export async function handlePullRequestReview(
       : review.state === "changes_requested"
         ? "💡 Suggested: Address the requested changes and update the PR"
         : "💡 Suggested: Review the feedback and respond if needed";
-  const reviewSuggestions = hasInlineComments
+  const reviewSuggestions = hasInlineComments || degraded
     ? `${baseReviewSuggestion}\n💬 Address EVERY inline comment. After pushing fixes, reply to and resolve each inline review thread on GitHub so the reviewer sees visible confirmation.`
     : baseReviewSuggestion;
 

--- a/src/tests/github-event-filter.test.ts
+++ b/src/tests/github-event-filter.test.ts
@@ -183,7 +183,7 @@ describe("suppressed cascade events", () => {
     expect(result.created).toBe(false);
   });
 
-  test("pull_request_review.submitted with empty commented review is ignored", async () => {
+  test("pull_request_review.submitted with empty commented review is created when inline comments are unverifiable", async () => {
     const event: PullRequestReviewEvent = {
       action: "submitted",
       review: {
@@ -207,7 +207,8 @@ describe("suppressed cascade events", () => {
       sender: { login: "reviewer" },
     };
     const result = await handlePullRequestReview(event);
-    expect(result.created).toBe(false);
+    expect(result.created).toBe(true);
+    expect(result.taskId).toBeDefined();
   });
 
   test("check_run.completed with failure returns created: false", async () => {

--- a/src/tests/github-handlers-inline-comments.test.ts
+++ b/src/tests/github-handlers-inline-comments.test.ts
@@ -4,13 +4,17 @@
  * Covers:
  * - CHANGES_REQUESTED review with inline comments → task description includes them
  * - commented-no-body-with-inline-comments → task is created (not skipped)
- * - commented-no-body-no-inline-comments → task is skipped (existing behavior preserved)
- * - commented-no-body-no-installation → graceful fallback, task is skipped
+ * - commented-no-body-no-inline-comments with trusted fetch → task is skipped
+ * - degraded fetch/no installation → task is created with a loud manual-fetch block
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { unlink } from "node:fs/promises";
 import { closeDb, createAgent, getDb, initDb } from "../be/db";
-import { handleComment, handlePullRequestReview } from "../github/handlers";
+import {
+  handleComment,
+  handlePullRequestReview,
+  setReviewCommentsRetryDelayForTests,
+} from "../github/handlers";
 import { GITHUB_BOT_NAME } from "../github/mentions";
 import type { CommentEvent, PullRequestReviewEvent } from "../github/types";
 import { getTemplateDefinition } from "../prompts/registry";
@@ -55,6 +59,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  setReviewCommentsRetryDelayForTests();
   closeDb();
   await unlink(TEST_DB_PATH).catch(() => {});
   await unlink(`${TEST_DB_PATH}-wal`).catch(() => {});
@@ -63,6 +68,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await ensureTemplatesRegistered();
+  setReviewCommentsRetryDelayForTests(() => {});
   getDb().prepare("DELETE FROM agent_tasks").run();
 });
 
@@ -71,6 +77,16 @@ beforeEach(async () => {
 const BASE_REPO = { full_name: "test/repo", html_url: "https://github.com/test/repo" };
 
 let reviewIdCounter = 9000;
+
+type TestInlineComment = {
+  id: number;
+  path: string;
+  line: number | null;
+  body: string;
+  html_url: string;
+  diff_hunk: string;
+  pull_request_review_id?: number | null;
+};
 
 function makeReviewEvent(opts: {
   state: "changes_requested" | "commented";
@@ -104,7 +120,7 @@ function makeReviewEvent(opts: {
   };
 }
 
-const SAMPLE_INLINE_COMMENTS = [
+const SAMPLE_INLINE_COMMENTS: TestInlineComment[] = [
   {
     id: 1001,
     path: "src/domain_tables.go",
@@ -123,15 +139,16 @@ const SAMPLE_INLINE_COMMENTS = [
   },
 ];
 
-function mockFetchWithComments(
-  comments: typeof SAMPLE_INLINE_COMMENTS | [],
-): ReturnType<typeof spyOn> {
+function commentsResponse(comments: TestInlineComment[]): Response {
+  return new Response(JSON.stringify(comments), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function mockFetchWithComments(comments: TestInlineComment[]): ReturnType<typeof spyOn> {
   return spyOn(globalThis, "fetch").mockImplementationOnce(
-    async () =>
-      new Response(JSON.stringify(comments), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
+    async () => commentsResponse(comments),
   );
 }
 
@@ -142,10 +159,19 @@ function getLastTaskText(): string | undefined {
   return row?.task;
 }
 
+function expectDegradedBlock(text: string | undefined): void {
+  expect(text).toContain("## ⚠️ Inline comments could NOT be auto-fetched");
+  expect(text).toContain(
+    'gh api "repos/test/repo/pulls/99/comments?per_page=100" --jq \'.[] | {id,path,line,body}\'',
+  );
+  expect(text).toContain("Do NOT dispatch off the review body alone");
+  expect(text).toContain("Address EVERY inline comment");
+}
+
 // ── Tests ──
 
 describe("inline review comment surfacing", () => {
-  test("CHANGES_REQUESTED review with inline comments: task includes path:line and bodies", async () => {
+  test("happy path: CHANGES_REQUESTED review with inline comments includes path:line and bodies", async () => {
     const fetchSpy = mockFetchWithComments(SAMPLE_INLINE_COMMENTS);
 
     const event = makeReviewEvent({
@@ -166,6 +192,29 @@ describe("inline review comment surfacing", () => {
     expect(text).toContain("Why is this hardcoded?");
     expect(text).toContain("Inline review comments");
     expect(text).toContain("reply to and resolve each inline review thread");
+    expect(text).not.toContain("Inline comments could NOT be auto-fetched");
+  });
+
+  test("consistency lag: empty review-scoped fetch retries and embeds later comments", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch")
+      .mockImplementationOnce(async () => commentsResponse([]))
+      .mockImplementationOnce(async () => commentsResponse([SAMPLE_INLINE_COMMENTS[0]]));
+
+    const event = makeReviewEvent({
+      state: "changes_requested",
+      body: "Please handle the line note",
+      installationId: 123,
+    });
+    const result = await handlePullRequestReview(event);
+
+    expect(result.created).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    fetchSpy.mockRestore();
+
+    const text = getLastTaskText();
+    expect(text).toContain("src/domain_tables.go:77");
+    expect(text).toContain("This logic looks wrong");
+    expect(text).not.toContain("Inline comments could NOT be auto-fetched");
   });
 
   test("commented review with no body but with inline comments: task is created, not skipped", async () => {
@@ -180,26 +229,34 @@ describe("inline review comment surfacing", () => {
   });
 
   test("commented review with no body and no inline comments: task is skipped", async () => {
-    const fetchSpy = mockFetchWithComments([]);
+    const fetchSpy = spyOn(globalThis, "fetch")
+      .mockImplementationOnce(async () => commentsResponse([]))
+      .mockImplementationOnce(async () => commentsResponse([]))
+      .mockImplementationOnce(async () => commentsResponse([]))
+      .mockImplementationOnce(async () => commentsResponse([]))
+      .mockImplementationOnce(async () => commentsResponse([]));
 
     const event = makeReviewEvent({ state: "commented", body: null, installationId: 123 });
     const result = await handlePullRequestReview(event);
 
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
     fetchSpy.mockRestore();
 
     expect(result.created).toBe(false);
   });
 
-  test("commented review with no body and no installation: graceful fallback, task is skipped", async () => {
+  test("commented review with no body and no installation: degraded task is created", async () => {
     const event = makeReviewEvent({ state: "commented", body: null });
     const result = await handlePullRequestReview(event);
-    expect(result.created).toBe(false);
+
+    expect(result.created).toBe(true);
+    expectDegradedBlock(getLastTaskText());
   });
 
-  test("review comments fetch failure: task still created (graceful degradation)", async () => {
-    const fetchSpy = spyOn(globalThis, "fetch").mockImplementationOnce(
-      async () => new Response("Internal Server Error", { status: 500 }),
-    );
+  test("non-2xx review-scoped fetch: degraded block is present", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch")
+      .mockImplementationOnce(async () => new Response("Internal Server Error", { status: 500 }))
+      .mockImplementationOnce(async () => commentsResponse([]));
 
     const event = makeReviewEvent({
       state: "changes_requested",
@@ -214,8 +271,38 @@ describe("inline review comment surfacing", () => {
     expect(result.created).toBe(true);
     const text = getLastTaskText();
     expect(text).toContain("Needs work");
-    // No inline comments section when fetch failed
-    expect(text).not.toContain("Inline review comments");
+    expectDegradedBlock(text);
+    expect(text).not.toContain("Inline review comments (");
+  });
+
+  test("PR-level fallback embeds a review comment missed by review-scoped fetch", async () => {
+    const event = makeReviewEvent({
+      state: "changes_requested",
+      body: "Review-scoped path missed this",
+      installationId: 123,
+    });
+    const fallbackComment = {
+      ...SAMPLE_INLINE_COMMENTS[1],
+      pull_request_review_id: event.review.id,
+    };
+    const fetchSpy = spyOn(globalThis, "fetch")
+      .mockImplementationOnce(async () => commentsResponse([]))
+      .mockImplementationOnce(async () => commentsResponse([]))
+      .mockImplementationOnce(async () => commentsResponse([]))
+      .mockImplementationOnce(async () => commentsResponse([]))
+      .mockImplementationOnce(async () => commentsResponse([fallbackComment]));
+
+    const result = await handlePullRequestReview(event);
+
+    fetchSpy.mockRestore();
+
+    expect(result.created).toBe(true);
+    const text = getLastTaskText();
+    expect(text).toContain("config/table-renderers.json:7");
+    expect(text).toContain("Why is this hardcoded?");
+    expect(text).toContain("Inline review comments (1)");
+    expect(text).toContain("Address EVERY inline comment");
+    expect(text).not.toContain("Inline comments could NOT be auto-fetched");
   });
 
   test("pagination: two-page review comment response surfaces all comments from both pages", async () => {

--- a/src/tests/github-handlers-inline-comments.test.ts
+++ b/src/tests/github-handlers-inline-comments.test.ts
@@ -147,9 +147,7 @@ function commentsResponse(comments: TestInlineComment[]): Response {
 }
 
 function mockFetchWithComments(comments: TestInlineComment[]): ReturnType<typeof spyOn> {
-  return spyOn(globalThis, "fetch").mockImplementationOnce(
-    async () => commentsResponse(comments),
-  );
+  return spyOn(globalThis, "fetch").mockImplementationOnce(async () => commentsResponse(comments));
 }
 
 function getLastTaskText(): string | undefined {
@@ -162,7 +160,7 @@ function getLastTaskText(): string | undefined {
 function expectDegradedBlock(text: string | undefined): void {
   expect(text).toContain("## ⚠️ Inline comments could NOT be auto-fetched");
   expect(text).toContain(
-    'gh api "repos/test/repo/pulls/99/comments?per_page=100" --jq \'.[] | {id,path,line,body}\'',
+    "gh api \"repos/test/repo/pulls/99/comments?per_page=100\" --jq '.[] | {id,path,line,body}'",
   );
   expect(text).toContain("Do NOT dispatch off the review body alone");
   expect(text).toContain("Address EVERY inline comment");

--- a/src/tests/github-handlers-inline-comments.test.ts
+++ b/src/tests/github-handlers-inline-comments.test.ts
@@ -147,7 +147,8 @@ function commentsResponse(comments: TestInlineComment[]): Response {
 }
 
 function mockFetchWithComments(comments: TestInlineComment[]): ReturnType<typeof spyOn> {
-  return spyOn(globalThis, "fetch").mockImplementationOnce(async () => commentsResponse(comments));
+  const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(async () => commentsResponse([]));
+  return fetchSpy.mockImplementationOnce(async () => commentsResponse(comments));
 }
 
 function getLastTaskText(): string | undefined {
@@ -195,6 +196,7 @@ describe("inline review comment surfacing", () => {
 
   test("consistency lag: empty review-scoped fetch retries and embeds later comments", async () => {
     const fetchSpy = spyOn(globalThis, "fetch")
+      .mockImplementation(async () => commentsResponse([]))
       .mockImplementationOnce(async () => commentsResponse([]))
       .mockImplementationOnce(async () => commentsResponse([SAMPLE_INLINE_COMMENTS[0]]));
 
@@ -206,7 +208,6 @@ describe("inline review comment surfacing", () => {
     const result = await handlePullRequestReview(event);
 
     expect(result.created).toBe(true);
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
     fetchSpy.mockRestore();
 
     const text = getLastTaskText();
@@ -228,6 +229,7 @@ describe("inline review comment surfacing", () => {
 
   test("commented review with no body and no inline comments: task is skipped", async () => {
     const fetchSpy = spyOn(globalThis, "fetch")
+      .mockImplementation(async () => commentsResponse([]))
       .mockImplementationOnce(async () => commentsResponse([]))
       .mockImplementationOnce(async () => commentsResponse([]))
       .mockImplementationOnce(async () => commentsResponse([]))
@@ -253,6 +255,7 @@ describe("inline review comment surfacing", () => {
 
   test("non-2xx review-scoped fetch: degraded block is present", async () => {
     const fetchSpy = spyOn(globalThis, "fetch")
+      .mockImplementation(async () => commentsResponse([]))
       .mockImplementationOnce(async () => new Response("Internal Server Error", { status: 500 }))
       .mockImplementationOnce(async () => commentsResponse([]));
 
@@ -284,6 +287,7 @@ describe("inline review comment surfacing", () => {
       pull_request_review_id: event.review.id,
     };
     const fetchSpy = spyOn(globalThis, "fetch")
+      .mockImplementation(async () => commentsResponse([]))
       .mockImplementationOnce(async () => commentsResponse([]))
       .mockImplementationOnce(async () => commentsResponse([]))
       .mockImplementationOnce(async () => commentsResponse([]))
@@ -310,6 +314,7 @@ describe("inline review comment surfacing", () => {
       "https://api.github.com/repos/test/repo/pulls/99/reviews/9001/comments?per_page=100&page=2";
 
     const fetchSpy = spyOn(globalThis, "fetch")
+      .mockImplementation(async () => commentsResponse([]))
       .mockImplementationOnce(
         async () =>
           new Response(JSON.stringify(page1), {


### PR DESCRIPTION
## Summary

Harden GitHub `pull_request_review` ingestion so inline PR review comments are never silently dropped from review tasks.

Root cause: `fetchReviewComments()` failed open by returning `[]` for null installation tokens, non-2xx responses, exceptions, and GitHub read-after-write lag. The handler could not distinguish a trusted empty review from an unverifiable/degraded fetch, so it created comment-less tasks with no warning. This was observed on Capchase/client-monorepo#29776, where fuvidani's CHANGES_REQUESTED review had inline comments but the spawned task had an empty inline-comments section.

## Hardening layers

- Return `{ comments, degraded }` from review-comment fetching, preserving partial results and marking null token, non-2xx, and exceptions as degraded.
- Retry trusted-empty review-scoped fetches with short backoff to absorb GitHub consistency lag after review submission.
- Fall back to PR-level `/pulls/{number}/comments`, filter by `pull_request_review_id`, merge and dedupe with review-scoped results.
- When the fetch remains degraded, create the task anyway with a loud manual-fetch instruction block and force the strict inline-comment handling suggestion.

This is upstream-general code and is a candidate to propagate to `desplega-ai/agent-swarm` via a separate upstream-review step after Capchase review.

## Checks

- `bun install`
- `bun run lint`
- `bun run tsc:check`
- `bun test src/tests/github-handlers-inline-comments.test.ts`
- `bun test`
- `bash scripts/check-db-boundary.sh`
