### PR TITLE
fix(identity): eradicate identity confabulation via provider-agnostic resolve-user invariant

### DIFF
--- a/src/agentmail/handlers.ts
+++ b/src/agentmail/handlers.ts
@@ -4,6 +4,7 @@ import {
   getAgentMailInboxMapping,
   getAllAgents,
 } from "../be/db";
+import { renderIdentity, resolveIdentityByEmail } from "../be/identity";
 import { findOrCreateUserByEmail } from "../be/users";
 import { resolveTemplate } from "../prompts/resolver";
 import { createIngressBuffer } from "../tasks/additive-ingress";
@@ -184,6 +185,13 @@ export async function handleMessageReceived(
     );
     requestedByUserId = user.id;
   }
+  // Render the resolved canonical name (or the UNKNOWN sentinel) for
+  // agent-visible text — never the raw From header. `findOrCreateUserByEmail`
+  // above auto-creates on a real email, so `senderEmail` present implies
+  // resolved; only a missing/unparseable From header falls to the sentinel.
+  const senderDisplay = senderEmail
+    ? renderIdentity(resolveIdentityByEmail(senderEmail))
+    : `${from} (unknown user)`;
   const preview = body.length > 500 ? `${body.substring(0, 500)}...` : body;
 
   // Emit workflow trigger event
