### PR TITLE
fix: stale FTS-init flag in memory delete path + data/fs leak from integration test

### DIFF
--- a/src/be/memory/providers/sqlite-store.ts
+++ b/src/be/memory/providers/sqlite-store.ts
@@ -234,7 +234,11 @@ export class SqliteMemoryStore implements MemoryStore {
   }
 
   private deleteFtsRows(ids: string[]): void {
-    if (ids.length === 0 || (!this.ftsInitialized && !this.getFtsTableSchema())) return;
+    // Always re-check the CURRENT db's schema instead of trusting
+    // ftsInitialized — the flag can outlive a DB swap (tests reinit the DB
+    // process-wide), and a stale `true` would make this DELETE throw
+    // "no such table: memory_fts". Mirrors the vec guard in purgeByIds.
+    if (ids.length === 0 || !this.getFtsTableSchema()) return;
     const db = getDb();
     const placeholders = ids.map(() => "?").join(",");
     db.prepare(`DELETE FROM memory_fts WHERE memory_id IN (${placeholders})`).run(...ids);

--- a/src/tests/http-api-integration.test.ts
+++ b/src/tests/http-api-integration.test.ts
@@ -6,12 +6,15 @@
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { unlink } from "node:fs/promises";
+import { rm, unlink } from "node:fs/promises";
 import type { Subprocess } from "bun";
 import { Webhook } from "svix";
 
 const TEST_PORT = 19876;
 const TEST_DB_PATH = `/tmp/test-http-integration-${Date.now()}.sqlite`;
+// Keep local-fs uploads out of the repo's ./data/fs (the provider default —
+// the attachment test was leaking data/fs/tasks/<id>/ into the worktree).
+const TEST_FS_DIR = `/tmp/test-http-integration-fs-${Date.now()}`;
 const BASE = `http://localhost:${TEST_PORT}`;
 const TEST_API_KEY = "test-http-integration-key";
 
@@ -107,6 +110,7 @@ beforeAll(async () => {
       PORT: String(TEST_PORT),
       DATABASE_PATH: TEST_DB_PATH,
       API_KEY: TEST_API_KEY,
+      AGENT_FS_LOCAL_DIR: TEST_FS_DIR,
       CAPABILITIES: "core,task-pool,messaging,profiles,services,scheduling,memory",
       // Disable optional integrations
       SLACK_BOT_TOKEN: "",
@@ -129,6 +133,9 @@ afterAll(async () => {
     } catch {}
   }
   await Bun.sleep(50);
+  try {
+    await rm(TEST_FS_DIR, { recursive: true, force: true });
+  } catch {}
   try {
     await unlink(TEST_DB_PATH);
   } catch {}


### PR DESCRIPTION
## Summary

Two small incidental findings from the DES-445 RBAC implementation session (Taras opted to fix rather than file issues):

1. **`SqliteMemoryStore.deleteFtsRows`** (`src/be/memory/providers/sqlite-store.ts`) trusted the per-instance `ftsInitialized` flag without re-checking the current DB's schema — the vec path (`purgeByIds`) does re-check. Under bun's process-wide test ordering, a stale `true` after a DB swap made memory deletes throw `no such table: memory_fts`. The guard now queries `sqlite_master` on the current DB (deletes are infrequent; one schema lookup is cheap).

2. **`http-api-integration.test.ts`** uploaded an attachment through the local-fs provider's default `./data/fs` root, leaking `data/fs/tasks/<id>/IMG_1357.jpeg` into the worktree on every full-suite run. The spawned server now gets `AGENT_FS_LOCAL_DIR` pointed at a per-run `/tmp` dir, removed in `afterAll` (same pattern `fs-routes.test.ts` already uses).

## Verification

- All four memory test files green (`memory-reranker`, `memory-store`, `memory`, `memory-e2e` — 116 pass)
- `http-api-integration.test.ts` green (163 pass), no `data/` directory left behind (verified isolated and combined runs)
- `tsc:check` + `lint` clean

https://claude.ai/code/session_0181AEH9bQjLd2oJwejiXSpw