### PR TITLE
feat(runner): reset base branch to origin/default on first task kickoff

### DIFF
--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -196,6 +196,20 @@ async function listSwarmAutostashes(clonePath: string, role: string): Promise<Sw
   }
 }
 
+/**
+ * A task is a "first kickoff" (safe to hard-reset the base branch) unless it is an
+ * explicit resume. `parentTaskId` is NOT a resume signal — send-task/trackers set it
+ * on ~every dispatched child task (verified 395/395 real coding tasks carried one; 0
+ * were typed "resume"). Native session-resume is deprecated (fresh session + context
+ * preamble, see the parentTaskId handling in the main task-processing loop), so only
+ * `taskType === "resume"` (created by supersedeTaskViaAPI on crash/cap recovery) may
+ * still hold locally-committed-but-unpushed work on the checked-out branch that a hard
+ * reset would strand.
+ */
+export function isFirstKickoffTask(task?: { taskType?: string } | null): boolean {
+  return task?.taskType !== "resume";
+}
+
 async function refreshExistingRepoForTask(
   repoConfig: { name: string; clonePath: string; defaultBranch: string },
   role: string,
@@ -5224,13 +5238,11 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
             clonePath: `/workspace/personal/repos/${taskVcsRepo.split("/").pop() || taskVcsRepo}`,
             defaultBranch: "main",
           };
-          // First kickoff = a genuinely new top-level task: no parentTaskId at
-          // all. A task with a parentTaskId is either an explicit resume
-          // (taskType "resume") or a follow-up/child task continuing prior
-          // work on an existing branch/PR — both must keep the clone's
-          // checked-out branch untouched, so only the no-parentTaskId case
-          // forces the base branch back to a clean origin/<default> state.
-          const isFirstKickoff = !taskObj?.parentTaskId;
+          // First kickoff = anything that isn't an explicit resume. parentTaskId is
+          // NOT a resume signal — trackers/send-task set it on ~every dispatched
+          // child task, so gating on it here would make the reset a no-op in
+          // production. See isFirstKickoffTask() for the full reasoning.
+          const isFirstKickoff = isFirstKickoffTask(taskObj);
           const repoResult = await ensureRepoForTask(effectiveConfig, role, isFirstKickoff);
           currentRepoContext = {
             ...repoResult,

--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -199,6 +199,7 @@ async function listSwarmAutostashes(clonePath: string, role: string): Promise<Sw
 async function refreshExistingRepoForTask(
   repoConfig: { name: string; clonePath: string; defaultBranch: string },
   role: string,
+  isFirstKickoff: boolean,
 ): Promise<string | null> {
   const { name, clonePath, defaultBranch } = repoConfig;
   const statusResult =
@@ -219,13 +220,36 @@ async function refreshExistingRepoForTask(
     }
   }
 
+  const fetchSpec = `${defaultBranch}:refs/remotes/origin/${defaultBranch}`;
+  const remoteRef = `refs/remotes/origin/${defaultBranch}`;
+
   try {
-    console.log(`[${role}] Refreshing ${name} from origin/${defaultBranch}...`);
-    const fetchSpec = `${defaultBranch}:refs/remotes/origin/${defaultBranch}`;
-    const remoteRef = `refs/remotes/origin/${defaultBranch}`;
     await Bun.$`env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX git -C ${clonePath} fetch origin ${fetchSpec}`.quiet();
-    await Bun.$`env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX git -C ${clonePath} merge --no-edit --no-stat ${remoteRef}`.quiet();
-    console.log(`[${role}] Refreshed ${name}`);
+
+    // First-kickoff guarantee (see call sites): the clone is REUSED task-to-task,
+    // so a leftover feature branch from a prior task can still be checked out here.
+    // On a genuine first kickoff (no parentTaskId / not a resume) we force the base
+    // branch back to a clean, current state before the caller creates a work branch
+    // off it — otherwise a diverged leftover branch would abort the merge below and
+    // leave the repo stale (only a warning was emitted). Resumes and follow-up/child
+    // tasks (which may legitimately still have that feature branch checked out with
+    // in-progress work) must NEVER take this path — merge is the safe default there.
+    if (isFirstKickoff) {
+      console.log(`[${role}] First kickoff for ${name} — resetting to ${remoteRef}...`);
+      try {
+        await Bun.$`env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX git -C ${clonePath} checkout ${defaultBranch}`.quiet();
+      } catch {
+        // Local branch may be missing (e.g. deleted by a prior task) — recreate it
+        // tracking the remote instead of failing the whole refresh.
+        await Bun.$`env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX git -C ${clonePath} checkout -B ${defaultBranch} ${remoteRef}`.quiet();
+      }
+      await Bun.$`env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX git -C ${clonePath} reset --hard ${remoteRef}`.quiet();
+      console.log(`[${role}] Reset ${name} to ${remoteRef}`);
+    } else {
+      console.log(`[${role}] Refreshing ${name} from ${remoteRef}...`);
+      await Bun.$`env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX git -C ${clonePath} merge --no-edit --no-stat ${remoteRef}`.quiet();
+      console.log(`[${role}] Refreshed ${name}`);
+    }
     return null;
   } catch (err) {
     const errorMsg = scrubSecrets((err as Error).message);
@@ -278,6 +302,13 @@ export async function ensureRepoForTask(
     hooks?: { enabled: boolean } | null;
   },
   role: string,
+  /**
+   * True only for a genuine first kickoff (a brand-new task, not a resume and
+   * not a follow-up/child task continuing prior work). Defaults to false —
+   * when in doubt, do NOT force-reset the base branch, since the clone is
+   * reused task-to-task and may hold another task's in-progress branch.
+   */
+  isFirstKickoff = false,
 ): Promise<{
   clonePath: string;
   claudeMd: string | null;
@@ -308,7 +339,11 @@ export async function ensureRepoForTask(
       console.log(`[${role}] Cloned ${name}`);
     } else {
       console.log(`[${role}] Repo ${name} already cloned at ${clonePath}`);
-      warning = await refreshExistingRepoForTask({ name, clonePath, defaultBranch }, role);
+      warning = await refreshExistingRepoForTask(
+        { name, clonePath, defaultBranch },
+        role,
+        isFirstKickoff,
+      );
     }
 
     await installRepoHooksForTask(repoConfig, role);
@@ -4794,7 +4829,9 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
             clonePath: `/workspace/personal/repos/${task.vcsRepo.split("/").pop() || task.vcsRepo}`,
             defaultBranch: "main",
           };
-          const repoContext = await ensureRepoForTask(effectiveConfig, role);
+          // This is the paused-task-resume-after-restart path — never a first
+          // kickoff, so never force-reset the base branch here.
+          const repoContext = await ensureRepoForTask(effectiveConfig, role, false);
           if (repoContext?.clonePath) {
             resumeCwd = repoContext.clonePath;
           }
@@ -5187,7 +5224,14 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
             clonePath: `/workspace/personal/repos/${taskVcsRepo.split("/").pop() || taskVcsRepo}`,
             defaultBranch: "main",
           };