@@ -207,7 +215,7 @@ export async function handleMessageReceived(
     if (
       agentmailBuffer.enabled &&
       agentmailBuffer.maybeBuffer(contextKey, siblingInFlight, {
-        from,
+        from: senderDisplay,
         subject,
         inboxId: inbox_id,
         threadId: thread_id,
@@ -226,7 +234,7 @@ export async function handleMessageReceived(
 
     // Create a follow-up task with parentTaskId to continue the session
     const followupResult = resolveTemplate("agentmail.email.followup", {
-      from,
+      from: senderDisplay,
       subject,
       inbox_id,
       thread_id,
@@ -264,7 +272,7 @@ export async function handleMessageReceived(
       if (agent.isLead) {
         // Route to lead as task
         const leadResult = resolveTemplate("agentmail.email.mapped_lead", {
-          from,
+          from: senderDisplay,
           subject,
           inbox_id,
           thread_id,
@@ -295,7 +303,7 @@ export async function handleMessageReceived(
 
       // Route to worker as task
       const workerResult = resolveTemplate("agentmail.email.mapped_worker", {
-        from,
+        from: senderDisplay,
         subject,
         inbox_id,
         thread_id,
@@ -328,7 +336,7 @@ export async function handleMessageReceived(
   const lead = findLeadAgent();
   if (lead) {
     const unmappedResult = resolveTemplate("agentmail.email.unmapped", {
-      from,
+      from: senderDisplay,
       subject,
       inbox_id,
       thread_id,
@@ -359,7 +367,7 @@ export async function handleMessageReceived(
 
   // No lead available - create unassigned task
   const noAgentResult = resolveTemplate("agentmail.email.no_agent", {
-    from,
+    from: senderDisplay,
     subject,
     inbox_id,
     thread_id,

--- a/src/agentmail/handlers.ts
+++ b/src/agentmail/handlers.ts
@@ -188,10 +188,12 @@ export async function handleMessageReceived(
   // Render the resolved canonical name (or the UNKNOWN sentinel) for
   // agent-visible text — never the raw From header. `findOrCreateUserByEmail`
   // above auto-creates on a real email, so `senderEmail` present implies
-  // resolved; only a missing/unparseable From header falls to the sentinel.
+  // resolved; a missing/unparseable From header has no machine-carried
+  // identifier at all, so it renders the same non-name sentinel shape via
+  // the identity primitive rather than echoing the raw header string.
   const senderDisplay = senderEmail
     ? renderIdentity(resolveIdentityByEmail(senderEmail))
-    : `${from} (unknown user)`;
+    : renderIdentity({ status: "unknown", kind: "email", externalId: "unknown" });
   const preview = body.length > 500 ? `${body.substring(0, 500)}...` : body;
 
   // Emit workflow trigger event

--- a/src/agentmail/templates.ts
+++ b/src/agentmail/templates.ts
@@ -21,7 +21,11 @@ Thread: {{thread_id}}
 
 {{preview}}`,
   variables: [
-    { name: "from", description: "Sender address(es)" },
+    {
+      name: "from",
+      description:
+        "Sender identity — resolved canonical name (e.g. 'Luis (email:luis@x.com)') or the UNKNOWN sentinel",
+    },
     { name: "subject", description: "Email subject" },
     { name: "inbox_id", description: "AgentMail inbox ID" },
     { name: "thread_id", description: "AgentMail thread ID" },
@@ -41,7 +45,11 @@ Message: {{message_id}}
 
 {{preview}}`,
   variables: [
-    { name: "from", description: "Sender address(es)" },
+    {
+      name: "from",
+      description:
+        "Sender identity — resolved canonical name (e.g. 'Luis (email:luis@x.com)') or the UNKNOWN sentinel",
+    },
     { name: "subject", description: "Email subject" },
     { name: "inbox_id", description: "AgentMail inbox ID" },
     { name: "thread_id", description: "AgentMail thread ID" },
@@ -61,7 +69,11 @@ Thread: {{thread_id}}
 
 {{preview}}`,
   variables: [
-    { name: "from", description: "Sender address(es)" },
+    {
+      name: "from",
+      description:
+        "Sender identity — resolved canonical name (e.g. 'Luis (email:luis@x.com)') or the UNKNOWN sentinel",
+    },
     { name: "subject", description: "Email subject" },
     { name: "inbox_id", description: "AgentMail inbox ID" },
     { name: "thread_id", description: "AgentMail thread ID" },
@@ -81,7 +93,11 @@ Message: {{message_id}}
 
 {{preview}}`,
   variables: [
-    { name: "from", description: "Sender address(es)" },
+    {
+      name: "from",
+      description:
+        "Sender identity — resolved canonical name (e.g. 'Luis (email:luis@x.com)') or the UNKNOWN sentinel",
+    },
     { name: "subject", description: "Email subject" },
     { name: "inbox_id", description: "AgentMail inbox ID" },
     { name: "thread_id", description: "AgentMail thread ID" },
@@ -101,7 +117,11 @@ Thread: {{thread_id}}
 
 {{preview}}`,
   variables: [
-    { name: "from", description: "Sender address(es)" },
+    {
+      name: "from",
+      description:
+        "Sender identity — resolved canonical name (e.g. 'Luis (email:luis@x.com)') or the UNKNOWN sentinel",
+    },
     { name: "subject", description: "Email subject" },
     { name: "inbox_id", description: "AgentMail inbox ID" },
     { name: "thread_id", description: "AgentMail thread ID" },

--- a/src/be/audit-user.ts
+++ b/src/be/audit-user.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage } from "node:http";
 import { getRequestAuth } from "../utils/request-auth-context";
-import { getTaskById } from "./db";
+import { getAgentCurrentTask, getTaskById } from "./db";
+import { findUserByExternalId } from "./users";
 
 /**
  * Resolve the trusted audit-actor user id for a write to an audited table
@@ -14,6 +15,13 @@ import { getTaskById } from "./db";
  * attribute a write to a task they already own, whose requester is legitimately
  * theirs.
  *
+ * Two fallbacks layer on top of the header, both still gated by ownership:
+ *   1. No header at all → the caller's own current in-progress task (never a
+ *      client-supplied id, so this can't be spoofed).
+ *   2. The resolved task has no `requestedByUserId` but carries a
+ *      machine-recorded provider external id (today: the Slack user field) →
+ *      the same generic reverse lookup used everywhere else.
+ *
  * Returns `null` when no trusted actor can be established — which leaves the
  * audit column untouched on updates and NULL on inserts.
  */
@@ -21,13 +29,29 @@ export function resolveTaskAuditUserId(
   sourceTaskId: string | undefined,
   callerAgentId: string | undefined,
 ): string | null {
-  if (!sourceTaskId || !callerAgentId) return null;
-  const task = getTaskById(sourceTaskId);
+  if (!callerAgentId) return null;
+
+  let resolvedSourceTaskId = sourceTaskId;
+  if (!resolvedSourceTaskId) {
+    const currentTask = getAgentCurrentTask(callerAgentId);
+    if (currentTask) resolvedSourceTaskId = currentTask.id;
+  }
+  if (!resolvedSourceTaskId) return null;
+
+  const task = getTaskById(resolvedSourceTaskId);
   if (!task) return null;
   // Bind the header to the caller's own task — otherwise it is just a
   // client-chosen value and its requester cannot be trusted.
   if (task.agentId !== callerAgentId) return null;
-  return task.requestedByUserId ?? null;
+
+  if (task.requestedByUserId) return task.requestedByUserId;
+
+  if (task.slackUserId) {
+    const user = findUserByExternalId("slack", task.slackUserId);
+    if (user) return user.id;
+  }
+
+  return null;
 }
 
 /**

--- a/src/be/db.ts
+++ b/src/be/db.ts
@@ -8894,6 +8894,7 @@ export interface ApprovalRequest {
   timeoutSeconds: number | null;
   expiresAt: string | null;
   notificationChannels: unknown[] | null;
+  createdBy?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -8913,6 +8914,7 @@ interface ApprovalRequestRow {
   timeoutSeconds: number | null;
   expiresAt: string | null;
   notificationChannels: string | null;
+  created_by: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -8933,6 +8935,7 @@ function rowToApprovalRequest(row: ApprovalRequestRow): ApprovalRequest {
     timeoutSeconds: row.timeoutSeconds,
     expiresAt: normalizeDate(row.expiresAt),
     notificationChannels: row.notificationChannels ? JSON.parse(row.notificationChannels) : null,
+    createdBy: row.created_by ?? undefined,
     createdAt: normalizeDateRequired(row.createdAt),
     updatedAt: normalizeDateRequired(row.updatedAt),
   };
@@ -8948,6 +8951,7 @@ export function createApprovalRequest(data: {
   sourceTaskId?: string;
   timeoutSeconds?: number;
   notificationChannels?: unknown[];
+  createdBy?: string;
 }): ApprovalRequest {
   const now = new Date().toISOString();
   const expiresAt = data.timeoutSeconds
@@ -8968,12 +8972,13 @@ export function createApprovalRequest(data: {
         number | null,
         string | null,
         string | null,
+        string | null,
         string,
         string,
       ]
     >(
-      `INSERT INTO approval_requests (id, title, questions, workflowRunId, workflowRunStepId, sourceTaskId, approvers, timeoutSeconds, expiresAt, notificationChannels, createdAt, updatedAt)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO approval_requests (id, title, questions, workflowRunId, workflowRunStepId, sourceTaskId, approvers, timeoutSeconds, expiresAt, notificationChannels, created_by, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        RETURNING *`,
     )
     .get(
@@ -8987,6 +8992,7 @@ export function createApprovalRequest(data: {
       data.timeoutSeconds ?? null,
       expiresAt,
       data.notificationChannels ? JSON.stringify(data.notificationChannels) : null,
+      data.createdBy ?? null,
       now,
       now,
     );

--- a/src/be/identity.ts
+++ b/src/be/identity.ts
@@ -1,0 +1,79 @@
+/**
+ * The framework's single identity-resolution primitive.
+ *
+ * Invariant (Rule 33 / provenance-or-silence): the swarm's sole responsibility
+ * for identity is the reverse lookup `(kind, externalId)` (or email) → linked
+ * user → canonical name, via `findUserByExternalId` / `findUserByEmail`. If
+ * the lookup points nowhere, callers render the explicit UNKNOWN sentinel —
+ * NEVER a provider display name, NEVER a guess. Every provider adapter that
+ * renders a human identity into agent-visible text MUST go through
+ * `renderIdentity(resolveIdentity(...))` (or `resolveIdentityByEmail`).
+ *
+ * Pure DB reads — zero provider API calls. `unknown` is a value, not an
+ * error: callers branch on `status`, never throw or fall back to a
+ * provider-supplied label.
+ *
+ * This module is API-side ONLY (see the DB-boundary note in `./users.ts`).
+ */
+
+import { findUserByEmail, findUserByExternalId } from "./users";
+
+export type IdentityResolution =
+  | {
+      status: "resolved";
+      kind: string;
+      externalId: string;
+      userId: string;
+      name: string;
+      email?: string;
+    }
+  | { status: "unknown"; kind: string; externalId: string };
+
+/** Reverse lookup by `(kind, externalId)` — e.g. `resolveIdentity('slack', 'U016H7XKZGS')`. */
+export function resolveIdentity(kind: string, externalId: string): IdentityResolution {
+  const user = findUserByExternalId(kind, externalId);
+  if (!user) {
+    return { status: "unknown", kind, externalId };
+  }
+  return {
+    status: "resolved",
+    kind,
+    externalId,
+    userId: user.id,
+    name: user.name,
+    email: user.email,
+  };
+}
+
+/**
+ * Reverse lookup by email (primary or alias). Email is a `users.email`
+ * attribute, not an external-id kind — rendered with `kind: "email"` so
+ * `renderIdentity` produces a consistent pair form regardless of provider.
+ */
+export function resolveIdentityByEmail(email: string): IdentityResolution {
+  const user = findUserByEmail(email);
+  if (!user) {
+    return { status: "unknown", kind: "email", externalId: email };
+  }
+  return {
+    status: "resolved",
+    kind: "email",
+    externalId: email,
+    userId: user.id,
+    name: user.name,
+    email: user.email,
+  };
+}
+
+/**
+ * Render an `IdentityResolution` into agent-visible text — the only two
+ * shapes an identity may ever take. The sentinel keeps the raw id but never
+ * a name: an unresolved identity must never be confused for a real one.
+ */
+export function renderIdentity(resolution: IdentityResolution): string {
+  const pair = `${resolution.kind}:${resolution.externalId}`;
+  if (resolution.status === "resolved") {
+    return `${resolution.name} (${pair})`;
+  }
+  return `${pair} (unknown user)`;
+}

--- a/src/be/scripts/typecheck.ts
+++ b/src/be/scripts/typecheck.ts
@@ -77,7 +77,7 @@ export interface SwarmSdk {
   swarm_get(args?: { includeFull?: boolean }): Promise<unknown>;
   agent_info(args?: Record<string, unknown>): Promise<unknown>;
   metrics_get(args?: Record<string, unknown>): Promise<unknown>;
-  user_resolve(args?: { kind?: string; externalId?: string; email?: string; userId?: string }): Promise<unknown>;
+  user_resolve(args?: { kind?: string; externalId?: string; email?: string; userId?: string; name?: string }): Promise<unknown>;
   db_query(args: { sql: string; params?: unknown[] }): Promise<unknown>;
   // --- config ---
   config_get(args?: { agentId?: string; repoId?: string; key?: string; includeSecrets?: boolean }): Promise<unknown>;

--- a/src/be/users.ts
+++ b/src/be/users.ts
@@ -136,6 +136,30 @@ export function findUserByEmail(email: string): User | null {
 }
 
 /**
+ * Look up users by display name — exact match (case-insensitive) first;
+ * falls back to a first-token prefix match (e.g. "Alberto" matches both
+ * "Alberto Maurel" and "Alberto Dubois"). Deterministic, no fuzzy matching:
+ * `resolve-user`'s name lookup treats more than one match as ambiguous
+ * rather than guessing.
+ */
+export function findUsersByName(name: string): User[] {
+  const trimmed = name.trim();
+  if (!trimmed) return [];
+  const db = getDb();
+
+  const exact = db
+    .prepare<UserRow, string>("SELECT * FROM users WHERE LOWER(name) = LOWER(?)")
+    .all(trimmed);
+  if (exact.length > 0) return exact.map(rowToUser);
+
+  const firstToken = trimmed.split(/\s+/)[0] ?? trimmed;
+  const prefixed = db
+    .prepare<UserRow, string>("SELECT * FROM users WHERE LOWER(name) LIKE LOWER(?) || '%'")
+    .all(firstToken);
+  return prefixed.map(rowToUser);
+}
+
+/**
  * Return all `(kind, externalId)` mappings for a user — used by the People
  * page detail view to render identity badges in one request.
  */

--- a/src/github/handlers.ts
+++ b/src/github/handlers.ts
@@ -1,4 +1,5 @@
 import { failTask, findTaskByVcs, getAllAgents, getSwarmConfigs, incrKv, upsertKv } from "../be/db";
+import { renderIdentity, resolveIdentity } from "../be/identity";
 import { findUserByExternalId } from "../be/users";
 import { resolveTemplate } from "../prompts/resolver";
 import { githubContextKey } from "../tasks/context-key";
@@ -239,7 +240,7 @@ export async function handlePullRequest(
         pr_number: pr.number,
         pr_title: pr.title,
         bot_name: GITHUB_BOT_NAME,
-        sender_login: sender.login,
+        sender_login: renderIdentity(resolveIdentity("github", sender.login)),
         repo_full_name: repository.full_name,
         head_ref: pr.head.ref,
         base_ref: pr.base.ref,
@@ -347,7 +348,7 @@ export async function handlePullRequest(
         pr_number: pr.number,
         pr_title: pr.title,
         bot_name: GITHUB_BOT_NAME,
-        sender_login: sender.login,
+        sender_login: renderIdentity(resolveIdentity("github", sender.login)),
         repo_full_name: repository.full_name,
         head_ref: pr.head.ref,
         base_ref: pr.base.ref,
@@ -447,7 +448,7 @@ export async function handlePullRequest(
         pr_number: pr.number,
         pr_title: pr.title,
         label_name: labelName,
-        sender_login: sender.login,
+        sender_login: renderIdentity(resolveIdentity("github", sender.login)),
         repo_full_name: repository.full_name,
         head_ref: pr.head.ref,
         base_ref: pr.base.ref,
@@ -536,7 +537,7 @@ export async function handlePullRequest(
     {
       pr_number: pr.number,
       pr_title: pr.title,
-      sender_login: sender.login,
+      sender_login: renderIdentity(resolveIdentity("github", sender.login)),
       repo_full_name: repository.full_name,
       head_ref: pr.head.ref,
       base_ref: pr.base.ref,
@@ -618,7 +619,7 @@ export async function handleIssue(
         issue_number: issue.number,
         issue_title: issue.title,
         bot_name: GITHUB_BOT_NAME,
-        sender_login: sender.login,
+        sender_login: renderIdentity(resolveIdentity("github", sender.login)),
         repo_full_name: repository.full_name,
         issue_url: issue.html_url,
         context: issue.body || issue.title,
@@ -714,7 +715,7 @@ export async function handleIssue(
         issue_number: issue.number,
         issue_title: issue.title,
         label_name: labelName,
-        sender_login: sender.login,
+        sender_login: renderIdentity(resolveIdentity("github", sender.login)),
         repo_full_name: repository.full_name,
         issue_url: issue.html_url,
         context: issue.body || issue.title,
@@ -785,7 +786,7 @@ export async function handleIssue(
     {
       issue_number: issue.number,
       issue_title: issue.title,
-      sender_login: sender.login,
+      sender_login: renderIdentity(resolveIdentity("github", sender.login)),
       repo_full_name: repository.full_name,
       issue_url: issue.html_url,
       context,
@@ -887,7 +888,7 @@ export async function handleComment(
       target_type: targetType,
       target_number: targetNumber,
       target_title: targetTitle,
-      sender_login: sender.login,
+      sender_login: renderIdentity(resolveIdentity("github", sender.login)),
       repo_full_name: repository.full_name,
       comment_url: comment.html_url,
       context,
@@ -1188,7 +1189,7 @@ export async function handlePullRequestReview(
       pr_number: pr.number,
       review_label: label,
       pr_title: pr.title,
-      sender_login: sender.login,
+      sender_login: renderIdentity(resolveIdentity("github", sender.login)),
       repo_full_name: repository.full_name,
       review_url: review.html_url,
       review_body_section: reviewBodySection,

--- a/src/github/templates.ts
+++ b/src/github/templates.ts
@@ -78,7 +78,11 @@ Context:
     { name: "pr_number", description: "Pull request number" },
     { name: "pr_title", description: "Pull request title" },
     { name: "bot_name", description: "GitHub bot username" },
-    { name: "sender_login", description: "Event sender login" },
+    {
+      name: "sender_login",
+      description:
+        "Event sender identity — resolved canonical name (e.g. 'Luis (github:login)') or the UNKNOWN sentinel",
+    },
     { name: "repo_full_name", description: "Repository full name (owner/repo)" },
     { name: "head_ref", description: "Head branch name" },
     { name: "base_ref", description: "Base branch name" },
@@ -107,7 +111,11 @@ Context:
     { name: "pr_number", description: "Pull request number" },
     { name: "pr_title", description: "Pull request title" },
     { name: "bot_name", description: "GitHub bot username" },
-    { name: "sender_login", description: "Event sender login" },
+    {
+      name: "sender_login",
+      description:
+        "Event sender identity — resolved canonical name (e.g. 'Luis (github:login)') or the UNKNOWN sentinel",
+    },
     { name: "repo_full_name", description: "Repository full name (owner/repo)" },
     { name: "head_ref", description: "Head branch name" },
     { name: "base_ref", description: "Base branch name" },
@@ -187,7 +195,11 @@ Context:
   variables: [
     { name: "pr_number", description: "Pull request number" },
     { name: "pr_title", description: "Pull request title" },
-    { name: "sender_login", description: "Event sender login" },
+    {
+      name: "sender_login",
+      description:
+        "Event sender identity — resolved canonical name (e.g. 'Luis (github:login)') or the UNKNOWN sentinel",
+    },
     { name: "repo_full_name", description: "Repository full name (owner/repo)" },
     { name: "head_ref", description: "Head branch name" },
     { name: "base_ref", description: "Base branch name" },
@@ -216,7 +228,11 @@ Context:
     { name: "pr_number", description: "Pull request number" },
     { name: "pr_title", description: "Pull request title" },
     { name: "label_name", description: "Label that was added" },
-    { name: "sender_login", description: "Event sender login" },
+    {
+      name: "sender_login",
+      description:
+        "Event sender identity — resolved canonical name (e.g. 'Luis (github:login)') or the UNKNOWN sentinel",
+    },
     { name: "repo_full_name", description: "Repository full name (owner/repo)" },
     { name: "head_ref", description: "Head branch name" },
     { name: "base_ref", description: "Base branch name" },
@@ -248,7 +264,11 @@ Context:
     { name: "issue_number", description: "Issue number" },
     { name: "issue_title", description: "Issue title" },
     { name: "bot_name", description: "GitHub bot username" },
-    { name: "sender_login", description: "Event sender login" },
+    {
+      name: "sender_login",
+      description:
+        "Event sender identity — resolved canonical name (e.g. 'Luis (github:login)') or the UNKNOWN sentinel",
+    },
     { name: "repo_full_name", description: "Repository full name (owner/repo)" },
     { name: "issue_url", description: "Issue HTML URL" },
     { name: "context", description: "Issue body or title as context" },
@@ -272,7 +292,11 @@ Context:
   variables: [
     { name: "issue_number", description: "Issue number" },
     { name: "issue_title", description: "Issue title" },
-    { name: "sender_login", description: "Event sender login" },
+    {
+      name: "sender_login",
+      description:
+        "Event sender identity — resolved canonical name (e.g. 'Luis (github:login)') or the UNKNOWN sentinel",
+    },
     { name: "repo_full_name", description: "Repository full name (owner/repo)" },
     { name: "issue_url", description: "Issue HTML URL" },
     { name: "context", description: "Extracted mention context or issue title" },
@@ -298,7 +322,11 @@ Context:
     { name: "issue_number", description: "Issue number" },
     { name: "issue_title", description: "Issue title" },
     { name: "label_name", description: "Label that was added" },
-    { name: "sender_login", description: "Event sender login" },
+    {
+      name: "sender_login",
+      description:
+        "Event sender identity — resolved canonical name (e.g. 'Luis (github:login)') or the UNKNOWN sentinel",
+    },
     { name: "repo_full_name", description: "Repository full name (owner/repo)" },
     { name: "issue_url", description: "Issue HTML URL" },
     { name: "context", description: "Issue body or title as context" },
@@ -327,7 +355,11 @@ Comment:
     { name: "target_type", description: "PR or Issue" },
     { name: "target_number", description: "PR or issue number" },
     { name: "target_title", description: "PR or issue title" },
-    { name: "sender_login", description: "Event sender login" },
+    {
+      name: "sender_login",
+      description:
+        "Event sender identity — resolved canonical name (e.g. 'Luis (github:login)') or the UNKNOWN sentinel",
+    },
     { name: "repo_full_name", description: "Repository full name (owner/repo)" },
     { name: "comment_url", description: "Comment HTML URL" },
     { name: "context", description: "Extracted mention context from comment" },
@@ -360,7 +392,11 @@ URL: {{review_url}}{{review_body_section}}{{inline_comments_section}}
     { name: "pr_number", description: "Pull request number" },
     { name: "review_label", description: "Review state label (APPROVED, CHANGES REQUESTED, etc.)" },
     { name: "pr_title", description: "Pull request title" },
-    { name: "sender_login", description: "Reviewer login" },
+    {
+      name: "sender_login",
+      description:
+        "Reviewer identity — resolved canonical name (e.g. 'Luis (github:login)') or the UNKNOWN sentinel",
+    },
     { name: "repo_full_name", description: "Repository full name (owner/repo)" },
     { name: "review_url", description: "Review HTML URL" },
     { name: "review_body_section", description: "Review overall body section or empty string" },

--- a/src/gitlab/handlers.ts
+++ b/src/gitlab/handlers.ts
@@ -9,6 +9,7 @@
  */
 
 import { failTask, findTaskByVcs, getAllAgents, incrKv, upsertKv } from "../be/db";
+import { renderIdentity, resolveIdentity } from "../be/identity";
 import { findOrCreateUserByEmail, findUserByExternalId, linkIdentity } from "../be/users";
 import { resolveTemplate } from "../prompts/resolver";
 import { gitlabContextKey } from "../tasks/context-key";
@@ -111,6 +112,14 @@ function resolveGitLabSender(
   return undefined;
 }
 
+/**
+ * Render a GitLab username for agent-visible text: the resolved canonical
+ * name or the explicit UNKNOWN sentinel — never the raw `username`.
+ */
+function renderGitLabIdentity(username: string): string {
+  return renderIdentity(resolveIdentity("gitlab", username));
+}
+
 // ── Event Handlers ──
 
 export async function handleMergeRequest(
@@ -152,7 +161,7 @@ export async function handleMergeRequest(
         mr_iid: mr.iid,
         mr_title: mr.title,
         repo,
-        username: user.username,
+        username: renderGitLabIdentity(user.username),
         source_branch: mr.source_branch,
         target_branch: mr.target_branch,
         mr_url: mr.url,
@@ -260,7 +269,7 @@ export async function handleIssue(
         issue_iid: issue.iid,
         issue_title: issue.title,
         repo,
-        username: user.username,
+        username: renderGitLabIdentity(user.username),
         issue_url: issue.url,
         context_section: contextSection,
       });
@@ -312,10 +321,8 @@ export async function handleNote(event: NoteEvent): Promise<{ created: boolean; 
   const { user, project, object_attributes: note } = event;
   const repo = project.path_with_namespace;
 
-  // Resolve canonical user from GitLab sender — currently dead-coded
-  // (underscore prefix). Rewired for parity with live sites; if a future
-  // change uses the value, the resolution path is already correct.
-  const _requestedByUserId = resolveGitLabSender(user, "note", note.note);
+  // Resolve canonical user from GitLab sender.
+  const requestedByUserId = resolveGitLabSender(user, "note", note.note);
 
   // Only handle comments with bot mentions
   if (!detectMention(note.note)) {
@@ -362,7 +369,7 @@ export async function handleNote(event: NoteEvent): Promise<{ created: boolean; 
 
   const noteResult = resolveTemplate("gitlab.comment.mentioned", {
     entity_label: entityLabel,
-    username: user.username,
+    username: renderGitLabIdentity(user.username),
     repo,
     target_url: targetUrl,
     context,
@@ -383,6 +390,7 @@ export async function handleNote(event: NoteEvent): Promise<{ created: boolean; 
     vcsNumber: targetNumber,
     vcsCommentId: note.id,
     vcsAuthor: user.username,
+    requestedByUserId,
     vcsUrl: targetUrl,
     parentTaskId: existingTask?.id,
     contextKey: targetNumber
@@ -410,8 +418,11 @@ export async function handleNote(event: NoteEvent): Promise<{ created: boolean; 
 export async function handlePipeline(
   event: PipelineEvent,
 ): Promise<{ created: boolean; taskId?: string }> {
-  const { project, object_attributes: pipeline } = event;
+  const { user, project, object_attributes: pipeline } = event;
   const repo = project.path_with_namespace;
+
+  // Resolve canonical user from GitLab sender — whoever triggered the pipeline.
+  const requestedByUserId = resolveGitLabSender(user, "pipeline", `Pipeline #${pipeline.id}`);
 
   // Only handle failed pipelines that are associated with a merge request
   if (pipeline.status !== "failed") {
@@ -458,6 +469,7 @@ export async function handlePipeline(
     vcsEventType: "pipeline",
     vcsNumber: mrIid,
     vcsAuthor: "",
+    requestedByUserId,
     vcsUrl: event.merge_request.url,
     parentTaskId: existingTask.id,
     contextKey: gitlabContextKey({

--- a/src/gitlab/templates.ts
+++ b/src/gitlab/templates.ts
@@ -48,7 +48,7 @@ registerTemplate({
   eventType: "gitlab.merge_request.opened",
   header: "[GitLab MR #{{mr_iid}}] {{mr_title}}",
   defaultBody: `Repo: {{repo}}
-Author: @{{username}}
+Author: {{username}}
 Branch: {{source_branch}} \u2192 {{target_branch}}
 URL: {{mr_url}}
 
@@ -57,7 +57,11 @@ URL: {{mr_url}}
     { name: "mr_iid", description: "Merge request IID" },
     { name: "mr_title", description: "Merge request title" },
     { name: "repo", description: "Project path with namespace" },
-    { name: "username", description: "Event sender username" },
+    {
+      name: "username",
+      description:
+        "Author identity \u2014 resolved canonical name (e.g. 'Luis (gitlab:username)') or the UNKNOWN sentinel",
+    },
     { name: "source_branch", description: "Source branch name" },
     { name: "target_branch", description: "Target branch name" },
     { name: "mr_url", description: "Merge request URL" },
@@ -74,7 +78,7 @@ registerTemplate({
   eventType: "gitlab.issue.assigned",
   header: "[GitLab Issue #{{issue_iid}}] {{issue_title}}",
   defaultBody: `Repo: {{repo}}
-Author: @{{username}}
+Author: {{username}}
 URL: {{issue_url}}
 
 {{context_section}}{{@template[common.command_suggestions.gitlab_issue]}}{{@template[common.delegation_instruction.gitlab]}}`,
@@ -82,7 +86,11 @@ URL: {{issue_url}}
     { name: "issue_iid", description: "Issue IID" },
     { name: "issue_title", description: "Issue title" },
     { name: "repo", description: "Project path with namespace" },
-    { name: "username", description: "Event sender username" },
+    {
+      name: "username",
+      description:
+        "Author identity — resolved canonical name (e.g. 'Luis (gitlab:username)') or the UNKNOWN sentinel",
+    },
     { name: "issue_url", description: "Issue URL" },
     { name: "context_section", description: "Context section with description or empty string" },
   ],
@@ -95,7 +103,7 @@ URL: {{issue_url}}
 
 registerTemplate({
   eventType: "gitlab.comment.mentioned",
-  header: "[GitLab Comment on {{entity_label}}] @{{username}} mentioned bot",
+  header: "[GitLab Comment on {{entity_label}}] {{username}} mentioned bot",
   defaultBody: `Repo: {{repo}}
 URL: {{target_url}}
 
@@ -103,7 +111,11 @@ Comment:
 {{context}}{{existing_task_note}}{{@template[common.delegation_instruction.gitlab]}}`,
   variables: [
     { name: "entity_label", description: "Entity label (e.g. 'MR #1' or 'Issue #2')" },
-    { name: "username", description: "Comment author username" },
+    {
+      name: "username",
+      description:
+        "Comment author identity — resolved canonical name (e.g. 'Luis (gitlab:username)') or the UNKNOWN sentinel",
+    },
     { name: "repo", description: "Project path with namespace" },
     { name: "target_url", description: "Target entity URL" },
     { name: "context", description: "Extracted mention context from comment" },

--- a/src/http/approval-requests.ts
+++ b/src/http/approval-requests.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { z } from "zod";
+import { resolveTaskAuditUserId } from "../be/audit-user";
 import {
   createApprovalRequest,
   createTaskExtended,
@@ -9,6 +10,7 @@ import {
   resolveApprovalRequest,
 } from "../be/db";
 import { resolveTemplate } from "../prompts/resolver";
+import { getRequestAuth } from "../utils/request-auth-context";
 import { workflowEventBus } from "../workflows/event-bus";
 import { route } from "./route-def";
 import { json, jsonError } from "./utils";
@@ -248,6 +250,15 @@ export async function handleApprovalRequests(
     if (!parsed) return true;
 
     const id = crypto.randomUUID();
+    // Prefer a trusted authenticated user (never client-controlled); else fall
+    // back to the ownership-validated sourceTaskId the request body carries.
+    const auth = getRequestAuth(req);
+    const rawCallerAgentId = req.headers["x-agent-id"];
+    const callerAgentId = Array.isArray(rawCallerAgentId) ? rawCallerAgentId[0] : rawCallerAgentId;
+    const createdBy =
+      auth?.kind === "user"
+        ? auth.userId
+        : (resolveTaskAuditUserId(parsed.body.sourceTaskId, callerAgentId) ?? undefined);
     const request = createApprovalRequest({
       id,
       title: parsed.body.title,
@@ -258,6 +269,7 @@ export async function handleApprovalRequests(
       sourceTaskId: parsed.body.sourceTaskId,
       timeoutSeconds: parsed.body.timeoutSeconds,
       notificationChannels: parsed.body.notifications,
+      createdBy,
     });
 
     res.writeHead(201, { "Content-Type": "application/json" });

--- a/src/http/poll.ts
+++ b/src/http/poll.ts
@@ -25,6 +25,7 @@ import {
   startTask,
   upsertChannelActivityCursor,
 } from "../be/db";
+import { renderIdentity, resolveIdentity } from "../be/identity";
 import { fetchChannelActivity } from "../slack/channel-activity";
 import { telemetry } from "../telemetry";
 import { route } from "./route-def";
@@ -274,11 +275,19 @@ export async function handlePoll(
               agentId: myAgentId,
             });
 
-            // Resolve requesting user if available
+            // Resolve requesting user if available. If the task carries a
+            // machine-recorded external id (today: the Slack user field) but
+            // no requestedByUserId, render the explicit UNKNOWN sentinel
+            // instead of silently omitting the section — never a substituted
+            // human (Rule 33 / provenance-or-silence).
             const requestedByUser = pendingTask.requestedByUserId
               ? getUserById(pendingTask.requestedByUserId)
               : undefined;
             const requestedByNotes = getRequesterNotes(requestedByUser?.notes);
+            const requestedByUnknownName =
+              !requestedByUser && pendingTask.slackUserId
+                ? renderIdentity(resolveIdentity("slack", pendingTask.slackUserId))
+                : undefined;
 
             return {
               trigger: {
@@ -296,6 +305,9 @@ export async function handlePoll(
                     role: requestedByUser.role,
                     notes: requestedByNotes,
                   },
+                }),
+                ...(requestedByUnknownName && {
+                  requestedBy: { name: requestedByUnknownName },
                 }),
               },
             };

--- a/src/http/tasks.ts
+++ b/src/http/tasks.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { ensure } from "@desplega.ai/business-use";
 import { z } from "zod";
+import { resolveHttpAuditUserId } from "../be/audit-user";
 import {
   backfillSupersedeTaskResumeTaskId,
   cancelTask,
@@ -14,7 +15,6 @@ import {
   getTaskAttachments,
   getTaskById,
   getTasksCount,
-  getUserById,
   pauseTask,
   resumeTask,
   supersedeTask,
@@ -37,7 +37,6 @@ import {
   ResumeReasonSchema,
   splitLegacyModelAlias,
 } from "../types";
-import { getRequestAuth } from "../utils/request-auth-context";
 import { route } from "./route-def";
 import { json, jsonError } from "./utils";
 
@@ -360,18 +359,15 @@ export async function handleTasks(
     const parsed = await createTask.parse(req, res, pathSegments, queryParams);
     if (!parsed) return true;
 
-    // Tolerant `requestedByUserId`: prevent the deleted-user race from
-    // becoming a 500 — if the referenced user doesn't exist, log and drop
-    // the field rather than letting the FK fail at INSERT.
-    const auth = getRequestAuth(req);
-    let requestedByUserId =
-      auth?.kind === "user" ? auth.userId : parsed.body.requestedByUserId || undefined;
-    if (requestedByUserId && !getUserById(requestedByUserId)) {
-      console.warn(
-        `[tasks] requestedByUserId ${requestedByUserId} does not exist — coercing to NULL`,
-      );
-      requestedByUserId = undefined;
-    }
+    // Attribution must not be spoofable by a client-supplied body field: a
+    // non-user-authenticated caller (agent/API key) could otherwise attribute
+    // a task to any existing userId (previously existence-checked only).
+    // Mirror the pattern already used at every other audited write site
+    // (schedules, workflows, approvals, pages, stats) — trust the
+    // authenticated request user directly, otherwise derive the actor from
+    // the caller's own task context (ownership-gated `X-Source-Task-Id` /
+    // ambient current task), never the request body.
+    const requestedByUserId = resolveHttpAuditUserId(req, myAgentId) ?? undefined;
 
     // Default agent for ingress-created tasks: when no explicit `agentId` is
     // provided, route to the lead so the task has an owner immediately

--- a/src/integrations/kapso/inbound.ts
+++ b/src/integrations/kapso/inbound.ts
@@ -2,8 +2,8 @@ import { resolveTemplate } from "@/prompts/resolver";
 import { createTaskWithSiblingAwareness } from "@/tasks/sibling-awareness";
 import { workflowEventBus } from "@/workflows/event-bus";
 import "@/tools/templates";
+import { type IdentityResolution, renderIdentity, resolveIdentity } from "@/be/identity";
 import { recordUnmappedIdentity } from "@/be/unmapped-identities";
-import { findUserByExternalId } from "@/be/users";
 import { getKapsoNumberMapping, markKapsoMessageSeen } from "./config";
 
 const KAPSO_IDENTITY_KIND = "kapso";
@@ -44,11 +44,15 @@ function extractText(message: NonNullable<KapsoWebhookPayload["message"]>): stri
 function buildTaskDescription(payload: KapsoWebhookPayload): string {
   const message = payload.message ?? {};
   const conversation = payload.conversation ?? {};
+  const externalId = normalizeKapsoSender(payload);
+  const contactDisplay = externalId
+    ? renderIdentity(resolveKapsoIdentity(externalId))
+    : "(unknown user)";
   return resolveTemplate("kapso.message.received", {
     conversation_id: conversation.id ?? "unknown",
     inbound_wamid: message.id ?? "unknown",
     sender_phone: message.from ?? conversation.phone_number ?? "unknown",
-    contact_name: conversation.contact_name ?? "unknown",
+    contact_name: contactDisplay,
     phone_number_id: payload.phone_number_id ?? "unknown",
     test_note: payload.test ? "\n- test: true (do NOT send a real WhatsApp reply)" : "",
     message_text: extractText(message),
@@ -61,14 +65,27 @@ function normalizeKapsoSender(payload: KapsoWebhookPayload): string | null {
   return digits || null;
 }
 
+/**
+ * Reverse-lookup a phone-number externalId across both identity kinds this
+ * integration writes (`kapso`, `whatsapp` — see the dual-kind note on
+ * `resolveKapsoRequestedByUserId`). Never a provider profile label.
+ */
+function resolveKapsoIdentity(externalId: string): IdentityResolution {
+  const kapsoResolution = resolveIdentity(KAPSO_IDENTITY_KIND, externalId);
+  if (kapsoResolution.status === "resolved") return kapsoResolution;
+  const whatsappResolution = resolveIdentity(WHATSAPP_IDENTITY_KIND, externalId);
+  if (whatsappResolution.status === "resolved") return whatsappResolution;
+  // Both unknown — report under the `kapso` kind for consistency with
+  // resolveKapsoRequestedByUserId's unmapped-tracker recording.
+  return kapsoResolution;
+}
+
 function resolveKapsoRequestedByUserId(payload: KapsoWebhookPayload): string | undefined {
   const externalId = normalizeKapsoSender(payload);
   if (!externalId) return undefined;
 
-  const mapped =
-    findUserByExternalId(KAPSO_IDENTITY_KIND, externalId) ??
-    findUserByExternalId(WHATSAPP_IDENTITY_KIND, externalId);
-  if (mapped) return mapped.id;
+  const resolution = resolveKapsoIdentity(externalId);
+  if (resolution.status === "resolved") return resolution.userId;
 
   recordUnmappedIdentity(KAPSO_IDENTITY_KIND, externalId, {
     sampleEventType: "kapso.message.received",

--- a/src/jira/sync.ts
+++ b/src/jira/sync.ts
@@ -21,6 +21,14 @@ import {
   getTrackerSyncByExternalId,
   updateTrackerSyncSwarmId,
 } from "../be/db-queries/tracker";
+import { renderIdentity, resolveIdentity } from "../be/identity";
+import { recordUnmappedIdentity } from "../be/unmapped-identities";
+import {
+  findOrCreateUserByEmail,
+  findUserByExternalId,
+  type IdentityActor,
+  linkIdentity,
+} from "../be/users";
 import { ensureToken, ensureTokenOrThrow } from "../oauth/ensure-token";
 import { resolveTemplate } from "../prompts/resolver";
 import { buildJiraContextKey } from "../tasks/context-key";
@@ -30,6 +38,66 @@ import { extractMentions, extractText } from "./adf";
 import { getJiraMetadata } from "./metadata";
 // Side-effect import: registers all Jira event templates in the prompt registry
 import "./templates";
+
+// ─── Actor resolution (mirrors resolveLinearActor / resolveSlackUserId) ────
+
+/** Audit-trail actor for the Jira auto-link cascade. */
+const JIRA_WEBHOOK_ACTOR: IdentityActor = { kind: "system", id: "webhook:jira" };
+
+/**
+ * Map a Jira Atlassian `accountId` to a canonical `users.id`:
+ *   1. Existing `(jira, accountId)` mapping — fast path.
+ *   2. No mapping + an email is present on the payload (privacy settings
+ *      permitting) → `findOrCreateUserByEmail` + `linkIdentity`.
+ *   3. No mapping + no email → record into the kv unmapped tracker; caller
+ *      proceeds without a `requestedByUserId`.
+ *
+ * Returns `undefined` when no mapping could be established.
+ */
+function resolveJiraActor(
+  accountId: string | undefined,
+  email: string | undefined,
+  name: string | undefined,
+  sampleEventType: string,
+  sampleContext: string,
+): string | undefined {
+  if (!accountId) return undefined;
+
+  const existing = findUserByExternalId("jira", accountId);
+  if (existing) return existing.id;
+
+  const trimmedEmail = typeof email === "string" ? email.trim() : "";
+  if (trimmedEmail !== "") {
+    const { user } = findOrCreateUserByEmail(
+      trimmedEmail,
+      { name: name?.trim() || undefined },
+      JIRA_WEBHOOK_ACTOR,
+    );
+    try {
+      linkIdentity(user.id, "jira", accountId, JIRA_WEBHOOK_ACTOR);
+    } catch (error) {
+      console.warn(
+        `[Jira Sync] linkIdentity('jira', ${accountId}) failed — likely a concurrent enroll`,
+        error,
+      );
+    }
+    return user.id;
+  }
+
+  recordUnmappedIdentity("jira", accountId, { sampleEventType, sampleContext });
+  return undefined;
+}
+
+/**
+ * Render a Jira actor for agent-visible text: the resolved canonical name or
+ * the explicit UNKNOWN sentinel — never the raw Jira `displayName`. Falls
+ * back to a bare "(unknown user)" when the payload carries no `accountId` at
+ * all (malformed/legacy webhook shape).
+ */
+function renderJiraIdentity(accountId: string | undefined): string {
+  if (!accountId) return "(unknown user)";
+  return renderIdentity(resolveIdentity("jira", accountId));
+}
 
 // ─── Bot identity (Atlassian accountId) ────────────────────────────────────
 
@@ -171,7 +239,7 @@ type IssueShape = {
   fields?: {
     summary?: string;
     description?: unknown;
-    reporter?: { displayName?: string; accountId?: string } | null;
+    reporter?: { displayName?: string; accountId?: string; emailAddress?: string } | null;
   };
 };
 
@@ -218,7 +286,14 @@ export async function handleIssueEvent(event: Record<string, unknown>): Promise<
   const issueId = issue.id;
   const issueKey = issue.key;
   const summary = issue.fields?.summary ?? "(no summary)";
-  const reporterName = issue.fields?.reporter?.displayName ?? "";
+  const reporterAccountId = issue.fields?.reporter?.accountId;
+  const requestedByUserId = resolveJiraActor(
+    reporterAccountId,
+    issue.fields?.reporter?.emailAddress,
+    issue.fields?.reporter?.displayName,
+    "issue_updated",
+    `${issueKey}: ${summary}`,
+  );
   const descriptionText = extractText(issue.fields?.description);
   const issueUrl = buildIssueUrl(issueKey);
 
@@ -241,7 +316,8 @@ export async function handleIssueEvent(event: Record<string, unknown>): Promise<
     await createInitialJiraTask({
       issueKey,
       summary,
-      reporterName,
+      reporterAccountId,
+      requestedByUserId,
       descriptionText,
       issueUrl,
       syncRowId: claim.sync.id,
@@ -265,7 +341,8 @@ export async function handleIssueEvent(event: Record<string, unknown>): Promise<
   await createInitialJiraTask({
     issueKey,
     summary,
-    reporterName,
+    reporterAccountId,
+    requestedByUserId,
     descriptionText,
     issueUrl,
     syncRowId: claim.sync.id,
@@ -280,8 +357,8 @@ export async function handleIssueEvent(event: Record<string, unknown>): Promise<
 type CommentShape = {
   id?: string;
   body?: unknown;
-  author?: { accountId?: string; displayName?: string } | null;
-  updateAuthor?: { accountId?: string; displayName?: string } | null;
+  author?: { accountId?: string; displayName?: string; emailAddress?: string } | null;
+  updateAuthor?: { accountId?: string; displayName?: string; emailAddress?: string } | null;
 };
 
 /**
@@ -345,7 +422,14 @@ export async function handleCommentEvent(event: Record<string, unknown>): Promis
   const summary = issue.fields?.summary ?? "(no summary)";
   const descriptionText = extractText(issue.fields?.description);
   const commentText = extractText(comment.body);
-  const commentAuthor = comment.author?.displayName ?? "";
+  const commentAuthorAccountId = comment.author?.accountId ?? comment.updateAuthor?.accountId;
+  const requestedByUserId = resolveJiraActor(
+    commentAuthorAccountId,
+    comment.author?.emailAddress ?? comment.updateAuthor?.emailAddress,
+    comment.author?.displayName ?? comment.updateAuthor?.displayName,
+    "comment_created",
+    `${issueKey}: ${commentText.slice(0, 80)}`,
+  );
   const issueUrl = buildIssueUrl(issueKey);
 
   if (!existing) {
@@ -372,7 +456,8 @@ export async function handleCommentEvent(event: Record<string, unknown>): Promis
         summary,
         descriptionText,
         commentText,
-        commentAuthor,
+        commentAuthorAccountId,
+        requestedByUserId,
         issueUrl,
         syncRowId: claim.sync.id,
       });
@@ -384,7 +469,8 @@ export async function handleCommentEvent(event: Record<string, unknown>): Promis
       summary,
       issueUrl,
       commentText,
-      commentAuthor,
+      commentAuthorAccountId,
+      requestedByUserId,
       syncRow: claim.sync,
     });
   }
@@ -394,7 +480,8 @@ export async function handleCommentEvent(event: Record<string, unknown>): Promis
     summary,
     issueUrl,
     commentText,
-    commentAuthor,
+    commentAuthorAccountId,
+    requestedByUserId,
     syncRow: existing,
   });
 }
@@ -404,7 +491,8 @@ async function routeCommentOnExistingSync(input: {
   summary: string;
   issueUrl: string;
   commentText: string;
-  commentAuthor: string;
+  commentAuthorAccountId: string | undefined;
+  requestedByUserId: string | undefined;
   syncRow: { id: string; swarmId: string };
 }): Promise<void> {
   const priorTask = input.syncRow.swarmId ? getTaskById(input.syncRow.swarmId) : null;
@@ -417,15 +505,17 @@ async function routeCommentOnExistingSync(input: {
   }
 
   // Terminal or orphan sync row → follow-up.
+  const commentAuthorDisplay = renderJiraIdentity(input.commentAuthorAccountId);
   await createInitialJiraTask({
     issueKey: input.issueKey,
     summary: input.summary,
-    reporterName: input.commentAuthor,
+    reporterAccountId: input.commentAuthorAccountId,
+    requestedByUserId: input.requestedByUserId,
     descriptionText: "",
     issueUrl: input.issueUrl,
     syncRowId: input.syncRow.id,
     followup: true,
-    followupTrigger: `New comment from ${input.commentAuthor || "user"}`,
+    followupTrigger: `New comment from ${commentAuthorDisplay}`,
     followupMessage: input.commentText,
   });
 }
@@ -453,7 +543,8 @@ export async function handleIssueDeleteEvent(event: Record<string, unknown>): Pr
 async function createInitialJiraTask(input: {
   issueKey: string;
   summary: string;
-  reporterName: string;
+  reporterAccountId: string | undefined;
+  requestedByUserId: string | undefined;
   descriptionText: string;
   issueUrl: string;
   syncRowId: string;
@@ -479,7 +570,7 @@ async function createInitialJiraTask(input: {
         issue_key: input.issueKey,
         issue_summary: input.summary,
         issue_url: input.issueUrl,
-        reporter: input.reporterName,
+        reporter: renderJiraIdentity(input.reporterAccountId),
         description_section: descriptionSection,
       };
 
@@ -493,6 +584,7 @@ async function createInitialJiraTask(input: {
     agentId: lead?.id ?? "",
     source: "jira",
     taskType: "jira-issue",
+    requestedByUserId: input.requestedByUserId,
     contextKey: buildJiraContextKey(input.issueKey),
   });
 
@@ -509,7 +601,8 @@ async function createCommentMentionTask(input: {
   summary: string;
   descriptionText: string;
   commentText: string;
-  commentAuthor: string;
+  commentAuthorAccountId: string | undefined;
+  requestedByUserId: string | undefined;
   issueUrl: string;
   syncRowId: string;
 }): Promise<void> {
@@ -522,7 +615,7 @@ async function createCommentMentionTask(input: {
     issue_key: input.issueKey,
     issue_summary: input.summary,
     issue_url: input.issueUrl,
-    comment_author: input.commentAuthor,
+    comment_author: renderJiraIdentity(input.commentAuthorAccountId),
     description_section: descriptionSection,
     comment_text: input.commentText,
   });
@@ -536,6 +629,7 @@ async function createCommentMentionTask(input: {
     agentId: lead?.id ?? "",
     source: "jira",
     taskType: "jira-issue",
+    requestedByUserId: input.requestedByUserId,
     contextKey: buildJiraContextKey(input.issueKey),
   });
 

--- a/src/jira/templates.ts
+++ b/src/jira/templates.ts
@@ -23,7 +23,11 @@ Reporter: {{reporter}}
     { name: "issue_key", description: "Jira issue key (e.g. ENG-123)" },
     { name: "issue_summary", description: "Issue summary / title" },
     { name: "issue_url", description: "Issue URL on the Jira site" },
-    { name: "reporter", description: "Reporter display name (or empty string)" },
+    {
+      name: "reporter",
+      description:
+        "Reporter identity — resolved canonical name (e.g. 'Luis (jira:<accountId>)') or the UNKNOWN sentinel",
+    },
     {
       name: "description_section",
       description: "Description section (extracted from ADF) or empty string",
@@ -46,7 +50,11 @@ Comment:
     { name: "issue_key", description: "Jira issue key (e.g. ENG-123)" },
     { name: "issue_summary", description: "Issue summary / title" },
     { name: "issue_url", description: "Issue URL on the Jira site" },
-    { name: "comment_author", description: "Comment author display name" },
+    {
+      name: "comment_author",
+      description:
+        "Comment author identity — resolved canonical name (e.g. 'Luis (jira:<accountId>)') or the UNKNOWN sentinel",
+    },
     {
       name: "description_section",
       description: "Description section (extracted from ADF) or empty string",

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -56,6 +56,7 @@ export function createStandaloneScheduleTask(
     modelTier: schedule.modelTier,
     scheduleId: schedule.id,
     source: "schedule",
+    requestedByUserId: schedule.createdBy,
     contextKey: scheduleContextKey({ scheduleId: schedule.id }),
   });
 }
@@ -136,6 +137,7 @@ export async function dispatchScheduleTarget(
       };
       const runId = await startWorkflowExecution(workflow, triggerData, registry, {
         triggerType: "schedule",
+        requestedByUserId: schedule.createdBy,
       });
       console.log(
         `[Scheduler] Schedule "${schedule.name}" → triggered workflow "${workflow.name}"`,

--- a/src/scripts-runtime/types/stdlib.d.ts
+++ b/src/scripts-runtime/types/stdlib.d.ts
@@ -108,6 +108,7 @@ declare module "swarm-sdk" {
       externalId?: string;
       email?: string;
       userId?: string;
+      name?: string;
     }): Promise<unknown>;
     db_query(args: { sql: string; params?: unknown[] }): Promise<unknown>;
     // --- config ---

--- a/src/scripts-runtime/types/swarm-sdk.d.ts
+++ b/src/scripts-runtime/types/swarm-sdk.d.ts
@@ -90,6 +90,7 @@ declare module "swarm-sdk" {
       externalId?: string;
       email?: string;
       userId?: string;
+      name?: string;
     }): Promise<unknown>;
     db_query(args: { sql: string; params?: unknown[] }): Promise<unknown>;
     // --- config ---

--- a/src/slack/assistant.ts
+++ b/src/slack/assistant.ts
@@ -3,7 +3,7 @@ import { getAgentWorkingOnThread, getLeadAgent, getMostRecentTaskInThread } from
 import { resolveTemplate } from "../prompts/resolver";
 import { slackContextKey } from "../tasks/context-key";
 import { createTaskWithSiblingAwareness } from "../tasks/sibling-awareness";
-import { resolveSlackUserId } from "./enrich";
+import { resolveSlackUserId, rewriteSlackMentions } from "./enrich";
 import { wasEventSeen } from "./event-dedup";
 import { hasOtherUserMention } from "./router";
 import { bufferThreadMessage } from "./thread-buffer";
@@ -76,6 +76,11 @@ export function createAssistant(): Assistant {
         const channelId = message.channel;
         const messageText = (msg.text as string) || "";
         const userId = (msg.user as string) || "";
+        // Any in-body `<@U…>` mention the requester typed is rewritten via
+        // the identity primitive before it reaches agent-visible task text —
+        // never a raw Slack ID. Bot-mention routing checks below use the
+        // raw `messageText`, not this rendered copy.
+        const renderedMessageText = rewriteSlackMentions(messageText);
 
         // Resolve the bot's own Slack user ID (cached after first call) so we can
         // check whether this message is actually addressed to us.
@@ -123,7 +128,7 @@ export function createAssistant(): Assistant {
 
           // Otherwise, create a follow-up task for the working agent
           const latestTask = getMostRecentTaskInThread(channelId, threadTs);
-          createTaskWithSiblingAwareness(messageText, {
+          createTaskWithSiblingAwareness(renderedMessageText, {
             agentId: workingAgent.id,
             source: "slack",
             slackChannelId: channelId,
@@ -141,8 +146,11 @@ export function createAssistant(): Assistant {
         // 2. First message in thread — create new task for lead
         await safeSetStatus("Processing your request...");
 
-        if (messageText) {
-          const title = messageText.length > 50 ? `${messageText.slice(0, 47)}...` : messageText;
+        if (renderedMessageText) {
+          const title =
+            renderedMessageText.length > 50
+              ? `${renderedMessageText.slice(0, 47)}...`
+              : renderedMessageText;
           await safeSetTitle(title);
         }
 
@@ -156,7 +164,7 @@ export function createAssistant(): Assistant {
         const lead = getLeadAgent();
         if (!lead) {
           // No lead — still queue the task
-          createTaskWithSiblingAwareness(messageText + channelContext, {
+          createTaskWithSiblingAwareness(renderedMessageText + channelContext, {
             source: "slack",
             slackChannelId: channelId,
             slackThreadTs: threadTs,
@@ -169,7 +177,7 @@ export function createAssistant(): Assistant {
           return;
         }
 
-        createTaskWithSiblingAwareness(messageText + channelContext, {
+        createTaskWithSiblingAwareness(renderedMessageText + channelContext, {
           agentId: lead.id,
           source: "slack",
           slackChannelId: channelId,

--- a/src/slack/enrich.ts
+++ b/src/slack/enrich.ts
@@ -23,6 +23,7 @@
 
 import type { WebClient } from "@slack/web-api";
 import { getKv, upsertKv } from "../be/db";
+import { resolveIdentity } from "../be/identity";
 import { recordUnmappedIdentity } from "../be/unmapped-identities";
 import {
   findOrCreateUserByEmail,
@@ -159,4 +160,20 @@ export async function resolveSlackUserId(
   // 3. No email — track as unmapped.
   recordUnmappedIdentity("slack", slackUserId, eventContext);
   return undefined;
+}
+
+/**
+ * Rewrite every Slack `<@USERID>` mention token in `text` via the identity
+ * primitive: `<@USERID|Name>` when resolved, `<@USERID> (unknown user)` when
+ * not. Covers both author labels (`<@U…>: message`) and mentions embedded in
+ * message bodies — both are just this same token. Pure DB reads via
+ * `resolveIdentity`; zero Slack API calls, no cache.
+ */
+export function rewriteSlackMentions(text: string): string {
+  return text.replace(/<@([A-Z0-9]+)>/g, (_match, userId: string) => {
+    const resolution = resolveIdentity("slack", userId);
+    return resolution.status === "resolved"
+      ? `<@${userId}|${resolution.name}>`
+      : `<@${userId}> (unknown user)`;
+  });
 }

--- a/src/slack/handlers.ts
+++ b/src/slack/handlers.ts
@@ -12,7 +12,7 @@ import { slackContextKey } from "../tasks/context-key";
 import { createTaskWithSiblingAwareness } from "../tasks/sibling-awareness";
 import { workflowEventBus } from "../workflows/event-bus";
 import { buildTreeBlocks, type TreeNode } from "./blocks";
-import { enrichSlackUserEmail, resolveSlackUserId } from "./enrich";
+import { enrichSlackUserEmail, resolveSlackUserId, rewriteSlackMentions } from "./enrich";
 import { wasEventSeen } from "./event-dedup";
 import type { SlackFile } from "./files";
 import { extractTaskFromMessage, hasOtherUserMention, routeMessage } from "./router";
@@ -250,23 +250,6 @@ async function wasThreadStartedBySwarm(
   return startedBySwarm;
 }
 
-// Cache for user display names
-const userNameCache = new Map<string, string>();
-
-async function getUserDisplayName(client: WebClient, userId: string): Promise<string> {
-  if (userNameCache.has(userId)) {
-    return userNameCache.get(userId)!;
-  }
-  try {
-    const result = await client.users.info({ user: userId });
-    const name = result.user?.profile?.display_name || result.user?.real_name || userId;
-    userNameCache.set(userId, name);
-    return name;
-  } catch {
-    return userId;
-  }
-}
-
 /**
  * Fetch thread history and format as context for the task.
  * Returns empty string if not in a thread or no previous messages.
@@ -297,7 +280,10 @@ async function getThreadContext(
 
     if (previousMessages.length === 0) return "";
 
-    // Format messages with user names or [Agent] for bot messages
+    // Format messages with user names or [Agent] for bot messages. Author
+    // identity is rendered via the identity primitive (resolved name or the
+    // UNKNOWN sentinel) — never a raw Slack API display name, and no
+    // `users.info` call.
     const formattedMessages: string[] = [];
     for (const m of previousMessages) {
       // Check if this is a bot/agent message (multiple ways to identify)
@@ -310,12 +296,12 @@ async function getThreadContext(
         const truncatedText = text.length > 500 ? `${text.slice(0, 500)}...` : text;
         formattedMessages.push(`[Agent]: ${truncatedText}`);
       } else {
-        const userName = m.user ? await getUserDisplayName(client, m.user) : "Unknown";
-        formattedMessages.push(`${userName}: ${text}`);
+        const authorTag = m.user ? `<@${m.user}>` : "Unknown";
+        formattedMessages.push(`${authorTag}: ${text}`);
       }
     }
 
-    return formattedMessages.join("\n");
+    return rewriteSlackMentions(formattedMessages.join("\n"));
   } catch (error) {
     console.error("[Slack] Failed to fetch thread context:", error);
     return "";

--- a/src/slack/thread-buffer.ts
+++ b/src/slack/thread-buffer.ts
@@ -4,6 +4,7 @@ import { slackContextKey } from "../tasks/context-key";
 import { createTaskWithSiblingAwareness } from "../tasks/sibling-awareness";
 import { getSlackApp } from "./app";
 import { buildBufferFlushBlocks } from "./blocks";
+import { rewriteSlackMentions } from "./enrich";
 import { extractSlackMessageText } from "./message-text";
 import { registerTreeMessage } from "./watcher";
 
@@ -107,7 +108,7 @@ async function getThreadContextForBuffer(channelId: string, threadTs: string): P
       })
       .join("\n");
 
-    return formatted;
+    return rewriteSlackMentions(formatted);
   } catch (error) {
     console.error("[Slack] Failed to fetch thread context for buffer:", error);
     return "";
@@ -137,8 +138,10 @@ async function slackFlush(
 
   console.log(`[Slack] Flushing buffer: ${key} (${items.length} messages, immediate=${immediate})`);
 
-  // Build combined task description
-  const combinedText = items.map((m) => m.text).join("\n---\n");
+  // Build combined task description. Any in-body `<@U…>` mentions the
+  // requester typed are rewritten via the identity primitive so the agent
+  // sees a name or the explicit UNKNOWN sentinel — never a raw Slack ID.
+  const combinedText = rewriteSlackMentions(items.map((m) => m.text).join("\n---\n"));
   const description = `[Thread follow-up — ${items.length} message(s) buffered]\n\n${combinedText}`;
 
   // Find the latest active task in this thread for dependency chaining

--- a/src/tests/agentmail-handlers.test.ts
+++ b/src/tests/agentmail-handlers.test.ts
@@ -81,7 +81,7 @@ function makePayload(opts: {
 // re-runs initDb's global resolver registration right before this file's own
 // resolveTemplate() calls, minimizing the window for another concurrently
 // executing test file's own initDb() to have repointed it in between.
-beforeEach(() => {
+beforeEach(async () => {
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       unlinkSync(`${TEST_DB_PATH}${suffix}`);
@@ -91,6 +91,14 @@ beforeEach(() => {
   // Ensure a lead exists so handler's findLeadAgent() returns truthy and a
   // task gets created on the "no inbox mapping" path.
   createAgent({ name: "LeadAgent", isLead: true, status: "idle" });
+  // Re-register agentmail templates — prompt-template-resolver.test.ts and
+  // prompt-template-session.test.ts call clearTemplateDefinitions() and never
+  // restore the shared (process-wide) registry, so if either runs first in
+  // the same bun worker, resolveTemplate("agentmail.email.*", ...) silently
+  // returns { text: "", skipped: true } here instead of throwing — producing
+  // a task with an empty body rather than a visible failure. Same defensive
+  // pattern as heartbeat-checklist.test.ts's beforeEach.
+  await import(`../agentmail/templates?t=${Date.now()}`);
 });
 
 afterEach(() => {

--- a/src/tests/agentmail-handlers.test.ts
+++ b/src/tests/agentmail-handlers.test.ts
@@ -186,8 +186,10 @@ describe("handleMessageReceived — identity auto-link via findOrCreateUserByEma
 
     const task = getTaskById(result.taskId!);
     expect(task!.requestedByUserId).toBeFalsy();
-    // No display name is ever guessed — the raw header is kept as the
-    // sentinel's identifier, suffixed with the explicit UNKNOWN marker.
-    expect(task!.task).toContain("Unknown Sender (no address) (unknown user)");
+    // No display name — not even the raw provider label — is ever rendered
+    // for an unresolved sender. The task text carries only the non-name
+    // sentinel shape, never the raw From header.
+    expect(task!.task).toContain("email:unknown (unknown user)");
+    expect(task!.task).not.toContain("Unknown Sender (no address)");
   });
 });

--- a/src/tests/agentmail-handlers.test.ts
+++ b/src/tests/agentmail-handlers.test.ts
@@ -111,6 +111,10 @@ describe("handleMessageReceived — identity auto-link via findOrCreateUserByEma
     const task = getTaskById(result.taskId!);
     expect(task).not.toBeNull();
     expect(task!.requestedByUserId).toBe(user!.id);
+    // The resolved canonical name renders in the task text — never the raw
+    // From header (Alice's display name + email as typed by the sender).
+    expect(task!.task).toContain("Alice Newcomer (email:alice.newcomer@example.com)");
+    expect(task!.task).not.toContain("Alice Newcomer <alice.newcomer@example.com>");
   });
 
   test("KNOWN sender (existing users.email) → no duplicate row, auto_merge event, task requestedByUserId populated", async () => {
@@ -162,5 +166,8 @@ describe("handleMessageReceived — identity auto-link via findOrCreateUserByEma
 
     const task = getTaskById(result.taskId!);
     expect(task!.requestedByUserId).toBeFalsy();
+    // No display name is ever guessed — the raw header is kept as the
+    // sentinel's identifier, suffixed with the explicit UNKNOWN marker.
+    expect(task!.task).toContain("Unknown Sender (no address) (unknown user)");
   });
 });

--- a/src/tests/agentmail-handlers.test.ts
+++ b/src/tests/agentmail-handlers.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { unlinkSync } from "node:fs";
 import { handleMessageReceived } from "../agentmail/handlers";
 import type { AgentMailWebhookPayload } from "../agentmail/types";
@@ -69,7 +69,19 @@ function makePayload(opts: {
   };
 }
 
-beforeAll(() => {
+// Per-test (not per-file) DB reset: bun's default `retry` (bunfig.toml) retries
+// a failing test in place, re-invoking beforeEach/afterEach around each
+// attempt. With a file-level beforeAll/afterAll instead, a transient failure
+// on attempt 1 (of any cause) leaves its side effects (the just-created user)
+// in place for the retry, which then finds that user already resolved and
+// silently no-ops the create — turning one flaky attempt into a deterministic
+// "before+1 != after" mismatch on every subsequent attempt. Resetting to a
+// fresh DB (and re-registering the lead) before every test/retry makes each
+// attempt idempotent regardless of how many times it's retried, and also
+// re-runs initDb's global resolver registration right before this file's own
+// resolveTemplate() calls, minimizing the window for another concurrently
+// executing test file's own initDb() to have repointed it in between.
+beforeEach(() => {
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       unlinkSync(`${TEST_DB_PATH}${suffix}`);
@@ -81,7 +93,7 @@ beforeAll(() => {
   createAgent({ name: "LeadAgent", isLead: true, status: "idle" });
 });
 
-afterAll(() => {
+afterEach(() => {
   closeDb();
   for (const suffix of ["", "-wal", "-shm"]) {
     try {

--- a/src/tests/approval-requests.test.ts
+++ b/src/tests/approval-requests.test.ts
@@ -6,6 +6,7 @@ import {
   createAgent,
   createApprovalRequest,
   createTaskExtended,
+  createUser,
   getAgentCurrentTask,
   getApprovalRequestById,
   getApprovalRequestByStepId,
@@ -256,6 +257,24 @@ describe("Approval Requests", () => {
       const data = makeApprovalData({ questions });
       const result = createApprovalRequest(data);
       expect(result.questions).toEqual(questions);
+    });
+
+    test("stamps createdBy when provided, round-trips through getApprovalRequestById", () => {
+      const requester = createUser({
+        name: "Approval Provenance User",
+        email: "approval-provenance@example.com",
+      });
+      const data = makeApprovalData({ createdBy: requester.id });
+      const created = createApprovalRequest(data);
+      expect(created.createdBy).toBe(requester.id);
+
+      const fetched = getApprovalRequestById(created.id);
+      expect(fetched?.createdBy).toBe(requester.id);
+    });
+
+    test("createdBy is undefined when not provided", () => {
+      const result = createApprovalRequest(makeApprovalData());
+      expect(result.createdBy).toBeUndefined();
     });
   });
 
@@ -586,6 +605,48 @@ describe("Approval Requests", () => {
       expect(created).not.toBeNull();
       expect(created!.title).toBe("Deploy approval");
       expect(created!.workflowRunStepId).toBe(stepId);
+    });
+
+    test("stamps createdBy from meta.requestedByUserId (workflow-run provenance)", async () => {
+      const requester = createUser({
+        name: "HITL Requester",
+        email: "hitl-requester@example.com",
+      });
+      const stepId = crypto.randomUUID();
+      const meta = { ...mockMeta, stepId, requestedByUserId: requester.id };
+      const executor = new HumanInTheLoopExecutor(mockDeps);
+
+      await executor.run({
+        config: {
+          title: "Deploy approval",
+          questions: [{ id: "q1", type: "approval", label: "Approve?", required: true }],
+          approvers: { policy: "any" },
+        },
+        context: {},
+        meta,
+      });
+
+      const created = getApprovalRequestByStepId(stepId);
+      expect(created?.createdBy).toBe(requester.id);
+    });
+
+    test("leaves createdBy unset when the workflow run carries no requester", async () => {
+      const stepId = crypto.randomUUID();
+      const meta = { ...mockMeta, stepId };
+      const executor = new HumanInTheLoopExecutor(mockDeps);
+
+      await executor.run({
+        config: {
+          title: "Deploy approval",
+          questions: [{ id: "q1", type: "approval", label: "Approve?", required: true }],
+          approvers: { policy: "any" },
+        },
+        context: {},
+        meta,
+      });
+
+      const created = getApprovalRequestByStepId(stepId);
+      expect(created?.createdBy).toBeUndefined();
     });
 
     test("idempotency: returns async marker for pending existing request", async () => {

--- a/src/tests/audit-user.test.ts
+++ b/src/tests/audit-user.test.ts
@@ -11,8 +11,11 @@ import { unlink } from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
 import { Readable } from "node:stream";
 import { resolveHttpAuditUserId, resolveTaskAuditUserId } from "../be/audit-user";
-import { closeDb, createAgent, createTaskExtended, createUser, initDb } from "../be/db";
+import { closeDb, createAgent, createTaskExtended, createUser, initDb, startTask } from "../be/db";
+import { type IdentityActor, linkIdentity } from "../be/users";
 import { setRequestAuth } from "../utils/request-auth-context";
+
+const SYSTEM_ACTOR: IdentityActor = { kind: "system", id: "test" };
 
 const TEST_DB_PATH = "./test-audit-user.sqlite";
 
@@ -94,6 +97,49 @@ describe("resolveTaskAuditUserId", () => {
 
   test("returns null when owned task has no human requester", () => {
     expect(resolveTaskAuditUserId(noRequesterTaskId, agentId)).toBeNull();
+  });
+
+  test("ambient-task fallback: no sourceTaskId resolves via the caller's current in-progress task", () => {
+    const ambientAgent = createAgent({ name: "ambient-agent", isLead: false, status: "idle" });
+    const ambientTask = createTaskExtended("ambient task", {
+      agentId: ambientAgent.id,
+      requestedByUserId: humanUserId,
+    });
+    startTask(ambientTask.id);
+
+    expect(resolveTaskAuditUserId(undefined, ambientAgent.id)).toBe(humanUserId);
+  });
+
+  test("ambient-task fallback: no in-progress task for the caller still returns null", () => {
+    const idleAgent = createAgent({ name: "idle-agent", isLead: false, status: "idle" });
+    expect(resolveTaskAuditUserId(undefined, idleAgent.id)).toBeNull();
+  });
+
+  test("machine-carried external-ID fallback: no requestedByUserId but a linked Slack id resolves the user", () => {
+    const slackLinkedUser = createUser({ name: "Slack Fallback User" });
+    linkIdentity(slackLinkedUser.id, "slack", "U_AUDIT_FALLBACK", SYSTEM_ACTOR);
+
+    const fallbackAgent = createAgent({ name: "fallback-agent", isLead: false, status: "idle" });
+    const fallbackTask = createTaskExtended("slack-originated task, requester never stamped", {
+      agentId: fallbackAgent.id,
+      slackUserId: "U_AUDIT_FALLBACK",
+    });
+
+    expect(resolveTaskAuditUserId(fallbackTask.id, fallbackAgent.id)).toBe(slackLinkedUser.id);
+  });
+
+  test("machine-carried external-ID fallback: unlinked Slack id still returns null (no guess)", () => {
+    const fallbackAgent = createAgent({
+      name: "fallback-agent-unlinked",
+      isLead: false,
+      status: "idle",
+    });
+    const fallbackTask = createTaskExtended("slack-originated task, unlinked sender", {
+      agentId: fallbackAgent.id,
+      slackUserId: "U_NEVER_LINKED_AUDIT",
+    });
+
+    expect(resolveTaskAuditUserId(fallbackTask.id, fallbackAgent.id)).toBeNull();
   });
 });
 

--- a/src/tests/github-handlers.test.ts
+++ b/src/tests/github-handlers.test.ts
@@ -119,11 +119,11 @@ function makeCommentEvent(senderLogin: string, body: string): CommentEvent {
   };
 }
 
-function makeReviewEvent(senderLogin: string): PullRequestReviewEvent {
+function makeReviewEvent(senderLogin: string, reviewId = 1): PullRequestReviewEvent {
   return {
     action: "submitted",
     review: {
-      id: 1,
+      id: reviewId,
       body: "Looks good",
       state: "approved",
       html_url: "https://github.com/test/repo/pull/99#pullrequestreview-1",
@@ -151,6 +151,13 @@ function getMappedUserTaskCount(userId: string): number {
     )
     .get(userId);
   return row?.n ?? 0;
+}
+
+function getLatestTaskText(): string | null {
+  const row = getDb()
+    .prepare<{ task: string }, []>("SELECT task FROM agent_tasks ORDER BY rowid DESC LIMIT 1")
+    .get();
+  return row?.task ?? null;
 }
 
 // ── Known sender → mapped requestedByUserId, no unmapped writes ──
@@ -215,6 +222,17 @@ describe("known github sender", () => {
     // Mapped sender → no unmapped kv writes.
     expect(getKv(UNMAPPED_NAMESPACE, "reviewer:meta")).toBeNull();
     expect(getKv(UNMAPPED_NAMESPACE, "reviewer:count")).toBeNull();
+  });
+
+  test("review event from mapped user renders the resolved identity pair, never the raw login", async () => {
+    const user = createUser({ name: "Pair Reviewer", email: "pair-reviewer@example.com" });
+    linkIdentity(user.id, "github", "pair-reviewer", SYSTEM_ACTOR);
+
+    const result = await handlePullRequestReview(makeReviewEvent("pair-reviewer", 1001));
+    expect(result.created).toBe(true);
+
+    const text = getLatestTaskText();
+    expect(text).toContain("Pair Reviewer (github:pair-reviewer)");
   });
 });
 
@@ -289,6 +307,14 @@ describe("unknown github sender", () => {
     const meta = getKv(UNMAPPED_NAMESPACE, "trunc-ghost:meta");
     const metaValue = meta?.value as { sampleContext: string };
     expect(metaValue.sampleContext.length).toBeLessThanOrEqual(100);
+  });
+
+  test("review event from unknown user renders the UNKNOWN sentinel, never a bare login", async () => {
+    const result = await handlePullRequestReview(makeReviewEvent("sentinel-ghost", 1002));
+    expect(result.created).toBe(true);
+
+    const text = getLatestTaskText();
+    expect(text).toContain("github:sentinel-ghost (unknown user)");
   });
 });
 

--- a/src/tests/gitlab-handlers.test.ts
+++ b/src/tests/gitlab-handlers.test.ts
@@ -979,5 +979,130 @@ describe("identity resolution — Note handler", () => {
     expect((meta?.sampleContext as string).length).toBeLessThanOrEqual(100);
     expect((meta?.sampleContext as string).startsWith(`@${GITLAB_BOT_NAME}`)).toBe(true);
     expect(getUnmappedCount("noteghost")).toBe(1);
+
+    // The dead-coded `_requestedByUserId` is now wired: undefined for an
+    // unresolvable sender, and the UNKNOWN sentinel (never the raw
+    // username) is rendered as the comment author in the task text.
+    const task = getTaskById(result.taskId!);
+    expect(task?.requestedByUserId).toBeFalsy();
+    expect(task?.task).toContain("gitlab:noteghost (unknown user)");
+    expect(task?.task).not.toContain("Note Ghost");
+  });
+
+  test("known GitLab user commenting -> requestedByUserId populated + rendered pair, never the raw username", async () => {
+    const known = createUser({ name: "Known Commenter" });
+    linkIdentity(known.id, "gitlab", "knowncommenter", { kind: "system", id: "test" });
+
+    const event = makeNoteEvent({
+      user: { id: 32, name: "Known Commenter", username: "knowncommenter", avatar_url: "" },
+      object_attributes: {
+        id: 961,
+        note: `@${GITLAB_BOT_NAME} please take a look`,
+        noteable_type: "MergeRequest",
+        noteable_id: 101,
+        url: "https://gitlab.com/group/project/-/merge_requests/2#note_961",
+        author_id: 32,
+        type: null,
+      },
+      merge_request: {
+        id: 101,
+        iid: 961,
+        title: "Known Commenter MR",
+        description: "",
+        state: "opened",
+        action: "open",
+        source_branch: "feat-knowncommenter",
+        target_branch: "main",
+        url: "https://gitlab.com/group/project/-/merge_requests/961",
+        last_commit: null,
+        author_id: 32,
+      },
+    });
+
+    const result = await handleNote(event);
+    expect(result.created).toBe(true);
+
+    const task = getTaskById(result.taskId!);
+    expect(task?.requestedByUserId).toBe(known.id);
+    expect(task?.task).toContain("Known Commenter (gitlab:knowncommenter)");
+  });
+});
+
+describe("identity resolution — Pipeline handler", () => {
+  test("known GitLab user triggers pipeline -> requestedByUserId populated on the task", async () => {
+    const known = createUser({ name: "Pipeline Trigger" });
+    linkIdentity(known.id, "gitlab", "pipelinetrigger", { kind: "system", id: "test" });
+
+    createTaskExtended("[GitLab MR #970] Pipeline identity test", {
+      source: "gitlab",
+      vcsProvider: "gitlab",
+      vcsRepo: "group/project",
+      vcsEventType: "merge_request",
+      vcsNumber: 970,
+      vcsUrl: "https://gitlab.com/group/project/-/merge_requests/970",
+      agentId: "lead-gl-001",
+    });
+
+    const event = makePipelineEvent({
+      user: { id: 41, name: "Pipeline Trigger", username: "pipelinetrigger", avatar_url: "" },
+      object_attributes: {
+        id: 500,
+        ref: "feature",
+        status: "failed",
+        source: "push",
+        detailed_status: "failed",
+      },
+      merge_request: {
+        id: 200,
+        iid: 970,
+        title: "MR with known pipeline trigger",
+        url: "https://gitlab.com/group/project/-/merge_requests/970",
+        source_branch: "feature",
+        target_branch: "main",
+      },
+    });
+
+    const result = await handlePipeline(event);
+    expect(result.created).toBe(true);
+
+    const task = getTaskById(result.taskId!);
+    expect(task?.requestedByUserId).toBe(known.id);
+  });
+
+  test("unknown GitLab user triggers pipeline -> requestedByUserId stays undefined", async () => {
+    createTaskExtended("[GitLab MR #971] Pipeline identity test", {
+      source: "gitlab",
+      vcsProvider: "gitlab",
+      vcsRepo: "group/project",
+      vcsEventType: "merge_request",
+      vcsNumber: 971,
+      vcsUrl: "https://gitlab.com/group/project/-/merge_requests/971",
+      agentId: "lead-gl-001",
+    });
+
+    const event = makePipelineEvent({
+      user: { id: 42, name: "Pipeline Ghost", username: "pipelineghost", avatar_url: "" },
+      object_attributes: {
+        id: 501,
+        ref: "feature",
+        status: "failed",
+        source: "push",
+        detailed_status: "failed",
+      },
+      merge_request: {
+        id: 201,
+        iid: 971,
+        title: "MR with unknown pipeline trigger",
+        url: "https://gitlab.com/group/project/-/merge_requests/971",
+        source_branch: "feature",
+        target_branch: "main",
+      },
+    });
+
+    const result = await handlePipeline(event);
+    expect(result.created).toBe(true);
+
+    const task = getTaskById(result.taskId!);
+    expect(task?.requestedByUserId).toBeFalsy();
   });
 });

--- a/src/tests/identity.test.ts
+++ b/src/tests/identity.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { unlink } from "node:fs/promises";
+import { closeDb, createUser, initDb } from "../be/db";
+import { renderIdentity, resolveIdentity, resolveIdentityByEmail } from "../be/identity";
+import { type IdentityActor, linkIdentity } from "../be/users";
+
+const TEST_DB_PATH = "./test-identity.sqlite";
+
+const SYSTEM_ACTOR: IdentityActor = { kind: "system", id: "test" };
+
+beforeAll(async () => {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      await unlink(TEST_DB_PATH + suffix);
+    } catch {}
+  }
+  closeDb();
+  initDb(TEST_DB_PATH);
+});
+
+afterAll(async () => {
+  closeDb();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      await unlink(TEST_DB_PATH + suffix);
+    } catch {}
+  }
+});
+
+describe("resolveIdentity", () => {
+  test("resolved: linked (kind, externalId) returns the user", () => {
+    const user = createUser({ name: "Luis", email: "luis@example.com" });
+    linkIdentity(user.id, "slack", "U016H7XKZGS", SYSTEM_ACTOR);
+
+    const resolution = resolveIdentity("slack", "U016H7XKZGS");
+    expect(resolution).toEqual({
+      status: "resolved",
+      kind: "slack",
+      externalId: "U016H7XKZGS",
+      userId: user.id,
+      name: "Luis",
+      email: "luis@example.com",
+    });
+  });
+
+  test("unknown: unlinked (kind, externalId) returns the sentinel value, never a name", () => {
+    const resolution = resolveIdentity("slack", "U_DOES_NOT_EXIST");
+    expect(resolution).toEqual({
+      status: "unknown",
+      kind: "slack",
+      externalId: "U_DOES_NOT_EXIST",
+    });
+  });
+
+  test("is provider-agnostic — any kind string works identically", () => {
+    const user = createUser({ name: "Jira Reporter", email: "jira-reporter@example.com" });
+    linkIdentity(user.id, "jira", "5b10a2844c20165700ede21g", SYSTEM_ACTOR);
+
+    const resolution = resolveIdentity("jira", "5b10a2844c20165700ede21g");
+    expect(resolution.status).toBe("resolved");
+    expect(resolution.status === "resolved" && resolution.userId).toBe(user.id);
+  });
+});
+
+describe("resolveIdentityByEmail", () => {
+  test("resolved: known email returns the user with kind 'email'", () => {
+    const user = createUser({ name: "Alberto", email: "alberto@example.com" });
+
+    const resolution = resolveIdentityByEmail("alberto@example.com");
+    expect(resolution).toEqual({
+      status: "resolved",
+      kind: "email",
+      externalId: "alberto@example.com",
+      userId: user.id,
+      name: "Alberto",
+      email: "alberto@example.com",
+    });
+  });
+
+  test("unknown: unregistered email returns the sentinel value", () => {
+    const resolution = resolveIdentityByEmail("nobody@example.com");
+    expect(resolution).toEqual({
+      status: "unknown",
+      kind: "email",
+      externalId: "nobody@example.com",
+    });
+  });
+});
+
+describe("renderIdentity", () => {
+  test("resolved renders 'Name (kind:externalId)'", () => {
+    const rendered = renderIdentity({
+      status: "resolved",
+      kind: "slack",
+      externalId: "U016H7XKZGS",
+      userId: "u1",
+      name: "Luis",
+    });
+    expect(rendered).toBe("Luis (slack:U016H7XKZGS)");
+  });
+
+  test("unknown renders 'kind:externalId (unknown user)' — the sentinel never contains a name", () => {
+    const rendered = renderIdentity({
+      status: "unknown",
+      kind: "slack",
+      externalId: "U016H7XKZGS",
+    });
+    expect(rendered).toBe("slack:U016H7XKZGS (unknown user)");
+    expect(rendered).not.toContain("Luis");
+  });
+
+  test("the sentinel is deterministic for the same input", () => {
+    const resolution = resolveIdentity("github", "octocat-unlinked");
+    expect(renderIdentity(resolution)).toBe(renderIdentity(resolution));
+    expect(renderIdentity(resolution)).toBe("github:octocat-unlinked (unknown user)");
+  });
+});

--- a/src/tests/jira-sync.test.ts
+++ b/src/tests/jira-sync.test.ts
@@ -1,6 +1,14 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { unlink } from "node:fs/promises";
-import { closeDb, completeTask, createAgent, getDb, getTaskById, initDb } from "../be/db";
+import {
+  closeDb,
+  completeTask,
+  createAgent,
+  createUser,
+  getDb,
+  getTaskById,
+  initDb,
+} from "../be/db";
 import { upsertOAuthApp } from "../be/db-queries/oauth";
 import {
   createTrackerSync,
@@ -8,6 +16,9 @@ import {
   getTrackerSyncByExternalId,
   updateTrackerSync,
 } from "../be/db-queries/tracker";
+import { findUserByExternalId, type IdentityActor, linkIdentity } from "../be/users";
+
+const SYSTEM_ACTOR: IdentityActor = { kind: "system", id: "test" };
 
 const TEST_DB_PATH = "./test-jira-sync.sqlite";
 const BOT_ACCOUNT_ID = "bot-account-12345";
@@ -300,6 +311,93 @@ describe("handleCommentEvent — short-circuits", () => {
       .query("SELECT COUNT(*) AS c FROM agent_tasks WHERE source = 'jira'")
       .get() as { c: number };
     expect(taskCount.c).toBe(2);
+  });
+});
+
+describe("identity resolution — Jira routes through resolveIdentity, never raw displayName", () => {
+  test("issue-assigned: reporter linked by accountId -> requestedByUserId set + rendered pair in task text", async () => {
+    const reporter = createUser({ name: "Zbigniew Reporter", email: "zbigniew-jira@example.com" });
+    linkIdentity(reporter.id, "jira", "reporter-linked-1", SYSTEM_ACTOR);
+
+    const event = makeIssueAssignedEvent("10030", "KAN-30", "Linked reporter issue");
+    event.issue.fields.reporter = {
+      displayName: "Reporter Name",
+      accountId: "reporter-linked-1",
+    };
+    await handleIssueEvent(event);
+
+    const sync = getTrackerSyncByExternalId("jira", "task", "10030");
+    const task = getTaskById(sync?.swarmId ?? "");
+    expect(task).not.toBeNull();
+    expect(task?.requestedByUserId).toBe(reporter.id);
+    expect(task?.task).toContain("Zbigniew Reporter (jira:reporter-linked-1)");
+    expect(task?.task).not.toContain("Reporter Name");
+  });
+
+  test("issue-assigned: reporter with an email but no prior link auto-links via findOrCreateUserByEmail", async () => {
+    const event = makeIssueAssignedEvent("10031", "KAN-31", "Email-cascade issue");
+    event.issue.fields.reporter = {
+      displayName: "Auto Linked",
+      accountId: "reporter-autolink-1",
+      emailAddress: "auto-linked-jira@example.com",
+    };
+    await handleIssueEvent(event);
+
+    const linked = findUserByExternalId("jira", "reporter-autolink-1");
+    expect(linked).not.toBeNull();
+    expect(linked?.name).toBe("Auto Linked");
+
+    const sync = getTrackerSyncByExternalId("jira", "task", "10031");
+    const task = getTaskById(sync?.swarmId ?? "");
+    expect(task?.requestedByUserId).toBe(linked?.id);
+    expect(task?.task).toContain("Auto Linked (jira:reporter-autolink-1)");
+  });
+
+  test("issue-assigned: unlinked reporter with no email renders the UNKNOWN sentinel, never the displayName", async () => {
+    const event = makeIssueAssignedEvent("10032", "KAN-32", "Unknown reporter issue");
+    event.issue.fields.reporter = {
+      displayName: "Never Registered",
+      accountId: "reporter-unknown-1",
+    };
+    await handleIssueEvent(event);
+
+    const sync = getTrackerSyncByExternalId("jira", "task", "10032");
+    const task = getTaskById(sync?.swarmId ?? "");
+    expect(task).not.toBeNull();
+    expect(task?.requestedByUserId ?? null).toBeNull();
+    expect(task?.task).toContain("jira:reporter-unknown-1 (unknown user)");
+    expect(task?.task).not.toContain("Never Registered");
+  });
+
+  test("comment-mention: linked author -> requestedByUserId set + rendered pair as comment_author", async () => {
+    const author = createUser({ name: "Manuel Commenter", email: "manuel-jira@example.com" });
+    linkIdentity(author.id, "jira", "commenter-linked-1", SYSTEM_ACTOR);
+
+    await handleCommentEvent(
+      makeCommentEvent("10033", "KAN-33", "commenter-linked-1", "please take a look", [
+        BOT_ACCOUNT_ID,
+      ]),
+    );
+
+    const sync = getTrackerSyncByExternalId("jira", "task", "10033");
+    const task = getTaskById(sync?.swarmId ?? "");
+    expect(task).not.toBeNull();
+    expect(task?.requestedByUserId).toBe(author.id);
+    expect(task?.task).toContain("Manuel Commenter (jira:commenter-linked-1)");
+    expect(task?.task).not.toContain("Some User");
+  });
+
+  test("comment-mention: unlinked author renders the UNKNOWN sentinel, never the raw displayName", async () => {
+    await handleCommentEvent(
+      makeCommentEvent("10034", "KAN-34", "commenter-unknown-1", "any updates?", [BOT_ACCOUNT_ID]),
+    );
+
+    const sync = getTrackerSyncByExternalId("jira", "task", "10034");
+    const task = getTaskById(sync?.swarmId ?? "");
+    expect(task).not.toBeNull();
+    expect(task?.requestedByUserId ?? null).toBeNull();
+    expect(task?.task).toContain("jira:commenter-unknown-1 (unknown user)");
+    expect(task?.task).not.toContain("Some User");
   });
 });
 

--- a/src/tests/kapso-inbound.test.ts
+++ b/src/tests/kapso-inbound.test.ts
@@ -147,6 +147,10 @@ describe("routeKapsoInbound", () => {
     const task = getTaskById(routing.taskId);
     expect(task!.requestedByUserId).toBe(user.id);
     expect(getKv("integration:unmapped:kapso", "34679077778:meta")).toBeNull();
+    // The resolved canonical name renders in the task text — never the raw
+    // WhatsApp profile `contact_name` ("Taras" from the fixture payload).
+    expect(task!.task).toContain("Known WhatsApp Sender (kapso:34679077778)");
+    expect(task!.task).not.toContain("Taras");
   });
 
   test("unknown Kapso sender → records unmapped identity and leaves task unowned", () => {
@@ -170,6 +174,9 @@ describe("routeKapsoInbound", () => {
     if (routing.kind !== "task") throw new Error("expected task");
     const task = getTaskById(routing.taskId);
     expect(task!.requestedByUserId).toBeUndefined();
+    // Unresolved -> explicit UNKNOWN sentinel, never the raw contact_name.
+    expect(task!.task).toContain("kapso:34679077779 (unknown user)");
+    expect(task!.task).not.toContain("Taras");
 
     const meta = getKv("integration:unmapped:kapso", "34679077779:meta");
     expect(meta?.valueType).toBe("json");

--- a/src/tests/mcp-tools-user.test.ts
+++ b/src/tests/mcp-tools-user.test.ts
@@ -106,12 +106,17 @@ describe("resolve-user MCP tool (new {kind, externalId, email} shape)", () => {
     expect(textOf(byAlias)).toContain(user.id);
   });
 
-  test("returns 'No user found' when nothing matches", async () => {
+  test("returns a structured {status: 'unknown', ...} payload when nothing matches — never prose", async () => {
     const result = await callTool(server, "resolve-user", {
       kind: "slack",
       externalId: "U_DOES_NOT_EXIST",
     });
-    expect(textOf(result)).toContain("No user found");
+    const parsed = JSON.parse(textOf(result));
+    expect(parsed).toEqual({
+      status: "unknown",
+      kind: "slack",
+      externalId: "U_DOES_NOT_EXIST",
+    });
   });
 
   // Schema-level validation tests. The MCP SDK runs Zod at the transport
@@ -132,12 +137,17 @@ describe("resolve-user MCP tool (new {kind, externalId, email} shape)", () => {
     expect(parsed.success).toBe(false);
     if (!parsed.success) {
       const msg = JSON.stringify(parsed.error.issues);
-      expect(msg).toMatch(/Provide either \(kind \+ externalId\), email, or userId/);
+      expect(msg).toMatch(/Provide either \(kind \+ externalId\), email, userId, or name/);
     }
   });
 
-  test("name parameter (old shape) is rejected", () => {
+  test("valid {name} input passes the schema", () => {
     const parsed = resolveUserInputSchema.safeParse({ name: "Whoever" });
+    expect(parsed.success).toBe(true);
+  });
+
+  test("name shorter than 2 chars fails the min-length constraint", () => {
+    const parsed = resolveUserInputSchema.safeParse({ name: "A" });
     expect(parsed.success).toBe(false);
   });
 
@@ -201,9 +211,53 @@ describe("resolve-user MCP tool (new {kind, externalId, email} shape)", () => {
     expect(parsed.externalIds[0]).toMatchObject({ kind: "linear", externalId: "L_UIDLOOKUP" });
   });
 
-  test("userId lookup returns 'No user found' for unknown ID", async () => {
+  test("userId lookup returns a structured {status: 'unknown', ...} payload for an unknown ID", async () => {
     const result = await callTool(server, "resolve-user", { userId: "nonexistent-user-id-xyz" });
-    expect(textOf(result)).toContain("No user found");
+    const parsed = JSON.parse(textOf(result));
+    expect(parsed).toEqual({
+      status: "unknown",
+      kind: "userId",
+      externalId: "nonexistent-user-id-xyz",
+    });
+  });
+
+  test("name lookup: single exact match resolves to the user profile", async () => {
+    const user = createUser({ name: "Zbigniew Solo", email: "zbigniew@example.com" });
+
+    const result = await callTool(server, "resolve-user", { name: "Zbigniew Solo" });
+    const parsed = JSON.parse(textOf(result));
+    expect(parsed.id).toBe(user.id);
+    expect(parsed.name).toBe("Zbigniew Solo");
+  });
+
+  test("name lookup: single first-token prefix match resolves to the user profile", async () => {
+    const user = createUser({ name: "Priyanka Unique Prefix", email: "priyanka@example.com" });
+
+    const result = await callTool(server, "resolve-user", { name: "Priyanka" });
+    const parsed = JSON.parse(textOf(result));
+    expect(parsed.id).toBe(user.id);
+  });
+
+  test("name lookup: multiple matches return {status: 'ambiguous', candidates: [...]} — never a guess", async () => {
+    const a = createUser({ name: "Alberto Maurel", email: "alberto.maurel@example.com" });
+    const b = createUser({ name: "Alberto Dubois", email: "alberto.dubois@example.com" });
+
+    const result = await callTool(server, "resolve-user", { name: "Alberto" });
+    const parsed = JSON.parse(textOf(result));
+    expect(parsed.status).toBe("ambiguous");
+    expect(parsed.message).toMatch(/AMBIGUOUS/);
+    const candidateIds = parsed.candidates.map((c: { userId: string }) => c.userId).sort();
+    expect(candidateIds).toEqual([a.id, b.id].sort());
+  });
+
+  test("name lookup: zero matches return a structured {status: 'unknown', kind: 'name', ...} payload", async () => {
+    const result = await callTool(server, "resolve-user", { name: "Nobody Registered Xyz" });
+    const parsed = JSON.parse(textOf(result));
+    expect(parsed).toEqual({
+      status: "unknown",
+      kind: "name",
+      externalId: "Nobody Registered Xyz",
+    });
   });
 });
 

--- a/src/tests/prompt-template-remaining.test.ts
+++ b/src/tests/prompt-template-remaining.test.ts
@@ -155,7 +155,7 @@ describe("GitLab — backward compatibility", () => {
     const expected = `[GitLab MR #5] Add feature
 
 Repo: group/project
-Author: @dev1
+Author: dev1
 Branch: feature-branch \u2192 main
 URL: https://gitlab.com/group/project/-/merge_requests/5
 
@@ -206,7 +206,7 @@ The CI pipeline has failed. Please investigate and fix the issues.
 
     expect(result.skipped).toBe(false);
 
-    const expected = `[GitLab Comment on MR #5] @dev1 mentioned bot
+    const expected = `[GitLab Comment on MR #5] dev1 mentioned bot
 
 Repo: group/project
 URL: https://gitlab.com/group/project/-/merge_requests/5

--- a/src/tests/scheduled-tasks.test.ts
+++ b/src/tests/scheduled-tasks.test.ts
@@ -4,11 +4,13 @@ import {
   closeDb,
   createAgent,
   createScheduledTask,
+  createUser,
   deleteScheduledTask,
   getDb,
   getScheduledTaskById,
   getScheduledTaskByName,
   getScheduledTasks,
+  getTaskById,
   initDb,
   updateScheduledTask,
 } from "../be/db";
@@ -313,6 +315,44 @@ describe("Scheduled Tasks Integration", () => {
       expect(afterRun?.nextRunAt).toBe(futureDate);
       // lastRunAt should be set
       expect(afterRun?.lastRunAt).toBeDefined();
+    });
+
+    test("fired task inherits the schedule's createdBy as requestedByUserId", async () => {
+      const requester = createUser({ name: "Schedule Requester", email: "sched-req@example.com" });
+      const schedule = createScheduledTask({
+        name: "test-manual-run-createdby",
+        cronExpression: "0 9 * * *",
+        taskTemplate: "Task carrying schedule provenance",
+        createdByAgentId: testAgent.id,
+        createdBy: requester.id,
+        enabled: true,
+      });
+
+      await runScheduleNow(schedule.id);
+
+      const createdTask = getDb()
+        .query("SELECT id FROM agent_tasks WHERE task = ? ORDER BY createdAt DESC LIMIT 1")
+        .get(schedule.taskTemplate) as { id: string };
+      const task = getTaskById(createdTask.id);
+      expect(task?.requestedByUserId).toBe(requester.id);
+    });
+
+    test("fired task has no requestedByUserId when the schedule's createdBy is unset (first-ever schedules)", async () => {
+      const schedule = createScheduledTask({
+        name: "test-manual-run-no-createdby",
+        cronExpression: "0 9 * * *",
+        taskTemplate: "Task with no schedule provenance",
+        createdByAgentId: testAgent.id,
+        enabled: true,
+      });
+
+      await runScheduleNow(schedule.id);
+
+      const createdTask = getDb()
+        .query("SELECT id FROM agent_tasks WHERE task = ? ORDER BY createdAt DESC LIMIT 1")
+        .get(schedule.taskTemplate) as { id: string };
+      const task = getTaskById(createdTask.id);
+      expect(task?.requestedByUserId ?? null).toBeNull();
     });
 
     test("should throw error for non-existent schedule", async () => {

--- a/src/tests/slack-identity-resolution.test.ts
+++ b/src/tests/slack-identity-resolution.test.ts
@@ -19,9 +19,16 @@
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { unlinkSync } from "node:fs";
-import { closeDb, getDb, getKv, initDb } from "../be/db";
-import { findUserByExternalId, getUserIdentities } from "../be/users";
-import { enrichSlackUserEmail, resolveSlackUserId } from "../slack/enrich";
+import { closeDb, createUser, getDb, getKv, initDb } from "../be/db";
+import {
+  findUserByExternalId,
+  getUserIdentities,
+  type IdentityActor,
+  linkIdentity,
+} from "../be/users";
+import { enrichSlackUserEmail, resolveSlackUserId, rewriteSlackMentions } from "../slack/enrich";
+
+const SYSTEM_ACTOR: IdentityActor = { kind: "system", id: "test" };
 
 const TEST_DB_PATH = "./test-slack-identity-resolution.sqlite";
 
@@ -344,5 +351,32 @@ describe("findUserByExternalId — sanity check after cascade", () => {
     const looked = findUserByExternalId("slack", "U_HUMAN");
     expect(looked).not.toBeNull();
     expect(looked!.id).toBe(id);
+  });
+});
+
+describe("rewriteSlackMentions — pure DB, zero Slack API calls", () => {
+  test("resolved mention renders '<@id|Name>' — the canonical pair", () => {
+    const user = createUser({ name: "Manuel", email: "manuel-rw@example.com" });
+    linkIdentity(user.id, "slack", "U3000RESOLVED", SYSTEM_ACTOR);
+
+    const rewritten = rewriteSlackMentions("hey <@U3000RESOLVED> can you look at this");
+    expect(rewritten).toBe("hey <@U3000RESOLVED|Manuel> can you look at this");
+  });
+
+  test("unresolved mention renders '<@id> (unknown user)' — never a guessed name", () => {
+    const rewritten = rewriteSlackMentions("hey <@U4000UNKNOWN> can you look at this");
+    expect(rewritten).toBe("hey <@U4000UNKNOWN> (unknown user) can you look at this");
+  });
+
+  test("multiple mentions in one string are each rewritten independently", () => {
+    const user = createUser({ name: "Tainá", email: "taina-rw@example.com" });
+    linkIdentity(user.id, "slack", "U5000RESOLVED", SYSTEM_ACTOR);
+
+    const rewritten = rewriteSlackMentions("<@U5000RESOLVED> and <@U6000UNKNOWN> both here");
+    expect(rewritten).toBe("<@U5000RESOLVED|Tainá> and <@U6000UNKNOWN> (unknown user) both here");
+  });
+
+  test("text with no mentions passes through unchanged", () => {
+    expect(rewriteSlackMentions("no mentions here")).toBe("no mentions here");
   });
 });

--- a/src/tests/slack-thread-buffer.test.ts
+++ b/src/tests/slack-thread-buffer.test.ts
@@ -4,15 +4,19 @@ import {
   closeDb,
   createAgent,
   createTaskExtended,
+  createUser,
   getLatestActiveTaskInThread,
   initDb,
 } from "../be/db";
+import { type IdentityActor, linkIdentity } from "../be/users";
 import {
   bufferThreadMessage,
   getBufferMessageCount,
   instantFlush,
   isThreadBuffered,
 } from "../slack/thread-buffer";
+
+const SYSTEM_ACTOR: IdentityActor = { kind: "system", id: "test" };
 
 const TEST_DB_PATH = "./test-slack-thread-buffer.sqlite";
 
@@ -124,6 +128,30 @@ describe("Slack thread buffer", () => {
       expect(task!.source).toBe("slack");
       expect(task!.slackChannelId).toBe(channelId);
       expect(task!.slackThreadTs).toBe(threadTs);
+    });
+
+    test("in-body <@U…> mentions are rewritten via the identity primitive — resolved and unknown", async () => {
+      const channelId = "C601";
+      const threadTs = "6001.0001";
+      const linked = createUser({ name: "Luis", email: "luis-buf@example.com" });
+      // Slack user ids are uppercase-alphanumeric only (matches the
+      // `/<@([A-Z0-9]+)>/g` mention regex) — no underscores.
+      linkIdentity(linked.id, "slack", "U1000LINKED", SYSTEM_ACTOR);
+
+      bufferThreadMessage(
+        channelId,
+        threadTs,
+        "cc <@U1000LINKED> and <@U2000UNKNOWN>",
+        "U1",
+        "6001.0010",
+      );
+
+      await instantFlush(`${channelId}:${threadTs}`);
+
+      const task = getLatestActiveTaskInThread(channelId, threadTs);
+      expect(task).not.toBeNull();
+      expect(task!.task).toContain("<@U1000LINKED|Luis>");
+      expect(task!.task).toContain("<@U2000UNKNOWN> (unknown user)");
     });
   });
 

--- a/src/tests/user-token-rest-auth.test.ts
+++ b/src/tests/user-token-rest-auth.test.ts
@@ -6,7 +6,7 @@ import {
   type Server,
   type ServerResponse,
 } from "node:http";
-import { closeDb, createAgent, createUser, getDb, initDb } from "../be/db";
+import { closeDb, createAgent, createTaskExtended, createUser, getDb, initDb } from "../be/db";
 import { type IdentityActor, mintToken, revokeToken } from "../be/users";
 import { handleCore } from "../http/core";
 import { handleTasks } from "../http/tasks";
@@ -108,6 +108,35 @@ describe("normal REST API user-bound token auth", () => {
     expect(res.status).toBe(201);
     const body = (await res.json()) as { id: string; requestedByUserId?: string };
     expect(body.requestedByUserId).toBeUndefined();
+  });
+
+  test("global API key caller cannot spoof requestedByUserId via body — falls back to owned task context", async () => {
+    const legitRequester = createUser({ name: "Legit Requester" });
+    const attacker = createUser({ name: "Attacker" });
+    const agent = createAgent({ name: "spoof-test-agent", isLead: false, status: "idle" });
+    const ownedTask = createTaskExtended("owned task for spoof test", {
+      agentId: agent.id,
+      requestedByUserId: legitRequester.id,
+    });
+
+    const res = await fetch(`http://localhost:${port}/api/tasks`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+        "Content-Type": "application/json",
+        "x-agent-id": agent.id,
+        "x-source-task-id": ownedTask.id,
+      },
+      body: JSON.stringify({
+        task: "created through global key with spoofed requestedByUserId",
+        requestedByUserId: attacker.id,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { id: string; requestedByUserId?: string };
+    expect(body.requestedByUserId).toBe(legitRequester.id);
+    expect(body.requestedByUserId).not.toBe(attacker.id);
   });
 
   test("revoked user token is unauthorized for normal API", async () => {

--- a/src/tools/request-human-input.ts
+++ b/src/tools/request-human-input.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod";
+import { resolveTaskAuditUserId } from "@/be/audit-user";
 import { createApprovalRequest, getAgentCurrentTask } from "@/be/db";
 import { createToolRegistrar } from "@/tools/utils";
 import { getAppUrl } from "@/utils/constants";
@@ -93,6 +94,7 @@ export const registerRequestHumanInputTool = (server: McpServer) => {
         approvers: { policy: "any" },
         sourceTaskId: sourceTaskId ?? undefined,
         timeoutSeconds,
+        createdBy: resolveTaskAuditUserId(sourceTaskId, requestInfo.agentId) ?? undefined,
       });
 
       const appUrl = getAppUrl();

--- a/src/tools/resolve-user.ts
+++ b/src/tools/resolve-user.ts
@@ -1,17 +1,30 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod";
-import { findUserByEmail, findUserByExternalId, findUserById, getUserIdentities } from "@/be/users";
+import { resolveIdentity, resolveIdentityByEmail } from "@/be/identity";
+import { findUserById, findUsersByName, getUserIdentities } from "@/be/users";
 import { createToolRegistrar } from "@/tools/utils";
+import type { User } from "@/types";
 
 /**
- * `resolve-user` — Q18 break-and-migrate shape:
- *   - `{kind, externalId}` for platform-identity lookups (replaces the old
- *     `slackUserId` / `linearUserId` / `githubUsername` / `gitlabUsername` fields).
+ * `resolve-user` — the framework's provider-agnostic reverse lookup:
+ *   - `{kind, externalId}` for platform-identity lookups. This is generic
+ *     across every provider — `{kind: 'slack', externalId: 'U016H7XKZGS'}`,
+ *     `{kind: 'linear', externalId: '<uuid>'}`, `{kind: 'github', externalId: 'octocat'}`,
+ *     `{kind: 'gitlab', externalId: 'jdoe'}`, `{kind: 'jira', externalId: '<accountId>'}` —
+ *     there are deliberately NO per-provider sugar keys (no `slackUserId`, no
+ *     `githubUsername`); the shape is always the same pair.
  *   - `email` for primary-email or alias lookup.
  *   - `userId` for direct canonical-ID lookup (reverse-resolution: "give me
  *     all external IDs for this swarm user").
+ *   - `name` for a human display-name search (convenience for forming a
+ *     query, NOT an identity-stamping key) — exact match, or first-token
+ *     prefix match. More than one match is ambiguous and is returned as
+ *     candidates, never guessed.
  *
- * Validator requires either (kind + externalId) OR email OR userId.
+ * A lookup that matches nothing returns a structured `{status: "unknown", ...}`
+ * payload (never prose) so callers and scripts can branch on it directly.
+ *
+ * Validator requires exactly one of: (kind + externalId), email, userId, name.
  *
  * Exported for tests so the schema can be validated without spinning up an
  * MCP transport (the SDK only runs Zod at the transport layer).
@@ -22,13 +35,13 @@ export const resolveUserInputSchema = z
       .string()
       .optional()
       .describe(
-        "Identity kind — e.g. 'slack', 'linear', 'github', 'gitlab', 'jira', or a custom value. Must be paired with externalId.",
+        "Identity kind — e.g. 'slack', 'linear', 'github', 'gitlab', 'jira', 'kapso', 'whatsapp', or a custom value. Must be paired with externalId.",
       ),
     externalId: z
       .string()
       .optional()
       .describe(
-        "Platform-specific identifier for the given kind (e.g. Slack user ID 'U08NR6QD6CS', Linear user UUID, GitHub login).",
+        "Platform-specific identifier for the given kind (e.g. Slack user ID 'U08NR6QD6CS', Linear user UUID, GitHub login, Jira accountId).",
       ),
     email: z.string().email().optional().describe("Email address (primary or alias)."),
     userId: z
@@ -37,15 +50,44 @@ export const resolveUserInputSchema = z
       .describe(
         "Canonical swarm user ID. Use this to reverse-look up all external identities for a known user (e.g. find their GitHub handle from a requestedByUserId).",
       ),
+    name: z
+      .string()
+      .min(2)
+      .optional()
+      .describe(
+        "Human display name to search for (exact, or first-token prefix). Convenience only — ambiguous matches return all candidates rather than picking one.",
+      ),
   })
   .strict()
   .refine(
     (v) =>
       (v.kind !== undefined && v.externalId !== undefined) ||
       v.email !== undefined ||
-      v.userId !== undefined,
-    { message: "Provide either (kind + externalId), email, or userId" },
+      v.userId !== undefined ||
+      v.name !== undefined,
+    { message: "Provide either (kind + externalId), email, userId, or name" },
   );
+
+function jsonResult(value: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }] };
+}
+
+function profileResult(user: User) {
+  return jsonResult({ ...user, externalIds: getUserIdentities(user.id) });
+}
+
+function unknownResult(kind: string, externalId: string) {
+  return jsonResult({ status: "unknown" as const, kind, externalId });
+}
+
+function ambiguousResult(candidates: User[]) {
+  return jsonResult({
+    status: "ambiguous" as const,
+    message:
+      "AMBIGUOUS — do not pick by salience. Multiple users match this name; disambiguate with (kind, externalId), email, or userId.",
+    candidates: candidates.map((u) => ({ userId: u.id, name: u.name, email: u.email })),
+  });
+}
 
 export const registerResolveUserTool = (server: McpServer) => {
   createToolRegistrar(server)(
@@ -53,32 +95,40 @@ export const registerResolveUserTool = (server: McpServer) => {
     {
       title: "Resolve user identity",
       description:
-        "Look up a canonical user profile by an `(kind, externalId)` pair (e.g. {kind: 'slack', externalId: 'U_X'}), by email (primary or alias), or by swarm `userId`. Returns the user profile including `externalIds` (all linked platform identities) or 'No user found'.",
+        "Provider-agnostic reverse lookup: (kind, externalId) → user, e.g. {kind: 'slack', externalId: 'U016H7XKZGS'} or {kind: 'github', externalId: 'octocat'} — the same shape for every provider, no per-provider keys. Also accepts email (primary or alias), userId (reverse lookup of all linked identities), or name (exact/prefix search). A miss returns a structured {status: 'unknown', ...} payload, never prose; an ambiguous name search returns {status: 'ambiguous', candidates: [...]}.",
       annotations: { readOnlyHint: true },
       inputSchema: resolveUserInputSchema,
     },
-    async ({ kind, externalId, email, userId }) => {
-      let user = null;
+    async ({ kind, externalId, email, userId, name }) => {
       if (kind && externalId) {
-        user = findUserByExternalId(kind, externalId);
-      } else if (email) {
-        user = findUserByEmail(email);
-      } else if (userId) {
-        user = findUserById(userId);
+        const resolution = resolveIdentity(kind, externalId);
+        if (resolution.status === "unknown") return unknownResult(kind, externalId);
+        const user = findUserById(resolution.userId);
+        if (!user) return unknownResult(kind, externalId);
+        return profileResult(user);
       }
 
-      if (!user) {
-        return {
-          content: [{ type: "text" as const, text: "No user found matching the given criteria." }],
-        };
+      if (email) {
+        const resolution = resolveIdentityByEmail(email);
+        if (resolution.status === "unknown") return unknownResult("email", email);
+        const user = findUserById(resolution.userId);
+        if (!user) return unknownResult("email", email);
+        return profileResult(user);
       }
 
-      const externalIds = getUserIdentities(user.id);
-      return {
-        content: [
-          { type: "text" as const, text: JSON.stringify({ ...user, externalIds }, null, 2) },
-        ],
-      };
+      if (userId) {
+        const user = findUserById(userId);
+        if (!user) return unknownResult("userId", userId);
+        return profileResult(user);
+      }
+
+      // name is guaranteed set here — the schema refine requires one of the
+      // four branches, and the three above are exhausted.
+      const matches = findUsersByName(name ?? "");
+      if (matches.length === 0) return unknownResult("name", name ?? "");
+      const [only] = matches;
+      if (matches.length === 1 && only) return profileResult(only);
+      return ambiguousResult(matches);
     },
   );
 };

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -31,7 +31,11 @@ A Kapso webhook fired on the swarm's provisioned WhatsApp number. Load the \`kap
     { name: "conversation_id", description: "Kapso conversation id, or 'unknown'" },
     { name: "inbound_wamid", description: "Inbound message WAMID, or 'unknown'" },
     { name: "sender_phone", description: "Sender phone (E.164 no +), or 'unknown'" },
-    { name: "contact_name", description: "Contact display name, or 'unknown'" },
+    {
+      name: "contact_name",
+      description:
+        "Sender identity — resolved canonical name (e.g. 'Luis (kapso:15551234567)') or the UNKNOWN sentinel — never the raw WhatsApp profile name",
+    },
     { name: "phone_number_id", description: "Provisioned phone-number id, or 'unknown'" },
     {
       name: "test_note",

--- a/src/workflows/executors/human-in-the-loop.ts
+++ b/src/workflows/executors/human-in-the-loop.ts
@@ -148,6 +148,7 @@ export class HumanInTheLoopExecutor extends BaseExecutor<
       workflowRunStepId: meta.stepId,
       timeoutSeconds: config.timeout?.seconds,
       notificationChannels: config.notifications,
+      createdBy: meta.requestedByUserId,
     });
 
     // 3. Dispatch notifications (fire-and-forget — failures must not block the workflow)


### PR DESCRIPTION
## Summary

Implements the approved identity-confabulation remediation plan (rev 3) in **one PR**, per Daniel's explicit directive to collapse the plan's PR-1/PR-2/PR-3 split into a single branch.

**The invariant:** the swarm's sole responsibility for identity is the reverse lookup `(provider, externalId) → linked identity → user record → canonical name`, via `resolve-user`. If the lookup points nowhere, render an explicit `UNKNOWN` sentinel — never a provider display name, memory, or plausibility guess.

### W1 — the resolution primitive (`fa0b4365`)
- New `src/be/identity.ts`: `resolveIdentity`/`resolveIdentityByEmail` + `renderIdentity` — pure DB, one enforcement point, `unknown` is a value not an error.
- `resolve-user` completed: generic `{kind, externalId}` / `{email}` / `{userId}` interface (no per-provider sugar keys), `name` lookup via new `findUsersByName` with ambiguity handling, structured UNKNOWN instead of prose.
- UNKNOWN rendered at the requester-render site (`poll.ts` / `runner.ts`) instead of silently omitted.

### W2 — every provider adapter conforms (`e14cea18`…`0dce6e3c`)
Slack, Jira, GitHub, GitLab, AgentMail, Kapso/WhatsApp — every human-label render routed through the W1 primitive; resolved → canonical pair, unresolved → sentinel, zero provider API calls added to the render path. Jira gains a `resolveJiraActor` (previously did **no** resolution at all — the worst offender). GitLab's dead-coded `_requestedByUserId` is wired live.

### W3 — machine-carried provenance (`21f343a5`, `9dd76d1e`)
- `audit-user.ts`'s `resolveTaskAuditUserId` gains an ambient-task fallback and a machine-carried external-ID fallback; the 4 existing call sites inherit both for free.
- Fired-task provenance: `scheduler.ts` now passes `requestedByUserId: schedule.createdBy` to spawned tasks (previously dropped).
- Approvals: `approval_requests.createdBy` now written (column existed since migration 082, never populated).
- **`http/tasks.ts` attribution-spoofing gap closed:** a non-user-authenticated caller (agent/API key) could previously attribute a task to any existing `userId` via the request body (existence-checked only). Now routed through the same `resolveHttpAuditUserId` primitive used at every other audited write site — trust the authenticated request user, otherwise derive from the caller's own task context, never the request body.

### Not in this PR (by design)
- **W4** (one-time correction of already-wrong live artifacts — `release-content-digest`, `pylon-stale-tickets-digest`, registry hygiene) is Lead-owned and executes against the live swarm directly, not via code change.
- **The one-shot `createdBy` backfill** for the 147/170 null-`createdBy` schedules is explicitly sequenced in the plan to run *after this PR merges*, gated on Daniel reviewing the exact dry-run writes (plan Gate 2) before applying. It is an operational/data-repair step, not a code change — flagging here so it isn't dropped.

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] `bun run lint` (read-only)
- [x] `bun run tsc:check`
- [x] `bun test` — all 270 tests across the 14 files this PR touches pass consistently, standalone and combined
- [x] `bash scripts/check-db-boundary.sh`
- [x] `bun run check:dep-graph` (0 errors; pre-existing warnings unrelated to changed files)
- [x] `bun run docs:openapi` — no diff (route logic changed, signatures didn't)
- [x] New regression test: global-API-key caller cannot spoof `requestedByUserId` via body even when it names a real user (`src/tests/user-token-rest-auth.test.ts`)
- [x] CI green: Lint, Typecheck, Run Tests, all 3 Docker builds, OpenAPI freshness, Merge Gate

### CI-caught issues fixed post-push (`1844f5a3`, `ef3d0f98`, `bcae09d2`)
Three CI-only failures surfaced during review, none reproducible standalone locally — all pre-existing test-infrastructure fragility unrelated to the identity-resolution logic itself, confirmed by two historical precedents of the same failure *class* hitting unrelated tests on `main` (a `Codex usage-limit` test on 2026-05-26, a `Pages — view_count` test on 2026-05-14 — both deterministic-per-commit, different victim each time):
1. `1844f5a3` — a real regression: `f83c2f1c` (GitLab W2 commit) dropped a hardcoded `"@"` template prefix, but two `prompt-template-remaining.test.ts` assertions still expected the old `"@dev1"` output. Fixed the stale assertions.
2. `ef3d0f98` — `agentmail-handlers.test.ts`'s "identity auto-link" describe block used a file-level `beforeAll`/`afterAll` around a persistent file-backed sqlite DB shared cumulatively across its 4 tests; combined with `bunfig.toml`'s `retry=3`, a transient attempt-1 failure (of any cause) left its side effect in place for the retry, turning one flaky attempt into a deterministic before/after count mismatch. Switched to `beforeEach`/`afterEach` for per-test isolation.
3. `bcae09d2` — the actual root cause of the CI-only failure: `prompt-template-resolver.test.ts`/`prompt-template-session.test.ts` call `clearTemplateDefinitions()` on the shared process-wide template registry and never restore it: when either runs first in the same bun worker, `resolveTemplate("agentmail.email.*", ...)` silently returned `{text: "", skipped: true}` instead of throwing, producing a task with an empty body. Fixed by defensively re-registering the AgentMail templates in this file's own `beforeEach`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
