### PR TITLE
rbac: auto-backfill default role for zero-role users at boot (DES-445 follow-up)

### DIFF
--- a/runbooks/local-development.md
+++ b/runbooks/local-development.md
@@ -33,7 +33,7 @@ Bun auto-loads `.env`. Don't use `dotenv`.
 
 `AGENT_SWARM_API_KEY` / `API_KEY` and `SECRETS_ENCRYPTION_KEY` are reserved — they cannot be stored in `swarm_config`.
 
-RBAC admission design: [DES-445 user policy/admission model](../thoughts/taras/plans/2026-07-07-des-445-rbac-user-policy-admission-model.md). The happy path does not require manual bootstrapping: migrations backfill existing users, the users-table trigger grants the default role to new users, and server boot self-heals built-in role seeds. Use `bun run src/cli.tsx rbac bootstrap` as an operator sanity tool before enabling `RBAC_ENABLED=true` on an existing deployment, after manual DB surgery or a restore that stripped user roles, and periodically if you want a drift check. It only attaches the default role to users with zero roles, so deliberately narrowed users keep their existing role set.
+RBAC admission design: [DES-445 user policy/admission model](../thoughts/taras/plans/2026-07-07-des-445-rbac-user-policy-admission-model.md). The happy path does not require manual bootstrapping: migrations backfill existing users, the users-table trigger grants the default role to new users, and server boot self-heals built-in role seeds plus users that somehow have zero roles. Use `bun run src/cli.tsx rbac bootstrap` as an explicit audit/verification and on-demand repair tool before enabling `RBAC_ENABLED=true` without rebooting, after manual DB surgery or a restore that stripped user roles, and periodically if you want a drift check. It only attaches the default role to users with zero roles, so deliberately narrowed users keep their existing role set.
 
 ## Tracker integrations (Linear & Jira)
 

--- a/src/be/rbac-roles.ts
+++ b/src/be/rbac-roles.ts
@@ -91,6 +91,14 @@ type RbacRoleSummaryRow = {
   attachedUserCount: number;
 };
 
