### PR TITLE
rbac: permission_audit log — async batched writer + retention (DES-445 increment 2)

### DIFF
--- a/.non-audit-tables
+++ b/.non-audit-tables
@@ -19,6 +19,7 @@ memory_retrieval
 oauth_apps
 oauth_refresh_locks
 oauth_tokens
+permission_audit
 script_embeddings
 seed_state
 session_costs

--- a/src/be/migrations/108_rbac_permission_audit.sql
+++ b/src/be/migrations/108_rbac_permission_audit.sql
@@ -1,0 +1,26 @@
+-- RBAC permission-audit trail (DES-445, slice 1 / increment 2).
+-- One row per can() authorization decision — allow AND deny — written by the
+-- async batched writer in src/be/rbac-audit.ts. Answers "which permission was
+-- missing, at which layer" without grepping logs. Rows are structured
+-- ids/verbs only (no payloads); retention GC purges rows older than
+-- RBAC_AUDIT_RETENTION_DAYS (default 30).
+-- originatorUserId is reserved for originating-user propagation (later
+-- increment); the slice-1 RbacCheck does not carry it yet.
+
+CREATE TABLE IF NOT EXISTS permission_audit (
+  id               TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  ts               TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  principalType    TEXT NOT NULL CHECK (principalType IN ('agent','user','operator')),
+  principalId      TEXT,
+  originatorUserId TEXT,
+  verb             TEXT NOT NULL,
+  resourceType     TEXT,
+  resourceId       TEXT,
+  decision         TEXT NOT NULL CHECK (decision IN ('allow','deny')),
+  reason           TEXT,
+  source           TEXT NOT NULL CHECK (source IN ('mcp','http'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_permission_audit_ts ON permission_audit(ts);
+CREATE INDEX IF NOT EXISTS idx_permission_audit_decision_ts ON permission_audit(decision, ts);
+CREATE INDEX IF NOT EXISTS idx_permission_audit_principal_ts ON permission_audit(principalId, ts);

--- a/src/be/rbac-audit.ts
+++ b/src/be/rbac-audit.ts
@@ -1,0 +1,197 @@
+/**
+ * RBAC permission-audit batched writer + retention GC (DES-445, Phase 6).
+ *
+ * `enqueueAuditRow` is the concrete `AuditSink` wired into `can()` at server
+ * boot (src/http/index.ts, src/stdio.ts). Rows buffer in memory and flush in
+ * a single prepared-statement transaction every FLUSH_INTERVAL_MS (2s) or at
+ * FLUSH_MAX_ROWS (200), whichever comes first. Every path is try/caught — a
+ * failed flush logs a warning and DROPS the batch; auditing must never throw
+ * into the request path. Rows are structured ids/verbs only (no payloads, no
+ * secret-bearing content).
+ *
+ * Kill-switch: `RBAC_AUDIT_DISABLED=true` makes the sink a no-op (checked per
+ * call so tests and live config reloads can toggle it).
+ *
+ * Retention: `startAuditGc` (pattern: startMemoryGc in src/http/memory.ts)
+ * ticks daily and deletes rows older than RBAC_AUDIT_RETENTION_DAYS
+ * (default 30).
+ */
+import type { RbacCheck, RbacDecision } from "../rbac";
+import { getDb } from "./db";
+
+type AuditRow = {
+  principalType: "agent" | "user" | "operator";
+  principalId: string | null;
+  originatorUserId: string | null;
+  verb: string;
+  resourceType: string | null;
+  resourceId: string | null;
+  decision: "allow" | "deny";
+  reason: string | null;
+  source: "mcp" | "http";
+};
+
+const FLUSH_INTERVAL_MS = 2_000;
+const FLUSH_MAX_ROWS = 200;
+const AUDIT_GC_INTERVAL_MS = 24 * 60 * 60 * 1000; // daily
+const DEFAULT_RETENTION_DAYS = 30;
+
+let buffer: AuditRow[] = [];
+let flushTimer: ReturnType<typeof setInterval> | null = null;
+let auditGcTimer: ReturnType<typeof setInterval> | null = null;
+
+function isAuditDisabled(): boolean {
+  return process.env.RBAC_AUDIT_DISABLED === "true";
+}
+
+function principalIdOf(principal: RbacCheck["principal"]): string | null {
+  switch (principal.kind) {
+    case "agent":
+      return principal.agentId;
+    case "user":
+      return principal.userId;
+    case "operator":
+      return null;
+  }
+}
+
+function resourceIdOf(resource: RbacCheck["resource"]): string | null {
+  if (!resource) return null;
+  switch (resource.kind) {
+    case "task":
+      return resource.taskId;
+    case "agent":
+      return resource.agentId;
+    case "kv-namespace":
+      return resource.namespace;
+    case "owned":
+      return resource.ownerAgentId ?? null;
+    case "none":
+      return null;
+  }
+}
+
+function toRow(check: RbacCheck, decision: RbacDecision): AuditRow {
+  return {
+    principalType: check.principal.kind,
+    principalId: principalIdOf(check.principal),
+    // Reserved: slice-1 RbacCheck carries no originating-user field yet.
+    originatorUserId: null,
+    verb: check.verb,
+    resourceType: check.resource?.kind ?? null,
+    resourceId: resourceIdOf(check.resource),
+    decision: decision.allow ? "allow" : "deny",
+    reason: decision.allow ? null : decision.reason,
+    source: check.source,
+  };
+}
+
+/**
+ * The concrete AuditSink for `can()`. Never throws — `can()` already swallows
+ * sink exceptions, but the audit path defends independently.
+ */
+export function enqueueAuditRow(check: RbacCheck, decision: RbacDecision): void {
+  if (isAuditDisabled()) return;
+  try {
+    buffer.push(toRow(check, decision));
+    if (buffer.length >= FLUSH_MAX_ROWS) flushAuditBuffer();
+  } catch (err) {
+    console.warn("[rbac-audit] enqueue failed, dropping row:", (err as Error).message);
+  }
+}
+
+/**
+ * Drain the buffer into permission_audit in one transaction. Called by the
+ * flush interval, the 200-row threshold, and shutdown. A failed flush logs a
+ * warning and drops the batch — never throws.
+ */
+export function flushAuditBuffer(): void {
+  if (buffer.length === 0) return;
+  const rows = buffer;
+  buffer = [];
+  try {
+    const db = getDb();
+    const stmt = db.prepare(
+      `INSERT INTO permission_audit
+         (principalType, principalId, originatorUserId, verb, resourceType, resourceId, decision, reason, source)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const insertAll = db.transaction((batch: AuditRow[]) => {
+      for (const r of batch) {
+        stmt.run(
+          r.principalType,
+          r.principalId,
+          r.originatorUserId,
+          r.verb,
+          r.resourceType,
+          r.resourceId,
+          r.decision,
+          r.reason,
+          r.source,
+        );
+      }
+    });
+    insertAll(rows);
+  } catch (err) {
+    console.warn(
+      `[rbac-audit] flush failed, dropping ${rows.length} row(s):`,
+      (err as Error).message,
+    );
+  }
+}
+
+/** Start the periodic flush (2s tick). Idempotent. */
+export function startAuditWriter(intervalMs = FLUSH_INTERVAL_MS): void {
+  if (flushTimer) return;
+  flushTimer = setInterval(() => flushAuditBuffer(), intervalMs);
+  if (typeof flushTimer?.unref === "function") flushTimer.unref();
+}
+
+/** Stop the periodic flush. Does NOT flush — shutdown calls flushAuditBuffer(). */
+export function stopAuditWriter(): void {
+  if (flushTimer) {
+    clearInterval(flushTimer);
+    flushTimer = null;
+  }
+}
+
+/** Delete audit rows older than the retention window. Returns rows deleted. */
+export function purgeExpiredAuditRows(): number {
+  try {
+    const days = Number(process.env.RBAC_AUDIT_RETENTION_DAYS) || DEFAULT_RETENTION_DAYS;
+    // ts is CURRENT_TIMESTAMP format ("YYYY-MM-DD HH:MM:SS"); compute the
+    // cutoff in SQLite so the string formats always match.
+    const result = getDb()
+      .prepare("DELETE FROM permission_audit WHERE ts < datetime('now', ?)")
+      .run(`-${days} days`);
+    return result.changes;
+  } catch (err) {
+    console.warn("[rbac-audit] retention purge failed:", (err as Error).message);
+    return 0;
+  }
+}
+
+/** Start the retention GC (daily tick, immediate first run). Idempotent. */
+export function startAuditGc(intervalMs = AUDIT_GC_INTERVAL_MS): void {
+  if (auditGcTimer) return;
+
+  const purged = purgeExpiredAuditRows();
+  if (purged > 0) {
+    console.log(`[rbac-audit] Initial retention purge removed ${purged} audit row(s)`);
+  }
+
+  auditGcTimer = setInterval(() => {
+    const n = purgeExpiredAuditRows();
+    if (n > 0) {
+      console.log(`[rbac-audit] Retention purge removed ${n} audit row(s)`);
+    }
+  }, intervalMs);
+  if (typeof auditGcTimer?.unref === "function") auditGcTimer.unref();
+}
+
+export function stopAuditGc(): void {
+  if (auditGcTimer) {
+    clearInterval(auditGcTimer);
+    auditGcTimer = null;
+  }
+}

--- a/src/be/rbac-audit.ts
+++ b/src/be/rbac-audit.ts
@@ -39,6 +39,7 @@ const DEFAULT_RETENTION_DAYS = 30;
 let buffer: AuditRow[] = [];
 let flushTimer: ReturnType<typeof setInterval> | null = null;
 let auditGcTimer: ReturnType<typeof setInterval> | null = null;
+let thresholdFlushScheduled = false;
 
 function isAuditDisabled(): boolean {
   return process.env.RBAC_AUDIT_DISABLED === "true";
@@ -94,7 +95,17 @@ export function enqueueAuditRow(check: RbacCheck, decision: RbacDecision): void 
   if (isAuditDisabled()) return;
   try {
     buffer.push(toRow(check, decision));
-    if (buffer.length >= FLUSH_MAX_ROWS) flushAuditBuffer();
+    // The threshold flush is deferred to a zero-delay timeout so the can()
+    // call that happens to be the 200th never pays for the SQLite transaction
+    // itself — audit stays fire-and-forget on the request path.
+    if (buffer.length >= FLUSH_MAX_ROWS && !thresholdFlushScheduled) {
+      thresholdFlushScheduled = true;
+      const t = setTimeout(() => {
+        thresholdFlushScheduled = false;
+        flushAuditBuffer();
+      }, 0);
+      if (typeof t.unref === "function") t.unref();
+    }
   } catch (err) {
     console.warn("[rbac-audit] enqueue failed, dropping row:", (err as Error).message);
   }

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -517,6 +517,15 @@ try {
   console.error("[startup] Failed to seed built-in entities:", err);
 }
 
+// Wire the RBAC permission-audit sink into can() and start the batched writer
+// (2s flush) + retention GC (daily tick) BEFORE the server accepts traffic —
+// installing it inside the listen callback would leave an unaudited startup
+// window (requests can land while telemetry/Slack init awaits are pending).
+// RBAC_AUDIT_DISABLED=true makes the sink a no-op inside enqueueAuditRow.
+setAuditSink(enqueueAuditRow);
+startAuditWriter();
+startAuditGc();
+
 // business-use initialization (no-op if envs not set)
 initialize();
 
@@ -608,12 +617,7 @@ httpServer
     // Start expired-memory garbage collector (1-hour tick, immediate first run)
     startMemoryGc();
 
-    // Wire the RBAC permission-audit sink into can() and start the batched
-    // writer (2s flush) + retention GC (daily tick). RBAC_AUDIT_DISABLED=true
-    // makes the sink a no-op inside enqueueAuditRow.
-    setAuditSink(enqueueAuditRow);
-    startAuditWriter();
-    startAuditGc();
+    // (RBAC audit sink is wired pre-listen — see above httpServer.listen.)
 
     // Background backfill: re-embed any agent_memory rows with wrong-dimension
     // embeddings (e.g. 1536d instead of 512d). Non-blocking, idempotent, no-op

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -9,6 +9,14 @@ import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/se
 import { getEnabledCapabilities, hasCapability } from "@/server";
 import { initAgentMail } from "../agentmail";
 import { closeDb, getSwarmConfigs, upsertSwarmConfig } from "../be/db";
+import {
+  enqueueAuditRow,
+  flushAuditBuffer,
+  startAuditGc,
+  startAuditWriter,
+  stopAuditGc,
+  stopAuditWriter,
+} from "../be/rbac-audit";
 import { initGitHub } from "../github";
 import { initGitLab } from "../gitlab";
 import { stopHeartbeat } from "../heartbeat";
@@ -21,6 +29,7 @@ import {
   withRemoteContext,
   withSpanContext,
 } from "../otel";
+import { clearAuditSink, setAuditSink } from "../rbac";
 import { startScriptRunSupervisor, stopScriptRunSupervisor } from "../script-workflows/supervisor";
 import { getServerSessionsProcessed } from "../server-runtime-counters";
 import { startSlackApp, stopSlackApp } from "../slack";
@@ -416,6 +425,12 @@ async function shutdown() {
   // Stop memory expired-row garbage collector
   stopMemoryGc();
 
+  // Stop RBAC audit: retention GC, flush interval, final drain, detach sink
+  stopAuditGc();
+  stopAuditWriter();
+  flushAuditBuffer();
+  clearAuditSink();
+
   if (globalState.__apiGcInterval) {
     clearInterval(globalState.__apiGcInterval);
     delete globalState.__apiGcInterval;
@@ -592,6 +607,13 @@ httpServer
 
     // Start expired-memory garbage collector (1-hour tick, immediate first run)
     startMemoryGc();
+
+    // Wire the RBAC permission-audit sink into can() and start the batched
+    // writer (2s flush) + retention GC (daily tick). RBAC_AUDIT_DISABLED=true
+    // makes the sink a no-op inside enqueueAuditRow.
+    setAuditSink(enqueueAuditRow);
+    startAuditWriter();
+    startAuditGc();
 
     // Background backfill: re-embed any agent_memory rows with wrong-dimension
     // embeddings (e.g. 1536d instead of 512d). Non-blocking, idempotent, no-op

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -33,13 +33,28 @@ async function main() {
 // NOTE: main() resolves right after the transport starts (the process stays
 // alive on stdin), so `.finally` below runs post-boot — NOT at shutdown.
 // getDb() lazily re-opens on the next query, which is why the existing
-// closeDb() here is harmless. Audit teardown must therefore hang off process
-// exit, where the synchronous final flush drains any buffered rows.
-process.on("exit", () => {
+// closeDb() here is harmless. Audit teardown therefore hangs off process
+// exit, where the synchronous final flush drains any buffered rows — and
+// because the `exit` event does NOT fire on SIGINT/SIGTERM, those signals get
+// explicit handlers that drain and then exit (supervisors stop stdio workers
+// with SIGTERM; without this, up to 199 buffered rows would be lost).
+let auditDrained = false;
+function drainAudit() {
+  if (auditDrained) return;
+  auditDrained = true;
   stopAuditGc();
   stopAuditWriter();
   flushAuditBuffer();
   clearAuditSink();
+}
+process.on("exit", drainAudit);
+process.on("SIGINT", () => {
+  drainAudit();
+  process.exit(130);
+});
+process.on("SIGTERM", () => {
+  drainAudit();
+  process.exit(143);
 });
 
 main()

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -1,9 +1,25 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "@/server";
 import { closeDb } from "./be/db";
+import {
+  enqueueAuditRow,
+  flushAuditBuffer,
+  startAuditGc,
+  startAuditWriter,
+  stopAuditGc,
+  stopAuditWriter,
+} from "./be/rbac-audit";
+import { clearAuditSink, setAuditSink } from "./rbac";
 
 async function main() {
+  // createServer() initializes the DB, so this standalone stdio transport OWNS
+  // the database and serves the same gated tools as src/http — wire the RBAC
+  // permission-audit sink here too (DES-445 Phase 6; plan "stdio blind spot").
   const server = createServer();
+  setAuditSink(enqueueAuditRow);
+  startAuditWriter();
+  startAuditGc();
+
   const transport = new StdioServerTransport();
 
   await server.connect(transport);
@@ -13,6 +29,18 @@ async function main() {
     data: "MCP server connected via stdio",
   });
 }
+
+// NOTE: main() resolves right after the transport starts (the process stays
+// alive on stdin), so `.finally` below runs post-boot — NOT at shutdown.
+// getDb() lazily re-opens on the next query, which is why the existing
+// closeDb() here is harmless. Audit teardown must therefore hang off process
+// exit, where the synchronous final flush drains any buffered rows.
+process.on("exit", () => {
+  stopAuditGc();
+  stopAuditWriter();
+  flushAuditBuffer();
+  clearAuditSink();
+});
 
 main()
   .catch(console.error)

--- a/src/tests/rbac-audit.test.ts
+++ b/src/tests/rbac-audit.test.ts
@@ -1,0 +1,341 @@
+/**
+ * RBAC permission-audit writer tests (DES-445, Phase 6).
+ *
+ * Covers the batched writer in src/be/rbac-audit.ts end-to-end against a real
+ * migrated DB: buffer + flush persistence (allow AND deny, all columns),
+ * the 200-row threshold, the interval flush, the RBAC_AUDIT_DISABLED
+ * kill-switch, flush resilience to a throwing DB, retention purge, the
+ * shutdown drain, and one migrated MCP gate (inject-learning) exercised
+ * through its real handler.
+ *
+ * Timer hygiene (plan Review Errata): bun test leaks module state
+ * process-wide, so EVERY interval started here is stopped in afterEach —
+ * dangling timers poison unrelated suites.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { unlink } from "node:fs/promises";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { closeDb, createAgent, getDb, initDb } from "../be/db";
+import {
+  enqueueAuditRow,
+  flushAuditBuffer,
+  purgeExpiredAuditRows,
+  startAuditGc,
+  startAuditWriter,
+  stopAuditGc,
+  stopAuditWriter,
+} from "../be/rbac-audit";
+import { can, clearAuditSink, setAuditSink } from "../rbac";
+import { registerInjectLearningTool } from "../tools/inject-learning";
+
+const TEST_DB_PATH = "./test-rbac-audit.sqlite";
+
+const LEAD_ID = "aaaa6000-0000-4000-8000-000000000001";
+const WORKER_ID = "bbbb6000-0000-4000-8000-000000000002";
+
+type AuditRowSelect = {
+  principalType: string;
+  principalId: string | null;
+  originatorUserId: string | null;
+  verb: string;
+  resourceType: string | null;
+  resourceId: string | null;
+  decision: string;
+  reason: string | null;
+  source: string;
+};
+
+function selectAuditRows(): AuditRowSelect[] {
+  return getDb()
+    .prepare(
+      `SELECT principalType, principalId, originatorUserId, verb, resourceType, resourceId,
+              decision, reason, source
+       FROM permission_audit ORDER BY ts, id`,
+    )
+    .all() as AuditRowSelect[];
+}
+
+function countAuditRows(): number {
+  const row = getDb().prepare("SELECT count(*) AS n FROM permission_audit").get() as { n: number };
+  return row.n;
+}
+
+async function removeDbFiles() {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      await unlink(TEST_DB_PATH + suffix);
+    } catch {
+      // File doesn't exist
+    }
+  }
+}
+
+let savedEnv: NodeJS.ProcessEnv;
+
+beforeAll(async () => {
+  savedEnv = { ...process.env };
+  delete process.env.RBAC_AUDIT_DISABLED;
+  delete process.env.RBAC_AUDIT_RETENTION_DAYS;
+
+  closeDb();
+  await removeDbFiles();
+  initDb(TEST_DB_PATH);
+
+  createAgent({ id: LEAD_ID, name: "Audit Lead", isLead: true, status: "idle" });
+  createAgent({ id: WORKER_ID, name: "Audit Worker", isLead: false, status: "idle" });
+});
+
+afterAll(async () => {
+  stopAuditWriter();
+  stopAuditGc();
+  clearAuditSink();
+  closeDb();
+  await removeDbFiles();
+
+  for (const key of Object.keys(process.env)) {
+    if (!(key in savedEnv)) delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+beforeEach(() => {
+  // Drain any leftover buffered rows, then start each test from a clean table.
+  flushAuditBuffer();
+  getDb().run("DELETE FROM permission_audit");
+  delete process.env.RBAC_AUDIT_DISABLED;
+  delete process.env.RBAC_AUDIT_RETENTION_DAYS;
+});
+
+afterEach(() => {
+  // CRITICAL: never leak intervals across test files (bun test module-state
+  // leakage) — stop both timers and detach the sink after every test.
+  stopAuditWriter();
+  stopAuditGc();
+  clearAuditSink();
+});
+
+describe("buffer + flush persistence", () => {
+  test("persists allow AND deny rows from can() with correct columns", () => {
+    setAuditSink(enqueueAuditRow);
+
+    const allow = can({
+      principal: { kind: "agent", agentId: LEAD_ID, isLead: true },
+      verb: "memory.learning.inject",
+      resource: { kind: "agent", agentId: WORKER_ID },
+      source: "mcp",
+    });
+    const deny = can({
+      principal: { kind: "agent", agentId: WORKER_ID, isLead: false },
+      verb: "memory.learning.inject",
+      resource: { kind: "agent", agentId: LEAD_ID },
+      source: "http",
+    });
+    expect(allow.allow).toBe(true);
+    expect(deny.allow).toBe(false);
+
+    // Buffered, not yet written.
+    expect(countAuditRows()).toBe(0);
+
+    flushAuditBuffer();
+
+    const rows = selectAuditRows();
+    expect(rows.length).toBe(2);
+
+    const allowRow = rows.find((r) => r.decision === "allow");
+    expect(allowRow).toMatchObject({
+      principalType: "agent",
+      principalId: LEAD_ID,
+      originatorUserId: null,
+      verb: "memory.learning.inject",
+      resourceType: "agent",
+      resourceId: WORKER_ID,
+      decision: "allow",
+      reason: null,
+      source: "mcp",
+    });
+
+    const denyRow = rows.find((r) => r.decision === "deny");
+    expect(denyRow).toMatchObject({
+      principalType: "agent",
+      principalId: WORKER_ID,
+      verb: "memory.learning.inject",
+      resourceType: "agent",
+      resourceId: LEAD_ID,
+      decision: "deny",
+      source: "http",
+    });
+    expect(denyRow?.reason).toBeTruthy();
+  });
+
+  test("auto-flushes at the 200-row threshold without a timer", () => {
+    for (let i = 0; i < 200; i++) {
+      enqueueAuditRow(
+        { principal: { kind: "operator" }, verb: "user.manage", source: "http" },
+        { allow: true },
+      );
+    }
+    // No flushAuditBuffer() call — the threshold flushed synchronously.
+    expect(countAuditRows()).toBe(200);
+  });
+
+  test("interval flush drains the buffer", async () => {
+    startAuditWriter(25);
+    enqueueAuditRow(
+      { principal: { kind: "user", userId: "user-1" }, verb: "user.manage", source: "http" },
+      { allow: true },
+    );
+    expect(countAuditRows()).toBe(0);
+
+    await Bun.sleep(120);
+    expect(countAuditRows()).toBe(1);
+    const row = selectAuditRows()[0];
+    expect(row).toMatchObject({ principalType: "user", principalId: "user-1" });
+  });
+});
+
+describe("kill-switch", () => {
+  test("RBAC_AUDIT_DISABLED=true writes nothing", () => {
+    process.env.RBAC_AUDIT_DISABLED = "true";
+    setAuditSink(enqueueAuditRow);
+
+    can({
+      principal: { kind: "agent", agentId: WORKER_ID, isLead: false },
+      verb: "memory.learning.inject",
+      source: "mcp",
+    });
+    enqueueAuditRow(
+      { principal: { kind: "operator" }, verb: "user.manage", source: "http" },
+      { allow: true },
+    );
+    flushAuditBuffer();
+
+    expect(countAuditRows()).toBe(0);
+  });
+});
+
+describe("flush resilience", () => {
+  test("throwing DB during flush does not propagate (batch dropped)", () => {
+    enqueueAuditRow(
+      { principal: { kind: "operator" }, verb: "user.manage", source: "http" },
+      { allow: true },
+    );
+
+    getDb().run("ALTER TABLE permission_audit RENAME TO permission_audit_broken");
+    try {
+      expect(() => flushAuditBuffer()).not.toThrow();
+    } finally {
+      getDb().run("ALTER TABLE permission_audit_broken RENAME TO permission_audit");
+    }
+
+    // Batch was dropped, not retried.
+    expect(countAuditRows()).toBe(0);
+    flushAuditBuffer();
+    expect(countAuditRows()).toBe(0);
+  });
+});
+
+describe("retention purge", () => {
+  test("deletes only rows older than the cutoff (default 30 days)", () => {
+    const insert = getDb().prepare(
+      `INSERT INTO permission_audit (ts, principalType, verb, decision, source)
+       VALUES (datetime('now', ?), 'agent', 'user.manage', 'deny', 'mcp')`,
+    );
+    insert.run("-40 days");
+    insert.run("-29 days");
+    insert.run("-0 seconds");
+    expect(countAuditRows()).toBe(3);
+
+    const purged = purgeExpiredAuditRows();
+    expect(purged).toBe(1);
+    expect(countAuditRows()).toBe(2);
+  });
+
+  test("respects RBAC_AUDIT_RETENTION_DAYS override and runs via startAuditGc", () => {
+    process.env.RBAC_AUDIT_RETENTION_DAYS = "7";
+    const insert = getDb().prepare(
+      `INSERT INTO permission_audit (ts, principalType, verb, decision, source)
+       VALUES (datetime('now', ?), 'agent', 'user.manage', 'deny', 'mcp')`,
+    );
+    insert.run("-10 days");
+    insert.run("-1 days");
+
+    // startAuditGc purges immediately on start (pattern: startMemoryGc).
+    startAuditGc();
+    expect(countAuditRows()).toBe(1);
+    stopAuditGc();
+  });
+});
+
+describe("shutdown flush", () => {
+  test("final flushAuditBuffer() drains everything below the thresholds", () => {
+    enqueueAuditRow(
+      {
+        principal: { kind: "agent", agentId: WORKER_ID, isLead: false },
+        verb: "user.manage",
+        source: "mcp",
+      },
+      { allow: false, reason: "requires lead agent", missing: "user.manage" },
+    );
+    enqueueAuditRow(
+      { principal: { kind: "operator" }, verb: "user.manage", source: "http" },
+      { allow: true },
+    );
+    expect(countAuditRows()).toBe(0);
+
+    // Shutdown path: stop the timer first, then drain.
+    stopAuditWriter();
+    flushAuditBuffer();
+    expect(countAuditRows()).toBe(2);
+
+    // Buffer is empty afterwards — a second drain writes nothing.
+    flushAuditBuffer();
+    expect(countAuditRows()).toBe(2);
+  });
+});
+
+describe("migrated gate end-to-end (inject-learning)", () => {
+  type ToolResult = {
+    content: Array<{ type: string; text: string }>;
+    structuredContent: { success: boolean; message: string };
+  };
+
+  test("worker call → soft denial → flush → deny audit row with expected verb", async () => {
+    setAuditSink(enqueueAuditRow);
+
+    const server = new McpServer({ name: "test-rbac-audit", version: "1.0.0" });
+    registerInjectLearningTool(server);
+    const tools = (
+      server as unknown as {
+        // biome-ignore lint/complexity/noBannedTypes: internal MCP SDK type, test-only
+        _registeredTools: Record<string, { handler: Function }>;
+      }
+    )._registeredTools;
+    const handler = tools["inject-learning"]?.handler;
+    expect(handler).toBeDefined();
+
+    const result = (await handler?.(
+      { agentId: LEAD_ID, learning: "audit e2e learning", category: "best-practice" },
+      {
+        sessionId: "test-session",
+        requestInfo: { headers: { "x-agent-id": WORKER_ID } },
+      },
+    )) as ToolResult;
+    expect(result.structuredContent.success).toBe(false);
+
+    flushAuditBuffer();
+
+    const rows = selectAuditRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0]).toMatchObject({
+      principalType: "agent",
+      principalId: WORKER_ID,
+      verb: "memory.learning.inject",
+      decision: "deny",
+      source: "mcp",
+    });
+    expect(rows[0]?.reason).toBeTruthy();
+  });
+});

--- a/src/tests/rbac-audit.test.ts
+++ b/src/tests/rbac-audit.test.ts
@@ -170,14 +170,18 @@ describe("buffer + flush persistence", () => {
     expect(denyRow?.reason).toBeTruthy();
   });
 
-  test("auto-flushes at the 200-row threshold without a timer", () => {
+  test("auto-flushes at the 200-row threshold without the interval writer", async () => {
     for (let i = 0; i < 200; i++) {
       enqueueAuditRow(
         { principal: { kind: "operator" }, verb: "user.manage", source: "http" },
         { allow: true },
       );
     }
-    // No flushAuditBuffer() call — the threshold flushed synchronously.
+    // The threshold flush is deferred off the enqueue path (zero-delay
+    // timeout) so the 200th can() call never blocks on the transaction —
+    // nothing is persisted synchronously, everything lands a tick later.
+    expect(countAuditRows()).toBe(0);
+    await Bun.sleep(10);
     expect(countAuditRows()).toBe(200);
   });
 

--- a/thoughts/taras/plans/2026-07-07-des-445-rbac-slice1-can-audit.md
+++ b/thoughts/taras/plans/2026-07-07-des-445-rbac-slice1-can-audit.md
@@ -6,7 +6,7 @@ topic: "DES-445 RBAC — Slice 1: central can() + audit log (increments 1+2)"
 tags: [plan, rbac, auth, security, des-445]
 status: in-progress
 last_updated: 2026-07-07
-last_updated_by: Claude (phase-5 agent)
+last_updated_by: Claude (phase-6 agent)
 related_brainstorm: thoughts/taras/brainstorms/2026-05-15-rbac-for-swarm.md
 related_research: thoughts/taras/research/2026-07-06-rbac-enforcement-surfaces.md
 ---
@@ -327,15 +327,15 @@ Deliverable: `permission_audit` table + always-on async batched writer hung off 
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Audit tests pass: `bun test src/tests/rbac-audit.test.ts`
-- [ ] Full suite: `bun test`
-- [ ] Types + lint + boundaries: `bun run tsc:check && bun run lint && bash scripts/check-db-boundary.sh && bash scripts/check-rbac-boundary.sh && bun run check:dep-graph`
-- [ ] Fresh-DB migration applies: `rm -f agent-swarm-db.sqlite agent-swarm-db.sqlite-wal agent-swarm-db.sqlite-shm && bun run start:http` boots clean (then Ctrl-C)
-- [ ] Existing-DB migration applies: restart `bun run start:http` against a pre-existing DB copy — runner applies 108 forward-only without error
+- [x] Audit tests pass: `bun test src/tests/rbac-audit.test.ts`
+- [x] Full suite: `bun test`
+- [x] Types + lint + boundaries: `bun run tsc:check && bun run lint && bash scripts/check-db-boundary.sh && bash scripts/check-rbac-boundary.sh && bun run check:dep-graph`
+- [x] Fresh-DB migration applies: `rm -f agent-swarm-db.sqlite agent-swarm-db.sqlite-wal agent-swarm-db.sqlite-shm && bun run start:http` boots clean (then Ctrl-C) — verified against a scratch `DATABASE_PATH`, 106 migrations incl. 108 applied clean
+- [x] Existing-DB migration applies: restart `bun run start:http` against a pre-existing DB copy — runner applies 108 forward-only without error (second boot applied 0 migrations, no errors)
 
 #### Automated QA:
-- [ ] With the server running, exercise a gated MCP tool as a worker (handshake per LOCAL_TESTING.md §"MCP tool testing over HTTP"), then `sqlite3 agent-swarm-db.sqlite "SELECT verb, decision, principalType, source FROM permission_audit ORDER BY ts DESC LIMIT 5;"` shows the deny row
-- [ ] Restart server with `RBAC_AUDIT_DISABLED=true`, repeat the tool call, confirm row count unchanged
+- [x] With the server running, exercise a gated MCP tool as a worker (handshake per LOCAL_TESTING.md §"MCP tool testing over HTTP"), then `sqlite3 agent-swarm-db.sqlite "SELECT verb, decision, principalType, source FROM permission_audit ORDER BY ts DESC LIMIT 5;"` shows the deny row — got `memory.learning.inject|deny|agent|mcp|requires lead agent`
+- [x] Restart server with `RBAC_AUDIT_DISABLED=true`, repeat the tool call, confirm row count unchanged — count stayed 1
 
 #### Manual Verification:
 - [ ] Taras spot-checks audit row `reason` strings for debuggability (the brainstorm's key UX win — "which permission was missing, at which layer")

--- a/thoughts/taras/plans/2026-07-07-des-445-rbac-slice1-can-audit.md
+++ b/thoughts/taras/plans/2026-07-07-des-445-rbac-slice1-can-audit.md
@@ -4,9 +4,9 @@ author: Claude
 planner: Claude
 topic: "DES-445 RBAC — Slice 1: central can() + audit log (increments 1+2)"
 tags: [plan, rbac, auth, security, des-445]
-status: in-progress
+status: completed
 last_updated: 2026-07-07
-last_updated_by: Claude (phase-6 agent)
+last_updated_by: Claude (orchestrator — whole-slice E2E passed)
 related_brainstorm: thoughts/taras/brainstorms/2026-05-15-rbac-for-swarm.md
 related_research: thoughts/taras/research/2026-07-06-rbac-enforcement-surfaces.md
 ---


### PR DESCRIPTION
## Summary

Increment 2 of DES-445, stacked on #921 (increment 1 — merge that first; this PR's base is `feat-rbac-1`).

Hangs the audit log off the `can()` sink seam introduced in increment 1: one `permission_audit` row per authorization decision, allow AND deny, always-on with a kill-switch.

- **Migration 108**: `permission_audit` (structured fields only — principal, verb, resource, decision, reason, source; no payloads) + indexes on `ts`, `(decision, ts)`, `(principalId, ts)`.
- **`src/be/rbac-audit.ts`**: in-memory buffer, flushed every 2s or 200 rows (whichever first) in a single prepared-statement transaction. Fire-and-forget — a failed flush warns and drops, never throws into the request path. `RBAC_AUDIT_DISABLED=true` no-ops entirely. Daily retention GC (`RBAC_AUDIT_RETENTION_DAYS`, default 30) modeled on `startMemoryGc`.
- **Wiring**: boot/shutdown in `src/http/index.ts`; also in `src/stdio.ts` — stdio owns the DB and serves the same gated tools, so it audits too (teardown via `process.on("exit")` since stdio's `main().finally` fires at startup; see code comment).
- `originatorUserId` is written NULL for now — systematic originator threading through `RbacCheck` is increment-3 work (column reserved).

Sample deny row:

| ts | principalType | verb | decision | reason | source |
|---|---|---|---|---|---|
| 2026-07-07 15:30:53 | agent | memory.learning.inject | deny | requires lead agent | mcp |

Plan: `thoughts/taras/plans/2026-07-07-des-445-rbac-slice1-can-audit.md` (phase 6).

## Verification

- `bun test` — 5905 pass, 0 fail (393 files); new `rbac-audit.test.ts` covers flush, kill-switch, throwing-DB flush, retention cutoff, shutdown drain, and one gate exercised end-to-end
- Fresh-DB boot applies 108 clean; second boot applies nothing (forward-only verified)
- Live QA: worker MCP deny → audit row appears after flush; with `RBAC_AUDIT_DISABLED=true` the denial still enforces but row count stays unchanged
- `tsc:check`, `lint`, `check-db-boundary.sh`, `check-rbac-boundary.sh`, `check:dep-graph` all green

https://claude.ai/code/session_0181AEH9bQjLd2oJwejiXSpw