-          const repoResult = await ensureRepoForTask(effectiveConfig, role);
+          // First kickoff = a genuinely new top-level task: no parentTaskId at
+          // all. A task with a parentTaskId is either an explicit resume
+          // (taskType "resume") or a follow-up/child task continuing prior
+          // work on an existing branch/PR — both must keep the clone's
+          // checked-out branch untouched, so only the no-parentTaskId case
+          // forces the base branch back to a clean origin/<default> state.
+          const isFirstKickoff = !taskObj?.parentTaskId;
+          const repoResult = await ensureRepoForTask(effectiveConfig, role, isFirstKickoff);
           currentRepoContext = {
             ...repoResult,
             guidelines: repoConfig?.guidelines ?? null,

--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -197,17 +197,104 @@ async function listSwarmAutostashes(clonePath: string, role: string): Promise<Sw
 }
 
 /**
- * A task is a "first kickoff" (safe to hard-reset the base branch) unless it is an
- * explicit resume. `parentTaskId` is NOT a resume signal — send-task/trackers set it
- * on ~every dispatched child task (verified 395/395 real coding tasks carried one; 0
- * were typed "resume"). Native session-resume is deprecated (fresh session + context
- * preamble, see the parentTaskId handling in the main task-processing loop), so only
- * `taskType === "resume"` (created by supersedeTaskViaAPI on crash/cap recovery) may
- * still hold locally-committed-but-unpushed work on the checked-out branch that a hard
- * reset would strand.
+ * Continuation task types that must NEVER take the destructive hard-reset path,
+ * even though they are not `taskType === "resume"`. Each of these ingress paths
+ * creates a NEW task that CONTINUES/cooperates with existing work — often on the
+ * same worker/reused clone — rather than starting genuinely fresh coding work:
+ *  - "follow-up" / "reroute-decision": lead-owned continuations created by
+ *    src/tasks/worker-follow-up.ts after a task completes/fails or needs
+ *    re-delegation; they inherit the parent's vcsRepo/branch context via
+ *    createTaskExtended's parentTaskId inheritance (src/be/db.ts).
+ *  - "agentmail-reply": AgentMail follow-up on an EXISTING thread
+ *    (src/agentmail/handlers.ts) — always carries `parentTaskId` pointing at
+ *    the task it's continuing (as opposed to "agentmail-message", which fires
+ *    only when no existing task was found for the thread).
+ *  - "github-comment" / "github-review" / "gitlab-comment" / "gitlab-ci":
+ *    tracker feedback on an ALREADY-OPEN PR/MR (review comments, review
+ *    verdicts, CI failures) — the point is to keep working on the existing
+ *    feature branch, not reset back to the default branch.
  */