+type RbacSeedSyncStats = {
+  rolesInserted: number;
+  rolesUpdated: number;
+  permissionsInserted: number;
+  permissionsDeleted: number;
+  usersBackfilled: number;
+};
+
 function roleRowToUserRole(row: UserRoleRow): UserRole {
   return {
     id: row.id,
@@ -219,7 +227,7 @@ export function listUserRoles(userId: string): UserRole[] {
     .map(roleRowToUserRole);
 }
 
-export function ensureRbacSeedsSynced(opts?: { quiet?: boolean }): void {
+export function ensureRbacSeedsSynced(opts?: { quiet?: boolean }): RbacSeedSyncStats {
   const db = getDb();
   const desiredVerbsByRoleId = validatedBuiltinVerbSets();
 
@@ -253,12 +261,24 @@ export function ensureRbacSeedsSynced(opts?: { quiet?: boolean }): void {
   const insertRolePermission = db.prepare<null, [string, string]>(
     "INSERT OR IGNORE INTO role_permissions (roleId, verb) VALUES (?, ?)",
   );
+  const backfillDefaultRoleForZeroRoleUsers = db.prepare<null, string>(
+    `INSERT OR IGNORE INTO principal_roles (principalType, principalId, roleId)
+     SELECT 'user', u.id, ?
+     FROM users u
+     WHERE NOT EXISTS (
+       SELECT 1
+       FROM principal_roles pr
+       WHERE pr.principalType = 'user'
+         AND pr.principalId = u.id
+     )`,
+  );
 
-  const stats = {
+  const stats: RbacSeedSyncStats = {
     rolesInserted: 0,
     rolesUpdated: 0,
     permissionsInserted: 0,
     permissionsDeleted: 0,
+    usersBackfilled: 0,
   };
 
   db.transaction(() => {
@@ -315,13 +335,21 @@ export function ensureRbacSeedsSynced(opts?: { quiet?: boolean }): void {
     }
 
     db.run(CREATE_USER_DEFAULT_ROLE_TRIGGER_SQL);
+
+    // DES-445 pre-GA heal: zero user roles is never intentional today; users
+    // are deactivated, not stripped. When RBAC reaches GA with real role
+    // management, zero roles becomes a deliberate deny-all posture and this
+    // auto-attach MUST be removed. Keep the CLI as the explicit operator tool.
+    stats.usersBackfilled += backfillDefaultRoleForZeroRoleUsers.run(DEFAULT_ROLE_ID).changes;
   })();
 
   if (!opts?.quiet) {
     console.log(
-      `[rbac] seed sync: roles inserted=${stats.rolesInserted}, updated=${stats.rolesUpdated}; permissions inserted=${stats.permissionsInserted}, deleted=${stats.permissionsDeleted}; trigger=ensured`,
+      `[rbac] seed sync: roles inserted=${stats.rolesInserted}, updated=${stats.rolesUpdated}; permissions inserted=${stats.permissionsInserted}, deleted=${stats.permissionsDeleted}; trigger=ensured; users backfilled=${stats.usersBackfilled}`,
     );
   }
+
+  return stats;
 }
 
 function describeRbacFlag(): string {
@@ -353,26 +381,6 @@ function printRolesTable(rows: RbacRoleSummaryRow[]): void {
   }
 }
 
-function bootstrapDefaultRoles(): number {
-  const db = getDb();
-  return db.transaction(() => {
-    const result = db
-      .prepare<null, string>(
-        `INSERT OR IGNORE INTO principal_roles (principalType, principalId, roleId)
-         SELECT 'user', u.id, ?
-         FROM users u
-         WHERE NOT EXISTS (
-           SELECT 1
-           FROM principal_roles pr
-           WHERE pr.principalType = 'user'
-             AND pr.principalId = u.id
-         )`,
-      )
-      .run(DEFAULT_ROLE_ID);
-    return result.changes;
-  })();
-}
-
 function getRbacRoleSummary(): RbacRoleSummaryRow[] {
   return getDb()
     .prepare<RbacRoleSummaryRow, []>(
@@ -398,13 +406,12 @@ export async function runRbacCliCommand(args: string[]): Promise<void> {
     throw new Error(`Unknown RBAC command: ${args.join(" ") || "(none)"}`);
   }
 
-  ensureRbacSeedsSynced({ quiet: true });
-  const usersBackfilled = bootstrapDefaultRoles();
+  const stats = ensureRbacSeedsSynced({ quiet: true });
   const roles = getRbacRoleSummary();
 
   console.log("RBAC bootstrap complete");
   console.log(`RBAC_ENABLED: ${describeRbacFlag()}`);
-  console.log(`Users backfilled this run: ${usersBackfilled}`);
+  console.log(`Users backfilled this run: ${stats.usersBackfilled}`);
   console.log("");
   printRolesTable(roles);
 }

--- a/src/tests/rbac-roles.test.ts
+++ b/src/tests/rbac-roles.test.ts
@@ -255,6 +255,29 @@ describe("ensureRbacSeedsSynced", () => {
     expect(listUserRoles(user.id).map((role) => role.id)).toEqual([DEFAULT_ROLE_ID]);
   });
 
+  test("backfills the default role for users with zero roles", () => {
+    const user = createUser({ name: "Backfilled User" });
+    detachRole(user.id, "admin");
+    expect(listUserRoles(user.id)).toEqual([]);
+
+    const stats = ensureRbacSeedsSynced({ quiet: true });
+
+    expect(stats.usersBackfilled).toBe(1);
+    expect(listUserRoles(user.id).map((role) => role.id)).toEqual([DEFAULT_ROLE_ID]);
+  });
+
+  test("does not touch users deliberately narrowed to requester-only", () => {
+    const user = createUser({ name: "Requester Only User" });
+    attachRole(user.id, "requester");
+    detachRole(user.id, "admin");
+    expect(listUserRoles(user.id).map((role) => role.id)).toEqual([REQUESTER_ROLE_ID]);
+
+    const stats = ensureRbacSeedsSynced({ quiet: true });
+
+    expect(stats.usersBackfilled).toBe(0);
+    expect(listUserRoles(user.id).map((role) => role.id)).toEqual([REQUESTER_ROLE_ID]);
+  });
+
   test("rejects invalid built-in role verbs before syncing", () => {
     const requester = BUILTIN_ROLES.find((role) => role.id === REQUESTER_ROLE_ID);
     if (!requester) {
@@ -279,5 +302,25 @@ describe("runRbacCliCommand", () => {
     await expect(runRbacCliCommand(["bootstrap", "--bogus"])).rejects.toThrow(
       "Unknown RBAC command: bootstrap --bogus",
     );
+  });
+
+  test("reports users backfilled by bootstrap once", async () => {
+    const user = createUser({ name: "CLI Backfilled User" });
+    detachRole(user.id, "admin");
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      await runRbacCliCommand(["bootstrap"]);
+
+      expect(logSpy).toHaveBeenCalledWith("Users backfilled this run: 1");
+      expect(listUserRoles(user.id).map((role) => role.id)).toEqual([DEFAULT_ROLE_ID]);
+
+      logSpy.mockClear();
+      await runRbacCliCommand(["bootstrap"]);
+
+      expect(logSpy).toHaveBeenCalledWith("Users backfilled this run: 0");
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
Follow-up to #935 (DES-445 increment 3), per Taras's decision: the default-role backfill for zero-role users now runs **automatically at boot** instead of only via `rbac bootstrap`.

- `ensureRbacSeedsSynced()` attaches the default `admin` role to every user holding zero roles (same semantics as the CLI backfill: users holding *any* role are never touched). Runs on both boot paths under the existing fatal-when-`RBAC_ENABLED`/warn-when-off wrapper; count surfaces in the boot summary line.
- **GA caveat (documented in code)**: this auto-grant is a pre-GA heal — today zero-roles is always drift (users are deactivated, not stripped). Once RBAC is GA with real role management, zero-roles becomes a deliberate deny-all posture and the auto-attach must be removed; the CLI stays as the explicit operator tool.
- `rbac bootstrap` dedupes onto the same code path; runbook updated (CLI = audit/report + flip-the-flag-without-reboot repair).
- Tests: zero-role user healed at sync; requester-only user untouched; CLI backfill counts (1 then 0) preserved.

Verification: full `bun test` 5957 pass / 0 fail, targeted + flag-ON suites, tsc, lint, db-boundary, rbac-coverage.

https://claude.ai/code/session_01S3uuDPexqpLpUNAjTphmvt
