### PR TITLE
chore(worker): add postgresql-16-pgvector to worker image

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -58,6 +58,7 @@ RUN apt-get update && apt-get install -y curl ca-certificates gnupg \
     openssh-client \
     postgresql-client \
     postgresql-16 \
+    postgresql-16-pgvector \
     postgresql-contrib-16 \
     nodejs \
     gh \


### PR DESCRIPTION
## Summary
Adds the `postgresql-16-pgvector` OS package (Ubuntu 24.04 `universe`, no PGDG repo needed) alongside the existing `postgresql-16` / `postgresql-contrib-16` install in `Dockerfile.worker`, so `CREATE EXTENSION IF NOT EXISTS vector;` works inside worker containers. Without it, workers hit a missing `vector.control`/`vector.so` and cannot self-install (no sudo, root-owned target dirs) — this blocks pgvector-backed integration specs (e.g. client-monorepo PR #29765).

## Test plan
- [x] Confirmed base image is `ubuntu:24.04` (`noble`) and `universe` is enabled in `Dockerfile.worker`.
- [x] No local Docker/sudo available in this environment to do a full image build (workers have neither — see `no-local-postgres-in-worker-containers` finding). Verified package resolution instead by downloading the live `noble/universe/binary-amd64/Packages.gz` index directly from `archive.ubuntu.com` and confirming `postgresql-16-pgvector` (0.6.0-1) exists there with `Depends: postgresql-16, postgresql-16-jit-llvm (>= 17), libc6` — both deps already present/pulled automatically, no extra repo/key setup required.
- [ ] Full `docker build -f Dockerfile.worker .` should still be run in CI/by a reviewer to confirm the layer builds end-to-end.