-export function isFirstKickoffTask(task?: { taskType?: string } | null): boolean {
-  return task?.taskType !== "resume";
+const CONTINUATION_TASK_TYPES = new Set([
+  "resume",
+  "follow-up",
+  "reroute-decision",
+  "agentmail-reply",
+  "github-comment",
+  "github-review",
+  "gitlab-comment",
+  "gitlab-ci",
+]);
+
+/**
+ * Task statuses under which a task may have already mutated the shared clone
+ * (checked out a feature branch, left uncommitted/unpushed work) — or could
+ * still be doing so concurrently, e.g. with `maxTasks > 1` on the same worker.
+ * Mirrors the ACTIVE_TASK_STATUSES / getInProgressTasksByContextKey status
+ * sets already used server-side (src/agentmail/handlers.ts, src/be/db.ts) for
+ * the same "is this task still doing live work" question.
+ */
+const ACTIVE_PARENT_STATUSES = new Set<string>(["pending", "in_progress", "offered", "paused"]);
+
+/**
+ * A task is a "first kickoff" (safe to hard-reset the base branch) only when it
+ * is BOTH (a) not an explicit continuation task-type and (b) not parent-linked
+ * to a still-active task.
+ *
+ * `parentTaskId` alone is NOT a resume signal — send-task/trackers set it on
+ * ~every dispatched child task (verified 395/395 real coding tasks carried one;
+ * 0 were typed "resume"), so gating on its mere presence made the reset a no-op
+ * in production (see git history on this function). But the *opposite*
+ * over-correction — treating every non-"resume" task as a safe root kickoff —
+ * is also wrong: several ingress paths create parent-linked NON-resume tasks
+ * specifically to CONTINUE existing work, often on the same worker/reused
+ * clone:
+ *  - Slack follow-ups (src/slack/handlers.ts) wire `parentTaskId:
+ *    latestTask?.id` with NO distinguishing taskType at all.
+ *  - Sibling-awareness (src/tasks/sibling-awareness.ts, applied to every
+ *    ingress via createTaskWithSiblingAwareness) wires `parentTaskId` to an
+ *    in-progress same-agent sibling for session continuity — again with no
+ *    reserved taskType.
+ *  - AgentMail replies, tracker comments/reviews/CI events — see
+ *    CONTINUATION_TASK_TYPES.
+ * Since the first two carry no reserved taskType, a taskType denylist alone
+ * cannot catch them — we ALSO check whether `parentTaskId` currently points at
+ * a still-active task (ACTIVE_PARENT_STATUSES). If so, that parent/sibling may
+ * hold a checked-out feature branch or unpushed/uncommitted work in the SAME
+ * shared clone (especially with `maxTasks > 1`), so a hard reset there would
+ * destroy it — take the non-destructive merge path instead.
+ *
+ * `fetchParentTaskStatus` is injected so this stays a pure, unit-testable
+ * function; the real call site fetches `GET /api/tasks/{id}` (same pattern as
+ * fetchProviderSessionInfo below).
+ */
+export async function isFirstKickoffTask(
+  task?: { taskType?: string; parentTaskId?: string } | null,
+  fetchParentTaskStatus?: (parentTaskId: string) => Promise<string | null | undefined>,
+): Promise<boolean> {
+  if (task?.taskType && CONTINUATION_TASK_TYPES.has(task.taskType)) return false;
+  if (task?.parentTaskId && fetchParentTaskStatus) {
+    const parentStatus = await fetchParentTaskStatus(task.parentTaskId);
+    if (parentStatus && ACTIVE_PARENT_STATUSES.has(parentStatus)) return false;
+  }
+  return true;
+}
+
+/** Fetch a task's current status by id. Returns null on any failure (not-found, network, etc). */
+async function fetchTaskStatus(
+  apiUrl: string,
+  apiKey: string,
+  taskId: string,
+): Promise<string | null> {
+  const headers: Record<string, string> = {};
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+  try {
+    const response = await fetch(`${apiUrl}/api/tasks/${taskId}`, { headers });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { status?: string };
+    return data.status ?? null;
+  } catch {
+    return null;
+  }
 }
 
 async function refreshExistingRepoForTask(
@@ -5238,11 +5325,14 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
             clonePath: `/workspace/personal/repos/${taskVcsRepo.split("/").pop() || taskVcsRepo}`,
             defaultBranch: "main",
           };
-          // First kickoff = anything that isn't an explicit resume. parentTaskId is
-          // NOT a resume signal — trackers/send-task set it on ~every dispatched
-          // child task, so gating on it here would make the reset a no-op in
-          // production. See isFirstKickoffTask() for the full reasoning.
-          const isFirstKickoff = isFirstKickoffTask(taskObj);
+          // First kickoff = a genuinely new root task: not a continuation
+          // task-type, and not parent-linked to a still-active task (Slack
+          // follow-ups / sibling-awareness wire parentTaskId with no
+          // reserved taskType). See isFirstKickoffTask() for the full
+          // reasoning and CONTINUATION_TASK_TYPES for the denylist.
+          const isFirstKickoff = await isFirstKickoffTask(taskObj, (parentTaskId) =>
+            fetchTaskStatus(apiUrl, apiKey, parentTaskId),
+          );
           const repoResult = await ensureRepoForTask(effectiveConfig, role, isFirstKickoff);
           currentRepoContext = {
             ...repoResult,

--- a/src/tests/runner-repo-autostash.test.ts
+++ b/src/tests/runner-repo-autostash.test.ts
@@ -145,4 +145,84 @@ describe("ensureRepoForTask auto-stash refresh", () => {
     expect(await readFile(join(clonePath, "remote.txt"), "utf8")).toBe("remote commit\n");
     expect((await git(clonePath, ["status", "--porcelain"])).trim()).toBe("");
   });
+
+  test("first kickoff hard-resets a leftover feature branch back to origin/default", async () => {
+    const remotePath = join(tempRoot, "remote.git");
+    const upstreamPath = join(tempRoot, "upstream");
+    const clonePath = join(tempRoot, "clone");
+
+    await gitRaw(["init", "--bare", remotePath]);
+    await mkdir(upstreamPath);
+    await git(upstreamPath, ["init", "-b", "main"]);
+    await configureIdentity(upstreamPath);
+    await writeFile(join(upstreamPath, "README.md"), "initial\n");
+    await commitAll(upstreamPath, "initial commit");
+    await git(upstreamPath, ["remote", "add", "origin", remotePath]);
+    await git(upstreamPath, ["push", "-u", "origin", "main"]);
+
+    await gitRaw(["clone", "--branch", "main", remotePath, clonePath]);
+    await configureIdentity(clonePath);
+
+    // Simulate a prior task leaving a diverged feature branch checked out —
+    // this is the scenario that used to abort the merge and strand the repo.
+    await git(clonePath, ["checkout", "-b", "leftover-feature"]);
+    await writeFile(join(clonePath, "feature.txt"), "leftover work\n");
+    await commitAll(clonePath, "leftover feature commit");
+
+    await writeFile(join(upstreamPath, "remote.txt"), "remote commit\n");
+    await commitAll(upstreamPath, "remote commit");
+    await git(upstreamPath, ["push", "origin", "main"]);
+
+    const result = await withCleanGitEnv(() =>
+      ensureRepoForTask(
+        { url: remotePath, name: "repo", clonePath, defaultBranch: "main" },
+        "test",
+        true,
+      ),
+    );
+
+    expect(result.warning).toBeNull();
+    expect((await git(clonePath, ["rev-parse", "--abbrev-ref", "HEAD"])).trim()).toBe("main");
+    expect((await git(clonePath, ["rev-parse", "HEAD"])).trim()).toBe(
+      (await git(upstreamPath, ["rev-parse", "HEAD"])).trim(),
+    );
+    expect(await readFile(join(clonePath, "remote.txt"), "utf8")).toBe("remote commit\n");
+    expect((await git(clonePath, ["status", "--porcelain"])).trim()).toBe("");
+  });
+
+  test("resume/continuation (isFirstKickoff=false) leaves a leftover feature branch checked out", async () => {
+    const remotePath = join(tempRoot, "remote.git");
+    const upstreamPath = join(tempRoot, "upstream");
+    const clonePath = join(tempRoot, "clone");
+
+    await gitRaw(["init", "--bare", remotePath]);
+    await mkdir(upstreamPath);
+    await git(upstreamPath, ["init", "-b", "main"]);
+    await configureIdentity(upstreamPath);
+    await writeFile(join(upstreamPath, "README.md"), "initial\n");
+    await commitAll(upstreamPath, "initial commit");
+    await git(upstreamPath, ["remote", "add", "origin", remotePath]);
+    await git(upstreamPath, ["push", "-u", "origin", "main"]);
+
+    await gitRaw(["clone", "--branch", "main", remotePath, clonePath]);
+    await configureIdentity(clonePath);
+
+    await git(clonePath, ["checkout", "-b", "in-progress-feature"]);
+    await writeFile(join(clonePath, "feature.txt"), "in-progress work\n");
+    await commitAll(clonePath, "in-progress feature commit");
+
+    const result = await withCleanGitEnv(() =>
+      ensureRepoForTask(
+        { url: remotePath, name: "repo", clonePath, defaultBranch: "main" },
+        "test",
+        false,
+      ),
+    );
+
+    expect(result.warning).toBeNull();
+    expect((await git(clonePath, ["rev-parse", "--abbrev-ref", "HEAD"])).trim()).toBe(
+      "in-progress-feature",
+    );
+    expect(await readFile(join(clonePath, "feature.txt"), "utf8")).toBe("in-progress work\n");
+  });
 });

