### PR TITLE
feat(slack): add lead-gated slack-delete and slack-update MCP tools

### DIFF
--- a/MCP.md
+++ b/MCP.md
@@ -47,6 +47,8 @@
   - [slack-list-channels](#slack-list-channels)
   - [slack-upload-file](#slack-upload-file)
   - [slack-download-file](#slack-download-file)
+  - [slack-delete](#slack-delete)
+  - [slack-update](#slack-update)
   - [register-agentmail-inbox](#register-agentmail-inbox)
   - [register-kapso-number](#register-kapso-number)
   - [unregister-kapso-number](#unregister-kapso-number)
@@ -556,6 +558,29 @@ Download a file from Slack by file ID or URL. Files are saved to the agent's dow
 | `url` | `string` | No | - | Direct URL to download (url_private_download from a file object). |
 | `savePath` | `string` | No | - | Where to save the file. Can be a directory or full path. Defaults to /workspace/shared/downloads/{agentId}/slack/ |
 | `filename` | `string` | No | - | Filename to use when saving. Only used if savePath is a directory. |
+
+### slack-delete
+
+**Delete a Slack message**
+
+Deletes a Slack message that THIS bot authored (e.g. a message previously posted via `slack-post`/`slack-reply`). Cannot delete messages authored by humans or other apps. Requires lead privileges.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `channelId` | `string` | Yes | - | The Slack channel ID the message is in. |
+| `messageTs` | `string` | Yes | - | Timestamp of the message to delete. Accepts the dotted form (1783411554.596189), the 'p' deep-link form (p1783411554596189), or a full Slack permalink URL. |
+
+### slack-update
+
+**Edit a Slack message**
+
+Edits (in place) the text of a Slack message that THIS bot authored — use it to post corrections to your own messages. Cannot edit messages authored by humans or other apps. Note: editing may reset the message's display name/icon to the app default (Slack's chat.update cannot set the crown persona). Requires lead privileges.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `channelId` | `string` | Yes | - | The Slack channel ID the message is in. |
+| `messageTs` | `string` | Yes | - | Timestamp of the message to edit (dotted, 'p' deep-link, or full permalink URL). |
+| `message` | `string` | Yes | - | The new message content. |
 
 ### register-agentmail-inbox
 

--- a/src/be/scripts/typecheck.ts
+++ b/src/be/scripts/typecheck.ts
@@ -137,6 +137,8 @@ export interface SwarmSdk {
   slack_startThread(args: { channelId: string; message: string }): Promise<unknown>;
   slack_uploadFile(args: Record<string, unknown>): Promise<unknown>;
   slack_downloadFile(args: { url: string }): Promise<unknown>;
+  slack_delete(args: { channelId: string; messageTs: string }): Promise<unknown>;
+  slack_update(args: { channelId: string; messageTs: string; message: string }): Promise<unknown>;
 
   // --- write: messaging (internal) ---
   message_post(args: { channel?: string; content: string; to?: string }): Promise<unknown>;

--- a/src/scripts-runtime/sdk-allowlist.ts
+++ b/src/scripts-runtime/sdk-allowlist.ts
@@ -67,6 +67,8 @@ export const SDK_TOOL_NAME_MAP = {
   slack_startThread: "slack-start-thread", // external: sends to Slack
   slack_uploadFile: "slack-upload-file", // external: sends to Slack
   slack_downloadFile: "slack-download-file",
+  slack_delete: "slack-delete", // external: mutates Slack, destructive
+  slack_update: "slack-update", // external: mutates Slack
 
   // ── messaging (internal) ──
   message_read: "read-messages",

--- a/src/scripts-runtime/types/swarm-sdk.d.ts
+++ b/src/scripts-runtime/types/swarm-sdk.d.ts
@@ -209,6 +209,8 @@ declare module "swarm-sdk" {
     slack_startThread(args: { channelId: string; message: string }): Promise<unknown>;
     slack_uploadFile(args: Record<string, unknown>): Promise<unknown>;
     slack_downloadFile(args: { url: string }): Promise<unknown>;
+    slack_delete(args: { channelId: string; messageTs: string }): Promise<unknown>;
+    slack_update(args: { channelId: string; messageTs: string; message: string }): Promise<unknown>;
 
     // --- write: messaging (internal) ---
     message_post(args: { channel?: string; content: string; to?: string }): Promise<unknown>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,12 +103,14 @@ import {
   registerSkillUninstallTool,
   registerSkillUpdateTool,
 } from "./tools/skills";
+import { registerSlackDeleteTool } from "./tools/slack-delete";
 import { registerSlackDownloadFileTool } from "./tools/slack-download-file";
 import { registerSlackListChannelsTool } from "./tools/slack-list-channels";
 import { registerSlackPostTool } from "./tools/slack-post";
 import { registerSlackReadTool } from "./tools/slack-read";
 import { registerSlackReplyTool } from "./tools/slack-reply";
 import { registerSlackStartThreadTool } from "./tools/slack-start-thread";
+import { registerSlackUpdateTool } from "./tools/slack-update";
 import { registerSlackUploadFileTool } from "./tools/slack-upload-file";
 import { registerStoreProgressTool } from "./tools/store-progress";
 // Swarm config tools
@@ -256,6 +258,8 @@ export function createServer() {
   registerSlackListChannelsTool(server);
   registerSlackUploadFileTool(server);
   registerSlackDownloadFileTool(server);
+  registerSlackDeleteTool(server);
+  registerSlackUpdateTool(server);
 
   // AgentMail integration tool (always registered, self-service inbox mapping)
   registerRegisterAgentmailInboxTool(server);

--- a/src/slack/message-text.ts
+++ b/src/slack/message-text.ts
@@ -178,3 +178,28 @@ export function extractSlackMessageText(msg: SlackMessageLike): string {
   }
   return bodyText || topText;
 }
+
+/**
+ * Normalize a Slack message timestamp into the dotted API form
+ * (1783411554.596189) that chat.delete/chat.update require.
+ *
+ * Accepts, in order of preference:
+ *   - the dotted API form            → "1783411554.596189"  (returned unchanged)
+ *   - the 'p' deep-link form         → "p1783411554596189"  (dot re-inserted)
+ *   - the bare digit run             → "1783411554596189"
+ *   - a full Slack permalink URL     → ".../archives/C.../p1783411554596189?thread_ts=..."
+ *
+ * The Lead can pass whatever handle it holds; this makes delete/edit reliable
+ * without the caller pre-cleaning the input.
+ */
+export function parseSlackTs(input: string): string {
+  const trimmed = input.trim();
+  if (/^\d{6,}\.\d{1,}$/.test(trimmed)) return trimmed; // already dotted
+
+  // Extract the p-form / bare digit run from anywhere in the string,
+  // including a full permalink URL (…/archives/C…/p1783411554596189?…).
+  const m = trimmed.match(/p?(\d{10})(\d{6})(?:\D|$)/);
+  if (m) return `${m[1]}.${m[2]}`;
+
+  return trimmed; // fall through; Slack rejects a bad ts with a clear error we map below
+}

--- a/src/tests/slack-delete.test.ts
+++ b/src/tests/slack-delete.test.ts
@@ -1,0 +1,157 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { unlink } from "node:fs/promises";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { closeDb, createAgent, initDb } from "../be/db";
+import { registerSlackDeleteTool } from "../tools/slack-delete";
+
+const TEST_DB_PATH = "./test-slack-delete.sqlite";
+
+const mockChatDelete = mock(() => Promise.resolve({ ok: true }));
+const mockGetSlackApp = mock(() => ({ client: { chat: { delete: mockChatDelete } } }));
+
+mock.module("../slack/app", () => ({
+  getSlackApp: mockGetSlackApp,
+}));
+
+type RegisteredTool = {
+  handler: (
+    args: unknown,
+    extra: unknown,
+  ) => Promise<{
+    structuredContent: { success: boolean; message: string };
+  }>;
+};
+
+function buildTool() {
+  const server = new McpServer({ name: "slack-delete-test", version: "1.0.0" });
+  registerSlackDeleteTool(server);
+  const registered = (server as unknown as { _registeredTools: Record<string, RegisteredTool> })
+    ._registeredTools;
+  const tool = registered["slack-delete"];
+  if (!tool) throw new Error("slack-delete tool not registered");
+  return tool;
+}
+
+function meta(agentId?: string) {
+  return { sessionId: "s1", requestInfo: { headers: agentId ? { "x-agent-id": agentId } : {} } };
+}
+
+describe("slack-delete", () => {
+  let leadAgentId: string;
+  let nonLeadAgentId: string;
+
+  beforeAll(async () => {
+    for (const suffix of ["", "-wal", "-shm"]) {
+      try {
+        await unlink(`${TEST_DB_PATH}${suffix}`);
+      } catch {}
+    }
+    initDb(TEST_DB_PATH);
+    leadAgentId = createAgent({ name: "Lead", isLead: true, status: "idle" }).id;
+    nonLeadAgentId = createAgent({ name: "Worker", isLead: false, status: "idle" }).id;
+  });
+
+  beforeEach(() => {
+    mockChatDelete.mockClear();
+    mockGetSlackApp.mockClear();
+  });
+
+  afterAll(async () => {
+    closeDb();
+    for (const suffix of ["", "-wal", "-shm"]) {
+      try {
+        await unlink(`${TEST_DB_PATH}${suffix}`);
+      } catch {}
+    }
+  });
+
+  test("rejects when agentId header is missing, without touching Slack", async () => {
+    const tool = buildTool();
+    const result = await tool.handler({ channelId: "C1", messageTs: "1783411554.596189" }, meta());
+
+    expect(result.structuredContent.success).toBe(false);
+    expect(result.structuredContent.message).toBe("Agent ID not found.");
+    expect(mockGetSlackApp).not.toHaveBeenCalled();
+    expect(mockChatDelete).not.toHaveBeenCalled();
+  });
+
+  test("rejects when the agent does not exist, without touching Slack", async () => {
+    const tool = buildTool();
+    const result = await tool.handler(
+      { channelId: "C1", messageTs: "1783411554.596189" },
+      meta("00000000-0000-0000-0000-000000000000"),
+    );
+
+    expect(result.structuredContent.success).toBe(false);
+    expect(result.structuredContent.message).toBe("Agent not found.");
+    expect(mockGetSlackApp).not.toHaveBeenCalled();
+    expect(mockChatDelete).not.toHaveBeenCalled();
+  });
+
+  test("rejects non-lead agents without touching Slack", async () => {
+    const tool = buildTool();
+    const result = await tool.handler(
+      { channelId: "C1", messageTs: "1783411554.596189" },
+      meta(nonLeadAgentId),
+    );
+
+    expect(result.structuredContent.success).toBe(false);
+    expect(result.structuredContent.message).toBe(
+      "Deleting Slack messages requires lead privileges.",
+    );
+    expect(mockGetSlackApp).not.toHaveBeenCalled();
+    expect(mockChatDelete).not.toHaveBeenCalled();
+  });
+
+  test("lead caller deletes using the normalized timestamp", async () => {
+    const tool = buildTool();
+    // 'p' deep-link form must be normalized to the dotted API form before chat.delete.
+    const result = await tool.handler(
+      { channelId: "C1", messageTs: "p1783411554596189" },
+      meta(leadAgentId),
+    );
+
+    expect(result.structuredContent.success).toBe(true);
+    expect(mockChatDelete).toHaveBeenCalledTimes(1);
+    expect(mockChatDelete.mock.calls[0][0]).toEqual({
+      channel: "C1",
+      ts: "1783411554.596189",
+    });
+  });
+
+  test.each([
+    ["message_not_found", "No message found at that timestamp in this channel."],
+    [
+      "cant_delete_message",
+      "Cannot delete this message — the bot can only delete messages it authored.",
+    ],
+    ["channel_not_found", "Channel not found or the bot has no access."],
+    ["not_in_channel", "The bot is not in that channel."],
+  ])("maps Slack error %s to a structured failure message", async (errorCode, expectedMessage) => {
+    mockChatDelete.mockImplementationOnce(() =>
+      Promise.reject(Object.assign(new Error("slack error"), { data: { error: errorCode } })),
+    );
+
+    const tool = buildTool();
+    const result = await tool.handler(
+      { channelId: "C1", messageTs: "1783411554.596189" },
+      meta(leadAgentId),
+    );
+
+    expect(result.structuredContent.success).toBe(false);
+    expect(result.structuredContent.message).toBe(expectedMessage);
+  });
+
+  test("falls back to the raw error message for unmapped Slack error codes", async () => {
+    mockChatDelete.mockImplementationOnce(() => Promise.reject(new Error("boom")));
+
+    const tool = buildTool();
+    const result = await tool.handler(
+      { channelId: "C1", messageTs: "1783411554.596189" },
+      meta(leadAgentId),
+    );
+
+    expect(result.structuredContent.success).toBe(false);
+    expect(result.structuredContent.message).toBe("Failed to delete message: boom");
+  });
+});

--- a/src/tests/slack-message-text.test.ts
+++ b/src/tests/slack-message-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { extractSlackMessageText } from "../slack/message-text";
+import { extractSlackMessageText, parseSlackTs } from "../slack/message-text";
 
 describe("extractSlackMessageText", () => {
   test("returns top-level text when present", () => {
@@ -452,5 +452,41 @@ describe("extractSlackMessageText", () => {
       expect(() => extractSlackMessageText(msg)).not.toThrow();
       expect(extractSlackMessageText(msg)).toBe("real");
     });
+  });
+});
+
+describe("parseSlackTs", () => {
+  test("passes the dotted API form through unchanged", () => {
+    expect(parseSlackTs("1783411554.596189")).toBe("1783411554.596189");
+  });
+
+  test("converts the 'p' deep-link form back to dotted", () => {
+    expect(parseSlackTs("p1783411554596189")).toBe("1783411554.596189");
+  });
+
+  test("converts a bare digit run back to dotted", () => {
+    expect(parseSlackTs("1783411554596189")).toBe("1783411554.596189");
+  });
+
+  test("extracts the ts from a full permalink URL", () => {
+    expect(
+      parseSlackTs("https://example.slack.com/archives/C0123456789/p1783411554596189"),
+    ).toBe("1783411554.596189");
+  });
+
+  test("extracts the ts from a permalink URL with a thread_ts query param", () => {
+    expect(
+      parseSlackTs(
+        "https://example.slack.com/archives/C0123456789/p1783411554596189?thread_ts=1783411000.000100&cid=C0123456789",
+      ),
+    ).toBe("1783411554.596189");
+  });
+
+  test("trims surrounding whitespace before parsing", () => {
+    expect(parseSlackTs("  1783411554.596189  ")).toBe("1783411554.596189");
+  });
+
+  test("falls through unchanged for unrecognized input", () => {
+    expect(parseSlackTs("not-a-ts")).toBe("not-a-ts");
   });
 });

--- a/src/tests/slack-message-text.test.ts
+++ b/src/tests/slack-message-text.test.ts
@@ -469,9 +469,9 @@ describe("parseSlackTs", () => {
   });
 
   test("extracts the ts from a full permalink URL", () => {
-    expect(
-      parseSlackTs("https://example.slack.com/archives/C0123456789/p1783411554596189"),
-    ).toBe("1783411554.596189");
+    expect(parseSlackTs("https://example.slack.com/archives/C0123456789/p1783411554596189")).toBe(
+      "1783411554.596189",
+    );
   });
 
   test("extracts the ts from a permalink URL with a thread_ts query param", () => {

--- a/src/tests/slack-update.test.ts
+++ b/src/tests/slack-update.test.ts
@@ -1,0 +1,167 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { unlink } from "node:fs/promises";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { closeDb, createAgent, initDb } from "../be/db";
+import { registerSlackUpdateTool } from "../tools/slack-update";
+
+const TEST_DB_PATH = "./test-slack-update.sqlite";
+
+const mockChatUpdate = mock(() => Promise.resolve({ ok: true, ts: "1783411554.596189" }));
+const mockGetSlackApp = mock(() => ({ client: { chat: { update: mockChatUpdate } } }));
+
+mock.module("../slack/app", () => ({
+  getSlackApp: mockGetSlackApp,
+}));
+
+type RegisteredTool = {
+  handler: (
+    args: unknown,
+    extra: unknown,
+  ) => Promise<{
+    structuredContent: { success: boolean; message: string; messageTs?: string };
+  }>;
+};
+
+function buildTool() {
+  const server = new McpServer({ name: "slack-update-test", version: "1.0.0" });
+  registerSlackUpdateTool(server);
+  const registered = (server as unknown as { _registeredTools: Record<string, RegisteredTool> })
+    ._registeredTools;
+  const tool = registered["slack-update"];
+  if (!tool) throw new Error("slack-update tool not registered");
+  return tool;
+}
+
+function meta(agentId?: string) {
+  return { sessionId: "s1", requestInfo: { headers: agentId ? { "x-agent-id": agentId } : {} } };
+}
+
+describe("slack-update", () => {
+  let leadAgentId: string;
+  let nonLeadAgentId: string;
+
+  beforeAll(async () => {
+    for (const suffix of ["", "-wal", "-shm"]) {
+      try {
+        await unlink(`${TEST_DB_PATH}${suffix}`);
+      } catch {}
+    }
+    initDb(TEST_DB_PATH);
+    leadAgentId = createAgent({ name: "Lead", isLead: true, status: "idle" }).id;
+    nonLeadAgentId = createAgent({ name: "Worker", isLead: false, status: "idle" }).id;
+  });
+
+  beforeEach(() => {
+    mockChatUpdate.mockClear();
+    mockGetSlackApp.mockClear();
+  });
+
+  afterAll(async () => {
+    closeDb();
+    for (const suffix of ["", "-wal", "-shm"]) {
+      try {
+        await unlink(`${TEST_DB_PATH}${suffix}`);
+      } catch {}
+    }
+  });
+
+  test("rejects when agentId header is missing, without touching Slack", async () => {
+    const tool = buildTool();
+    const result = await tool.handler(
+      { channelId: "C1", messageTs: "1783411554.596189", message: "corrected" },
+      meta(),
+    );
+
+    expect(result.structuredContent.success).toBe(false);
+    expect(result.structuredContent.message).toBe("Agent ID not found.");
+    expect(mockGetSlackApp).not.toHaveBeenCalled();
+    expect(mockChatUpdate).not.toHaveBeenCalled();
+  });
+
+  test("rejects when the agent does not exist, without touching Slack", async () => {
+    const tool = buildTool();
+    const result = await tool.handler(
+      { channelId: "C1", messageTs: "1783411554.596189", message: "corrected" },
+      meta("00000000-0000-0000-0000-000000000000"),
+    );
+
+    expect(result.structuredContent.success).toBe(false);
+    expect(result.structuredContent.message).toBe("Agent not found.");
+    expect(mockGetSlackApp).not.toHaveBeenCalled();
+    expect(mockChatUpdate).not.toHaveBeenCalled();
+  });
+
+  test("rejects non-lead agents without touching Slack", async () => {
+    const tool = buildTool();
+    const result = await tool.handler(
+      { channelId: "C1", messageTs: "1783411554.596189", message: "corrected" },
+      meta(nonLeadAgentId),
+    );
+
+    expect(result.structuredContent.success).toBe(false);
+    expect(result.structuredContent.message).toBe(
+      "Editing Slack messages requires lead privileges.",
+    );
+    expect(mockGetSlackApp).not.toHaveBeenCalled();
+    expect(mockChatUpdate).not.toHaveBeenCalled();
+  });
+
+  test("lead caller updates using the normalized timestamp", async () => {
+    const tool = buildTool();
+    // Full permalink form (with a thread_ts query param) must normalize to the dotted API form.
+    const result = await tool.handler(
+      {
+        channelId: "C1",
+        messageTs: "https://x.slack.com/archives/C1/p1783411554596189?thread_ts=123.456",
+        message: "corrected message",
+      },
+      meta(leadAgentId),
+    );
+
+    expect(result.structuredContent.success).toBe(true);
+    expect(result.structuredContent.messageTs).toBe("1783411554.596189");
+    expect(mockChatUpdate).toHaveBeenCalledTimes(1);
+    expect(mockChatUpdate.mock.calls[0][0]).toMatchObject({
+      channel: "C1",
+      ts: "1783411554.596189",
+      text: "corrected message",
+    });
+  });
+
+  test.each([
+    ["message_not_found", "No message found at that timestamp in this channel."],
+    [
+      "cant_update_message",
+      "Cannot edit this message — the bot can only edit messages it authored.",
+    ],
+    ["edit_window_closed", "The edit window for this message has closed."],
+    ["channel_not_found", "Channel not found or the bot has no access."],
+    ["not_in_channel", "The bot is not in that channel."],
+  ])("maps Slack error %s to a structured failure message", async (errorCode, expectedMessage) => {
+    mockChatUpdate.mockImplementationOnce(() =>
+      Promise.reject(Object.assign(new Error("slack error"), { data: { error: errorCode } })),
+    );
+
+    const tool = buildTool();
+    const result = await tool.handler(
+      { channelId: "C1", messageTs: "1783411554.596189", message: "corrected" },
+      meta(leadAgentId),
+    );
+
+    expect(result.structuredContent.success).toBe(false);
+    expect(result.structuredContent.message).toBe(expectedMessage);
+  });
+
+  test("falls back to the raw error message for unmapped Slack error codes", async () => {
+    mockChatUpdate.mockImplementationOnce(() => Promise.reject(new Error("boom")));
+
+    const tool = buildTool();
+    const result = await tool.handler(
+      { channelId: "C1", messageTs: "1783411554.596189", message: "corrected" },
+      meta(leadAgentId),
+    );
+
+    expect(result.structuredContent.success).toBe(false);
+    expect(result.structuredContent.message).toBe("Failed to update message: boom");
+  });
+});

--- a/src/tests/tool-annotations.test.ts
+++ b/src/tests/tool-annotations.test.ts
@@ -107,6 +107,7 @@ describe("Tool Annotations & Classification", () => {
       "delete-config",
       "delete-workflow",
       "unregister-service",
+      "slack-delete",
     ];
 
     for (const name of expectedDestructive) {
@@ -163,6 +164,8 @@ describe("Tool Annotations & Classification", () => {
       "slack-upload-file",
       "slack-download-file",
       "slack-list-channels",
+      "slack-delete",
+      "slack-update",
     ];
 
     for (const name of slackTools) {

--- a/src/tools/slack-delete.ts
+++ b/src/tools/slack-delete.ts
@@ -1,0 +1,104 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod";
+import { getAgentById } from "@/be/db";
+import { getSlackApp } from "@/slack/app";
+import { parseSlackTs } from "@/slack/message-text";
+import { createToolRegistrar } from "@/tools/utils";
+
+export const registerSlackDeleteTool = (server: McpServer) => {
+  createToolRegistrar(server)(
+    "slack-delete",
+    {
+      title: "Delete a Slack message",
+      description:
+        "Deletes a Slack message that THIS bot authored (e.g. a message previously posted via `slack-post`/`slack-reply`). Cannot delete messages authored by humans or other apps. Requires lead privileges.",
+      annotations: { openWorldHint: true, destructiveHint: true },
+
+      inputSchema: z.object({
+        channelId: z.string().min(1).describe("The Slack channel ID the message is in."),
+        messageTs: z
+          .string()
+          .min(1)
+          .describe(
+            "Timestamp of the message to delete. Accepts the dotted form (1783411554.596189), the 'p' deep-link form (p1783411554596189), or a full Slack permalink URL.",
+          ),
+      }),
+      outputSchema: z.object({
+        success: z.boolean(),
+        message: z.string(),
+      }),
+    },
+    async ({ channelId, messageTs }, requestInfo, _meta) => {
+      if (!requestInfo.agentId) {
+        return {
+          content: [{ type: "text", text: "Agent ID not found." }],
+          structuredContent: { success: false, message: "Agent ID not found." },
+        };
+      }
+
+      const agent = getAgentById(requestInfo.agentId);
+      if (!agent) {
+        return {
+          content: [{ type: "text", text: "Agent not found." }],
+          structuredContent: { success: false, message: "Agent not found." },
+        };
+      }
+
+      if (!agent.isLead) {
+        return {
+          content: [
+            { type: "text", text: "Deleting Slack messages requires lead privileges." },
+          ],
+          structuredContent: {
+            success: false,
+            message: "Deleting Slack messages requires lead privileges.",
+          },
+        };
+      }
+
+      const app = getSlackApp();
+      if (!app) {
+        return {
+          content: [{ type: "text", text: "Slack not configured." }],
+          structuredContent: { success: false, message: "Slack not configured." },
+        };
+      }
+
+      try {
+        const ts = parseSlackTs(messageTs);
+        await app.client.chat.delete({ channel: channelId, ts });
+
+        return {
+          content: [{ type: "text", text: "Message deleted successfully." }],
+          structuredContent: { success: true, message: "Message deleted successfully." },
+        };
+      } catch (error) {
+        const errorCode = (error as { data?: { error?: string } } | undefined)?.data?.error;
+        const errorMsg = error instanceof Error ? error.message : String(error);
+
+        let message: string;
+        switch (errorCode) {
+          case "message_not_found":
+            message = "No message found at that timestamp in this channel.";
+            break;
+          case "cant_delete_message":
+            message = "Cannot delete this message — the bot can only delete messages it authored.";
+            break;
+          case "channel_not_found":
+            message = "Channel not found or the bot has no access.";
+            break;
+          case "not_in_channel":
+            message = "The bot is not in that channel.";
+            break;
+          default:
+            message = `Failed to delete message: ${errorMsg}`;
+        }
+
+        return {
+          content: [{ type: "text", text: message }],
+          structuredContent: { success: false, message },
+        };
+      }
+    },
+  );
+};

--- a/src/tools/slack-delete.ts
+++ b/src/tools/slack-delete.ts
@@ -46,9 +46,7 @@ export const registerSlackDeleteTool = (server: McpServer) => {
 
       if (!agent.isLead) {
         return {
-          content: [
-            { type: "text", text: "Deleting Slack messages requires lead privileges." },
-          ],
+          content: [{ type: "text", text: "Deleting Slack messages requires lead privileges." }],
           structuredContent: {
             success: false,
             message: "Deleting Slack messages requires lead privileges.",

--- a/src/tools/slack-reply.ts
+++ b/src/tools/slack-reply.ts
@@ -35,6 +35,7 @@ export const registerSlackReplyTool = (server: McpServer) => {
       outputSchema: z.object({
         success: z.boolean(),
         message: z.string(),
+        messageTs: z.string().optional(),
       }),
     },
     async ({ inboxMessageId, taskId, message }, requestInfo, _meta) => {
@@ -119,7 +120,7 @@ export const registerSlackReplyTool = (server: McpServer) => {
       try {
         const slackMessage = markdownToSlack(message);
 
-        await withAutoJoin(app.client, slackChannelId, () =>
+        const result = await withAutoJoin(app.client, slackChannelId, () =>
           app.client.chat.postMessage({
             channel: slackChannelId,
             thread_ts: slackThreadTs,
@@ -138,6 +139,8 @@ export const registerSlackReplyTool = (server: McpServer) => {
           }),
         );
 
+        const messageTs = result.ts;
+
         // After successful postMessage, mark task as having a Slack reply
         if (taskId) {
           markTaskSlackReplySent(taskId);
@@ -145,8 +148,13 @@ export const registerSlackReplyTool = (server: McpServer) => {
         }
 
         return {
-          content: [{ type: "text", text: "Reply sent successfully." }],
-          structuredContent: { success: true, message: "Reply sent successfully." },
+          content: [
+            {
+              type: "text",
+              text: `Reply sent successfully.${messageTs ? ` Message timestamp: ${messageTs}` : ""}`,
+            },
+          ],
+          structuredContent: { success: true, message: "Reply sent successfully.", messageTs },
         };
       } catch (error) {
         return {

--- a/src/tools/slack-start-thread.ts
+++ b/src/tools/slack-start-thread.ts
@@ -24,6 +24,7 @@ export const registerSlackStartThreadTool = (server: McpServer) => {
         message: z.string(),
         channelId: z.string().optional(),
         ts: z.string().optional(),
+        messageTs: z.string().optional(),
       }),
     },
     async ({ channelId, message }, requestInfo, _meta) => {
@@ -112,6 +113,7 @@ export const registerSlackStartThreadTool = (server: McpServer) => {
             message: "Thread started successfully.",
             channelId: resolvedChannelId,
             ts,
+            messageTs: ts,
           },
         };
       } catch (error) {

--- a/src/tools/slack-update.ts
+++ b/src/tools/slack-update.ts
@@ -1,0 +1,127 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod";
+import { getAgentById } from "@/be/db";
+import { getSlackApp } from "@/slack/app";
+import { parseSlackTs } from "@/slack/message-text";
+import { markdownToSlack } from "@/slack/responses";
+import { createToolRegistrar } from "@/tools/utils";
+
+export const registerSlackUpdateTool = (server: McpServer) => {
+  createToolRegistrar(server)(
+    "slack-update",
+    {
+      title: "Edit a Slack message",
+      description:
+        "Edits (in place) the text of a Slack message that THIS bot authored — use it to post corrections to your own messages. Cannot edit messages authored by humans or other apps. Note: editing may reset the message's display name/icon to the app default (Slack's chat.update cannot set the crown persona). Requires lead privileges.",
+      annotations: { openWorldHint: true },
+
+      inputSchema: z.object({
+        channelId: z.string().min(1).describe("The Slack channel ID the message is in."),
+        messageTs: z
+          .string()
+          .min(1)
+          .describe(
+            "Timestamp of the message to edit (dotted, 'p' deep-link, or full permalink URL).",
+          ),
+        message: z.string().min(1).max(4000).describe("The new message content."),
+      }),
+      outputSchema: z.object({
+        success: z.boolean(),
+        message: z.string(),
+        messageTs: z.string().optional(),
+      }),
+    },
+    async ({ channelId, messageTs, message }, requestInfo, _meta) => {
+      if (!requestInfo.agentId) {
+        return {
+          content: [{ type: "text", text: "Agent ID not found." }],
+          structuredContent: { success: false, message: "Agent ID not found." },
+        };
+      }
+
+      const agent = getAgentById(requestInfo.agentId);
+      if (!agent) {
+        return {
+          content: [{ type: "text", text: "Agent not found." }],
+          structuredContent: { success: false, message: "Agent not found." },
+        };
+      }
+
+      if (!agent.isLead) {
+        return {
+          content: [{ type: "text", text: "Editing Slack messages requires lead privileges." }],
+          structuredContent: {
+            success: false,
+            message: "Editing Slack messages requires lead privileges.",
+          },
+        };
+      }
+
+      const app = getSlackApp();
+      if (!app) {
+        return {
+          content: [{ type: "text", text: "Slack not configured." }],
+          structuredContent: { success: false, message: "Slack not configured." },
+        };
+      }
+
+      try {
+        const ts = parseSlackTs(messageTs);
+        const slackMessage = markdownToSlack(message);
+
+        const result = await app.client.chat.update({
+          channel: channelId,
+          ts,
+          text: slackMessage,
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: slackMessage,
+              },
+            },
+          ],
+        });
+
+        return {
+          content: [{ type: "text", text: "Message updated successfully." }],
+          structuredContent: {
+            success: true,
+            message: "Message updated successfully.",
+            messageTs: result.ts,
+          },
+        };
+      } catch (error) {
+        const errorCode = (error as { data?: { error?: string } } | undefined)?.data?.error;
+        const errorMsg = error instanceof Error ? error.message : String(error);
+
+        let message: string;
+        switch (errorCode) {
+          case "message_not_found":
+            message = "No message found at that timestamp in this channel.";
+            break;
+          case "cant_update_message":
+            message = "Cannot edit this message — the bot can only edit messages it authored.";
+            break;
+          case "edit_window_closed":
+            message = "The edit window for this message has closed.";
+            break;
+          case "channel_not_found":
+            message = "Channel not found or the bot has no access.";
+            break;
+          case "not_in_channel":
+            message = "The bot is not in that channel.";
+            break;
+          default:
+            message = `Failed to update message: ${errorMsg}`;
+        }
+
+        return {
+          content: [{ type: "text", text: message }],
+          structuredContent: { success: false, message },
+        };
+      }
+    },
+  );
+};

--- a/src/tools/tool-config.ts
+++ b/src/tools/tool-config.ts
@@ -86,7 +86,7 @@ export const DEFERRED_TOOLS = new Set([
   "context-history",
   "context-diff",
 
-  // Slack (7)
+  // Slack (9)
   "slack-reply",
   "slack-read",
   "slack-upload-file",
@@ -94,6 +94,8 @@ export const DEFERRED_TOOLS = new Set([
   "slack-list-channels",
   "slack-post",
   "slack-start-thread",
+  "slack-delete",
+  "slack-update",
 
   // Channel management (2)
   "create-channel",


### PR DESCRIPTION
## Summary
- Adds two new lead-gated MCP tools, `slack-delete` and `slack-update`, so the Lead agent can delete/edit Slack messages it authored (mirrors the existing `slack-post` pattern; uses `chat.delete`/`chat.update`, both already covered by the bot's existing `chat:write` scope — no Slack app changes needed).
- Adds a shared `parseSlackTs` helper (`src/slack/message-text.ts`) that normalizes the dotted API ts, the `p`-form deep link, a bare digit run, or a full Slack permalink URL into the dotted form `chat.delete`/`chat.update` require — so the Lead never has to pre-clean whatever handle it's holding. Unit-tested for all forms.
- `slack-update` uses `chat.update` (in-place edit) per explicit requirement — re-posting doesn't satisfy "correct my own message." The persona reset on edit (message renders under the app default identity, not the `:crown:` persona) is a documented, accepted limitation since `chat.update` can't set `username`/`icon_emoji`.
- Closes a reliability gap: `slack-post` already echoed `messageTs`, but `slack-reply` didn't return any handle at all, and `slack-start-thread` only returned `ts`. Both now also echo `messageTs` (purely additive) so any message the Lead authors is addressable by the new delete/update tools.
- Wires both tools into `server.ts`, `tool-config.ts` (Slack tool count 7 → 9), and the scripts-runtime SDK allowlist; extends `tool-annotations.test.ts` coverage; documents both tools in `MCP.md`.

Plan: `thoughts/6557a439-15b8-4c55-a639-638626f4983e/plans/2026-07-07-slack-delete-update-mcp-tools.md` (agent-fs, org `4fdbb8e2-f63b-4977-95be-6e18019f0e86`).

**Deployment note:** these tools only become callable once this PR merges to `main` *and* the swarm redeploys — the MCP tool registry is resolved once at server boot.

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] `bun run lint` (read-only; ran `lint:fix` once for formatting, then verified `lint` is clean)
- [x] `bun run tsc:check`
- [x] `bun test` — full suite: relevant files (`slack-message-text.test.ts` incl. new `parseSlackTs` tests, `tool-annotations.test.ts`) pass 100% in isolation and in the full run. The full-suite run shows pre-existing flakiness unrelated to this change (varying fail counts of unrelated Kapso/HTTP-integration/migration tests across runs, all pass in isolation) — not introduced by this diff.
- [x] `bash scripts/check-db-boundary.sh`
- [x] `bun run check:dep-graph` (0 errors; pre-existing warnings only, unrelated to this diff)
- [x] `bun run scripts/check-sdk-tool-registration.ts` (both new tools registered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)