--- a/src/tests/runner-repo-autostash.test.ts
+++ b/src/tests/runner-repo-autostash.test.ts
@@ -4,7 +4,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { ensureRepoForTask } from "../commands/runner";
+import { ensureRepoForTask, isFirstKickoffTask } from "../commands/runner";
 
 const execFileAsync = promisify(execFile);
 
@@ -224,5 +224,28 @@ describe("ensureRepoForTask auto-stash refresh", () => {
       "in-progress-feature",
     );
     expect(await readFile(join(clonePath, "feature.txt"), "utf8")).toBe("in-progress work\n");
+  });
+});
+
+describe("isFirstKickoffTask", () => {
+  test("a follow-up/child task with a parentTaskId is still a first kickoff", () => {
+    expect(isFirstKickoffTask({ parentTaskId: "parent-1", taskType: "feature" })).toBe(true);
+  });
+
+  test("a pr-fix task with a parentTaskId is still a first kickoff", () => {
+    expect(isFirstKickoffTask({ parentTaskId: "parent-1", taskType: "pr-fix" })).toBe(true);
+  });
+
+  test("an explicit resume task is never a first kickoff", () => {
+    expect(isFirstKickoffTask({ taskType: "resume" })).toBe(false);
+  });
+
+  test("a brand-new top-level task with no fields at all is a first kickoff", () => {
+    expect(isFirstKickoffTask({})).toBe(true);
+  });
+
+  test("undefined/null task is a first kickoff (safe default)", () => {
+    expect(isFirstKickoffTask(undefined)).toBe(true);
+    expect(isFirstKickoffTask(null)).toBe(true);
   });
 });

--- a/src/tests/runner-repo-autostash.test.ts
+++ b/src/tests/runner-repo-autostash.test.ts
@@ -275,9 +275,9 @@ describe("isFirstKickoffTask", () => {
   });
 
   test("a genuinely new root task type (e.g. agentmail-message, no reserved taskType) stays a first kickoff", async () => {
-    expect(
-      await isFirstKickoffTask({ taskType: "agentmail-message" }, async () => null),
-    ).toBe(true);
+    expect(await isFirstKickoffTask({ taskType: "agentmail-message" }, async () => null)).toBe(
+      true,
+    );
   });
 
   // Regression: a parent-linked NON-resume follow-up (Slack follow-ups and

--- a/src/tests/runner-repo-autostash.test.ts
+++ b/src/tests/runner-repo-autostash.test.ts
@@ -228,24 +228,88 @@ describe("ensureRepoForTask auto-stash refresh", () => {
 });
 
 describe("isFirstKickoffTask", () => {
-  test("a follow-up/child task with a parentTaskId is still a first kickoff", () => {
-    expect(isFirstKickoffTask({ parentTaskId: "parent-1", taskType: "feature" })).toBe(true);
+  test("a feature task with a parentTaskId but an inactive/unknown parent is still a first kickoff", async () => {
+    expect(
+      await isFirstKickoffTask({ parentTaskId: "parent-1", taskType: "feature" }, async () => null),
+    ).toBe(true);
   });
 
-  test("a pr-fix task with a parentTaskId is still a first kickoff", () => {
-    expect(isFirstKickoffTask({ parentTaskId: "parent-1", taskType: "pr-fix" })).toBe(true);
+  test("a pr-fix task with a parentTaskId but an inactive/unknown parent is still a first kickoff", async () => {
+    expect(
+      await isFirstKickoffTask({ parentTaskId: "parent-1", taskType: "pr-fix" }, async () => null),
+    ).toBe(true);
   });
 
-  test("an explicit resume task is never a first kickoff", () => {
-    expect(isFirstKickoffTask({ taskType: "resume" })).toBe(false);
+  test("a parentTaskId with no status-checker at all is still a first kickoff (taskType alone decides)", async () => {
+    expect(await isFirstKickoffTask({ parentTaskId: "parent-1", taskType: "feature" })).toBe(true);
   });
 
-  test("a brand-new top-level task with no fields at all is a first kickoff", () => {
-    expect(isFirstKickoffTask({})).toBe(true);
+  test("an explicit resume task is never a first kickoff", async () => {
+    expect(await isFirstKickoffTask({ taskType: "resume" })).toBe(false);
   });
 
-  test("undefined/null task is a first kickoff (safe default)", () => {
-    expect(isFirstKickoffTask(undefined)).toBe(true);
-    expect(isFirstKickoffTask(null)).toBe(true);
+  test("a brand-new top-level task with no fields at all is a first kickoff", async () => {
+    expect(await isFirstKickoffTask({})).toBe(true);
+  });
+
+  test("undefined/null task is a first kickoff (safe default)", async () => {
+    expect(await isFirstKickoffTask(undefined)).toBe(true);
+    expect(await isFirstKickoffTask(null)).toBe(true);
+  });
+
+  test("known continuation task types are never a first kickoff, regardless of parent status", async () => {
+    const continuationTypes = [
+      "follow-up",
+      "reroute-decision",
+      "agentmail-reply",
+      "github-comment",
+      "github-review",
+      "gitlab-comment",
+      "gitlab-ci",
+    ];
+    for (const taskType of continuationTypes) {
+      expect(
+        await isFirstKickoffTask({ parentTaskId: "parent-1", taskType }, async () => null),
+      ).toBe(false);
+    }
+  });
+
+  test("a genuinely new root task type (e.g. agentmail-message, no reserved taskType) stays a first kickoff", async () => {
+    expect(
+      await isFirstKickoffTask({ taskType: "agentmail-message" }, async () => null),
+    ).toBe(true);
+  });
+
+  // Regression: a parent-linked NON-resume follow-up (Slack follow-ups and
+  // sibling-awareness both wire parentTaskId with no reserved taskType at
+  // all) must NOT take the hard-reset path when the parent it's continuing
+  // is still active — e.g. an in-progress sibling on the same worker with
+  // maxTasks > 1, or a paused task that may resume onto the same clone.
+  test("a Slack-style follow-up (no distinguishing taskType) with an in-progress parent is NOT a first kickoff", async () => {
+    const fetchParentTaskStatus = async (parentTaskId: string) => {
+      expect(parentTaskId).toBe("active-parent-1");
+      return "in_progress";
+    };
+    expect(
+      await isFirstKickoffTask({ parentTaskId: "active-parent-1" }, fetchParentTaskStatus),
+    ).toBe(false);
+  });
+
+  test("a sibling-awareness-linked task with a paused parent is NOT a first kickoff", async () => {
+    expect(
+      await isFirstKickoffTask(
+        { parentTaskId: "paused-parent-1", taskType: "github-pr" },
+        async () => "paused",
+      ),
+    ).toBe(false);
+  });
+
+  test("a parent-linked task whose parent already completed IS a first kickoff", async () => {
+    expect(
+      await isFirstKickoffTask(
+        { parentTaskId: "done-parent-1", taskType: "feature" },
+        async () => "completed",
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

Coding tasks kept starting work on a branch that was **behind master/main**. The root cause is in the runner's per-task repo refresh, `refreshExistingRepoForTask` (`src/commands/runner.ts`), which every coding task passes through at kickoff.

The worker's repo clone is **reused task-to-task** (there are no per-task worktrees). `refreshExistingRepoForTask` fetched `origin/<default>` at task start, but had two gaps:

1. **It never `git checkout <default>` first.** The fetch + merge landed on top of whatever leftover feature branch the *previous* task left checked out — not the base branch.
2. **It used `git merge`, not `git reset --hard`.** If that leftover branch had diverged from `origin/<default>`, the merge aborted and the branch was left stale — only a warning was logged, no hard failure and no fix.

## The fix

On a genuine **first kickoff**, `refreshExistingRepoForTask` now checks out the default branch and hard-resets it to the remote before the caller creates a new work branch:

```
git checkout <default>          # falls back to `checkout -B <default> origin/<default>` if the local branch is missing
git reset --hard origin/<default>
```

This guarantees a clean, current base every time.

## Why it's gated (and how)

A hard reset applied blindly would destroy in-progress work, since the clone is shared across a task's lifecycle. The reset is threaded through `ensureRepoForTask` → `refreshExistingRepoForTask` via an `isFirstKickoff` parameter that **defaults to `false`** (safe fallback), and only fires for genuine first kickoffs:

```ts
export function isFirstKickoffTask(task?: { taskType?: string } | null): boolean {
  return task?.taskType !== "resume";
}
```

- **Main task-processing loop** (`~line 5233`): `isFirstKickoff = isFirstKickoffTask(taskObj)` — true for everything except an explicit `taskType === "resume"` task.
- **Paused-task-resume-after-restart path** (`~line 4834`): always passes `isFirstKickoff: false` — it is *always* a resume.

**Why key off `taskType`, not `parentTaskId`?** `parentTaskId` is not a resume signal: `send-task` and the GitHub/GitLab/Linear trackers set it on ~every dispatched child task. Verified against two weeks of real data — **395/395 coder coding tasks (feature/bug/pr-fix) carried a non-null `parentTaskId`, and 0 were typed `resume`**. Gating on `!parentTaskId` would make the reset a no-op in production.

Native session-resume is deprecated (a fresh session is always spawned; continuity flows through the context preamble, not by restoring the clone's working tree). The only task shape that may still hold locally-committed-but-unpushed work on the checked-out branch is an explicit `taskType === "resume"` task (created by `supersedeTaskViaAPI` on crash/cap recovery) — which is exactly what the guard preserves. The boolean is extracted into an exported helper so it's covered by tests rather than living as an untested inline expression.

## Tests

`src/tests/runner-repo-autostash.test.ts` (9 passing):
- `isFirstKickoff=true` hard-resets a leftover diverged feature branch back to `origin/main` (the exact scenario that used to abort the merge and strand the repo).
- `isFirstKickoff=false` leaves an in-progress feature branch and its committed work untouched.
- `isFirstKickoffTask()` unit tests over the real task shapes: `{parentTaskId, taskType:"feature"}` → true, `{parentTaskId, taskType:"pr-fix"}` → true, `{taskType:"resume"}` → false, `{}` → true, `undefined`/`null` → true.

## PR checks

- `bun run lint:fix`, `bun run tsc:check` — clean
- `bun test src/tests/runner-repo-autostash.test.ts` — 9 pass
- `bash scripts/check-db-boundary.sh` — passed
- `bun run check:dep-graph` — 0 errors (pre-existing warnings only)
- Remote CI — all required checks green: Lint and Type Check, Run Tests, Docker Build (×3), Merge Gate, Migration Conflict Check
