### PR TITLE
feat(workflows): configurable webhook verification formats

### DIFF
--- a/apps/ui/src/api/types.ts
+++ b/apps/ui/src/api/types.ts
@@ -899,10 +899,28 @@ export interface WorkflowDefinition {
   onNodeFailure?: "fail" | "continue";
 }
 
+export type WebhookVerification =
+  | {
+      format: "hmac-sha256";
+      header?: string;
+    }
+  | {
+      format: "timestamped-hmac-sha256";
+      header: string;
+      timestampKey?: string;
+      signatureKey?: string;
+      toleranceSeconds?: number;
+    }
+  | {
+      format: "token-equality";
+      header: string;
+    };
+
 export interface TriggerConfig {
   type: "webhook" | "schedule";
   hmacSecret?: string;
   hmacHeader?: string;
+  verification?: WebhookVerification;
   scheduleId?: string;
 }
 

--- a/apps/ui/src/pages/workflows/[id]/page.tsx
+++ b/apps/ui/src/pages/workflows/[id]/page.tsx
@@ -17,7 +17,7 @@ import {
   Webhook,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import { api, TriggerSchemaApiError } from "@/api/client";
@@ -35,6 +35,7 @@ import {
 import type {
   CooldownConfig,
   TriggerConfig,
+  WebhookVerification,
   WorkflowNode,
   WorkflowRun,
   WorkflowRunStatus,
@@ -1718,7 +1719,7 @@ function TriggerCard({ workflowId, trigger }: { workflowId: string; trigger: Tri
   if (trigger.type === "webhook") {
     const apiUrl = getConfig().apiUrl.replace(/\/$/, "");
     const webhookUrl = `${apiUrl}/api/webhooks/${workflowId}`;
-    const hmacHeader = trigger.hmacHeader ?? "X-Hub-Signature-256";
+    const verification = getWebhookVerificationDisplay(trigger);
     return (
       <div className="rounded-lg border bg-card p-4 space-y-3">
         <div className="flex items-center gap-2">
@@ -1731,11 +1732,17 @@ function TriggerCard({ workflowId, trigger }: { workflowId: string; trigger: Tri
           <CopyableField label="POST URL" value={webhookUrl} />
           {trigger.hmacSecret ? (
             <>
-              <CopyableField label="HMAC header" value={hmacHeader} />
-              <SecretField label="HMAC secret" value={trigger.hmacSecret} />
+              <CopyableField label="Verification format" value={verification.formatLabel} />
+              <CopyableField label="Verification header" value={verification.header} />
+              {verification.toleranceSeconds !== undefined && (
+                <CopyableField
+                  label="Timestamp tolerance"
+                  value={`${verification.toleranceSeconds}s`}
+                />
+              )}
+              <SecretField label={verification.secretLabel} value={trigger.hmacSecret} />
               <p className="text-[11px] text-muted-foreground leading-relaxed">
-                Sign the raw request body with HMAC-SHA256 using the secret, then send the digest as{" "}
-                <code className="font-mono">{hmacHeader}: sha256=&lt;hex&gt;</code>.
+                {verification.hint}
               </p>
             </>
           ) : (
@@ -1773,6 +1780,79 @@ function TriggerCard({ workflowId, trigger }: { workflowId: string; trigger: Tri
       </Badge>
     </div>
   );
+}
+
+function getWebhookVerificationDisplay(trigger: TriggerConfig): {
+  formatLabel: string;
+  header: string;
+  toleranceSeconds?: number;
+  secretLabel: string;
+  hint: ReactNode;
+} {
+  const verification: WebhookVerification | undefined = trigger.verification;
+
+  if (!verification) {
+    const header = trigger.hmacHeader ?? "X-Hub-Signature-256";
+    return {
+      formatLabel: "hmac-sha256 (legacy)",
+      header,
+      secretLabel: "HMAC secret",
+      hint: (
+        <>
+          Sign the raw request body with HMAC-SHA256 using the secret, then send the digest as{" "}
+          <code className="font-mono">{header}: sha256=&lt;hex&gt;</code>.
+        </>
+      ),
+    };
+  }
+
+  if (verification.format === "timestamped-hmac-sha256") {
+    const timestampKey = verification.timestampKey ?? "t";
+    const signatureKey = verification.signatureKey ?? "v1";
+    return {
+      formatLabel: "timestamped-hmac-sha256",
+      header: verification.header,
+      toleranceSeconds: verification.toleranceSeconds ?? 300,
+      secretLabel: "HMAC secret",
+      hint: (
+        <>
+          Sign <code className="font-mono">&lt;timestamp&gt;.&lt;raw body&gt;</code> with
+          HMAC-SHA256, then send{" "}
+          <code className="font-mono">
+            {verification.header}: {timestampKey}=&lt;timestamp&gt;,{signatureKey}=&lt;hex&gt;
+          </code>
+          .
+        </>
+      ),
+    };
+  }
+
+  if (verification.format === "token-equality") {
+    return {
+      formatLabel: "token-equality",
+      header: verification.header,
+      secretLabel: "Shared token",
+      hint: (
+        <>
+          Send the shared token in{" "}
+          <code className="font-mono">{verification.header}: &lt;token&gt;</code>.
+        </>
+      ),
+    };
+  }
+
+  const header = verification.header ?? "X-Hub-Signature-256";
+  return {
+    formatLabel: "hmac-sha256",
+    header,
+    secretLabel: "HMAC secret",
+    hint: (
+      <>
+        Sign the raw request body with HMAC-SHA256 using the secret, then send the digest as{" "}
+        <code className="font-mono">{header}: sha256=&lt;hex&gt;</code>.
+      </>
+    ),
+  };
 }
 
 // --- Version History ---

--- a/docs-site/content/docs/(documentation)/concepts/workflows.mdx
+++ b/docs-site/content/docs/(documentation)/concepts/workflows.mdx
@@ -11,7 +11,7 @@ A workflow consists of:
 
 - **Nodes** — Individual steps with a `next` field that defines routing (no explicit edges needed)
 - **Executors** — Class-based step implementations with Zod-typed config and output schemas
-- **Triggers** — Entry points: webhook (HMAC-SHA256), schedule (ref), or manual
+- **Triggers** — Entry points: webhook (HMAC-SHA256, timestamped HMAC, shared token), schedule (ref), or manual
 - **Checkpoint durability** — Atomic DB write after every step; resume from last checkpoint on crash
 - **Fan-out / convergence** — Parallel execution via array `next` with automatic convergence gating
 
@@ -56,7 +56,7 @@ The `next` field supports three formats:
   "name": "pr-review-pipeline",
   "description": "Auto-assign PR reviews on webhook",
   "triggers": [
-    { "type": "webhook", "config": { "hmacSecret": "my-secret" } }
+    { "type": "webhook", "hmacSecret": "secret.GITHUB_WEBHOOK_SECRET" }
   ],
   "definition": {
     "nodes": [
@@ -86,9 +86,65 @@ The `next` field supports three formats:
 
 | Type | Description |
 |------|-------------|
-| `webhook` | HTTP POST to `/api/workflows/:id/trigger` with optional HMAC-SHA256 verification |
+| `webhook` | HTTP POST to `/api/workflows/:id/trigger` with optional verification |
 | `schedule` | References a schedule by ID — the schedule creates workflow runs at configured times |
 | `manual` | Triggered via the `trigger-workflow` MCP tool or dashboard UI |
+
+### Webhook verification formats
+
+Webhook triggers verify signatures only when `hmacSecret` is set. The secret can be a literal, an environment reference such as `${WEBHOOK_SECRET}`, or a swarm secret reference such as `secret.SUPERAGENT_WEBHOOK_SECRET`.
+
+Omitting `verification` keeps the legacy behavior: HMAC-SHA256 over the raw request body, accepting either `sha256=<hex>` or bare hex. The verifier checks `hmacHeader` first and then the legacy fallback headers.
+
+```json
+{
+  "type": "webhook",
+  "hmacSecret": "secret.GITHUB_WEBHOOK_SECRET",
+  "hmacHeader": "X-Hub-Signature-256"
+}
+```
+
+Set `verification.format` to make the expected format explicit. Explicit formats read only the configured header.
+
+```json
+{
+  "type": "webhook",
+  "hmacSecret": "secret.GITHUB_WEBHOOK_SECRET",
+  "verification": {
+    "format": "hmac-sha256",
+    "header": "X-Hub-Signature-256"
+  }
+}
+```
+
+Use `timestamped-hmac-sha256` for Stripe/Superagent-style headers such as `t=<timestamp>,v1=<hex>`. The signed payload is `<timestamp>.<raw body>`, multiple `v1` entries are accepted for secret rotation, and timestamps outside the tolerance window are rejected.
+
+```json
+{
+  "type": "webhook",
+  "hmacSecret": "secret.SUPERAGENT_WEBHOOK_SECRET",
+  "verification": {
+    "format": "timestamped-hmac-sha256",
+    "header": "X-Superagent-Signature",
+    "timestampKey": "t",
+    "signatureKey": "v1",
+    "toleranceSeconds": 300
+  }
+}
+```
+
+Use `token-equality` for shared-token providers such as GitLab. The configured `hmacSecret` stores the expected token and the request header must match it.
+
+```json
+{
+  "type": "webhook",
+  "hmacSecret": "secret.GITLAB_WEBHOOK_TOKEN",
+  "verification": {
+    "format": "token-equality",
+    "header": "X-Gitlab-Token"
+  }
+}
+```
 
 ### Cooldown
 

--- a/openapi.json
+++ b/openapi.json
@@ -15597,7 +15597,88 @@
                             },
                             "hmacHeader": {
                               "type": "string",
-                              "default": "X-Hub-Signature-256"
+                              "default": "X-Hub-Signature-256",
+                              "description": "Legacy HMAC header for webhook verification. Prefer verification.header for new workflows."
+                            },
+                            "verification": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "format": {
+                                      "type": "string",
+                                      "enum": [
+                                        "hmac-sha256"
+                                      ]
+                                    },
+                                    "header": {
+                                      "type": "string",
+                                      "default": "X-Hub-Signature-256",
+                                      "description": "Header containing HMAC-SHA256 over the raw request body. Accepts sha256=<hex> or bare hex."
+                                    }
+                                  },
+                                  "required": [
+                                    "format"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "format": {
+                                      "type": "string",
+                                      "enum": [
+                                        "timestamped-hmac-sha256"
+                                      ]
+                                    },
+                                    "header": {
+                                      "type": "string",
+                                      "minLength": 1,
+                                      "description": "Header containing comma-separated timestamp/signature pairs such as t=<timestamp>,v1=<hex>."
+                                    },
+                                    "timestampKey": {
+                                      "type": "string",
+                                      "default": "t",
+                                      "description": "Timestamp field key in the signature header"
+                                    },
+                                    "signatureKey": {
+                                      "type": "string",
+                                      "default": "v1",
+                                      "description": "Signature field key in the signature header; multiple entries are allowed"
+                                    },
+                                    "toleranceSeconds": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0,
+                                      "default": 300,
+                                      "description": "Maximum allowed clock skew, in seconds, for replay protection"
+                                    }
+                                  },
+                                  "required": [
+                                    "format",
+                                    "header"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "format": {
+                                      "type": "string",
+                                      "enum": [
+                                        "token-equality"
+                                      ]
+                                    },
+                                    "header": {
+                                      "type": "string",
+                                      "minLength": 1,
+                                      "description": "Header containing the shared token to compare"
+                                    }
+                                  },
+                                  "required": [
+                                    "format",
+                                    "header"
+                                  ]
+                                }
+                              ],
+                              "description": "Optional webhook verification format. Omit to keep legacy HMAC-SHA256 behavior with fallback header scanning."
                             }
                           },
                           "required": [
@@ -15935,7 +16016,88 @@
                             },
                             "hmacHeader": {
                               "type": "string",
-                              "default": "X-Hub-Signature-256"
+                              "default": "X-Hub-Signature-256",
+                              "description": "Legacy HMAC header for webhook verification. Prefer verification.header for new workflows."
+                            },
+                            "verification": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "format": {
+                                      "type": "string",
+                                      "enum": [
+                                        "hmac-sha256"
+                                      ]
+                                    },
+                                    "header": {
+                                      "type": "string",
+                                      "default": "X-Hub-Signature-256",
+                                      "description": "Header containing HMAC-SHA256 over the raw request body. Accepts sha256=<hex> or bare hex."
+                                    }
+                                  },
+                                  "required": [
+                                    "format"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "format": {
+                                      "type": "string",
+                                      "enum": [
+                                        "timestamped-hmac-sha256"
+                                      ]
+                                    },
+                                    "header": {
+                                      "type": "string",
+                                      "minLength": 1,
+                                      "description": "Header containing comma-separated timestamp/signature pairs such as t=<timestamp>,v1=<hex>."
+                                    },
+                                    "timestampKey": {
+                                      "type": "string",
+                                      "default": "t",
+                                      "description": "Timestamp field key in the signature header"
+                                    },
+                                    "signatureKey": {
+                                      "type": "string",
+                                      "default": "v1",
+                                      "description": "Signature field key in the signature header; multiple entries are allowed"
+                                    },
+                                    "toleranceSeconds": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0,
+                                      "default": 300,
+                                      "description": "Maximum allowed clock skew, in seconds, for replay protection"
+                                    }
+                                  },
+                                  "required": [
+                                    "format",
+                                    "header"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "format": {
+                                      "type": "string",
+                                      "enum": [
+                                        "token-equality"
+                                      ]
+                                    },
+                                    "header": {
+                                      "type": "string",
+                                      "minLength": 1,
+                                      "description": "Header containing the shared token to compare"
+                                    }
+                                  },
+                                  "required": [
+                                    "format",
+                                    "header"
+                                  ]
+                                }
+                              ],
+                              "description": "Optional webhook verification format. Omit to keep legacy HMAC-SHA256 behavior with fallback header scanning."
                             }
                           },
                           "required": [

--- a/src/tests/workflow-triggers-v2.test.ts
+++ b/src/tests/workflow-triggers-v2.test.ts
@@ -11,6 +11,7 @@ import {
   upsertSwarmConfig,
 } from "../be/db";
 import type { Workflow } from "../types";
+import { TriggerConfigSchema } from "../types";
 import { startWorkflowExecution } from "../workflows/engine";
 import { BaseExecutor, type ExecutorResult } from "../workflows/executors/base";
 import { ExecutorRegistry } from "../workflows/executors/registry";
@@ -551,6 +552,33 @@ describe("handleWebhookTrigger — verification formats", () => {
       expect((err as WebhookError).statusCode).toBe(401);
     }
   });
+
+  test("verification configured without hmacSecret fails closed instead of accepting the request", async () => {
+    // Bypasses the create/update Zod schema (which now also rejects this shape) to
+    // exercise the runtime guard directly — e.g. for data written before this fix,
+    // or any future write path that skips schema validation.
+    const workflow = makeWorkflow({
+      triggers: [
+        {
+          type: "webhook",
+          verification: { format: "token-equality", header: "X-Gitlab-Token" },
+        },
+      ],
+    });
+
+    try {
+      await handleWebhookTrigger(
+        workflow.id,
+        '{"event":"push"}',
+        { "x-gitlab-token": "anything" },
+        registry,
+      );
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(WebhookError);
+      expect((err as WebhookError).statusCode).toBe(500);
+    }
+  });
 });
 
 describe("handleWebhookTrigger — hmacSecret references", () => {
@@ -740,5 +768,37 @@ describe("cooldown", () => {
     const runId2 = await startWorkflowExecution(workflow, {}, registry);
     const run2 = getWorkflowRun(runId2);
     expect(run2!.status).toBe("completed");
+  });
+});
+
+// ─── TriggerConfigSchema validation ──────────────────────────
+
+describe("TriggerConfigSchema", () => {
+  test("rejects verification configured without hmacSecret", () => {
+    const result = TriggerConfigSchema.safeParse({
+      type: "webhook",
+      verification: { format: "token-equality", header: "X-Gitlab-Token" },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.path.includes("hmacSecret"))).toBe(true);
+    }
+  });
+
+  test("accepts verification configured with hmacSecret", () => {
+    const result = TriggerConfigSchema.safeParse({
+      type: "webhook",
+      hmacSecret: "gitlab-token",
+      verification: { format: "token-equality", header: "X-Gitlab-Token" },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a webhook trigger with neither hmacSecret nor verification (intentionally unauthenticated)", () => {
+    const result = TriggerConfigSchema.safeParse({ type: "webhook" });
+
+    expect(result.success).toBe(true);
   });
 });

--- a/src/tests/workflow-triggers-v2.test.ts
+++ b/src/tests/workflow-triggers-v2.test.ts
@@ -14,7 +14,13 @@ import type { Workflow } from "../types";
 import { startWorkflowExecution } from "../workflows/engine";
 import { BaseExecutor, type ExecutorResult } from "../workflows/executors/base";
 import { ExecutorRegistry } from "../workflows/executors/registry";
-import { handleWebhookTrigger, verifyHmacSignature, WebhookError } from "../workflows/triggers";
+import {
+  handleWebhookTrigger,
+  verifyHmacSignature,
+  verifyTimestampedHmacSignature,
+  verifyTokenEquality,
+  WebhookError,
+} from "../workflows/triggers";
 
 const TEST_DB_PATH = "./test-workflow-triggers-v2.sqlite";
 
@@ -108,6 +114,88 @@ describe("verifyHmacSignature", () => {
 
   test("empty signature fails", () => {
     expect(verifyHmacSignature(secret, body, "")).toBe(false);
+  });
+});
+
+describe("verifyTimestampedHmacSignature", () => {
+  const secret = "timestamped-secret";
+  const body = '{"event":"finding.triage_completed"}';
+  const timestamp = 1_700_000_000;
+  const nowMs = timestamp * 1000;
+
+  function sign(ts: number, signingSecret = secret): string {
+    return crypto.createHmac("sha256", signingSecret).update(`${ts}.${body}`).digest("hex");
+  }
+
+  test("valid timestamped signature passes", () => {
+    const header = `t=${timestamp},v1=${sign(timestamp)}`;
+
+    expect(verifyTimestampedHmacSignature(secret, body, header, {}, nowMs)).toBe(true);
+  });
+
+  test("wrong secret fails", () => {
+    const header = `t=${timestamp},v1=${sign(timestamp, "wrong-secret")}`;
+
+    expect(verifyTimestampedHmacSignature(secret, body, header, {}, nowMs)).toBe(false);
+  });
+
+  test("expired timestamp fails", () => {
+    const oldTimestamp = timestamp - 301;
+    const header = `t=${oldTimestamp},v1=${sign(oldTimestamp)}`;
+
+    expect(verifyTimestampedHmacSignature(secret, body, header, {}, nowMs)).toBe(false);
+  });
+
+  test("future timestamp beyond tolerance fails", () => {
+    const futureTimestamp = timestamp + 301;
+    const header = `t=${futureTimestamp},v1=${sign(futureTimestamp)}`;
+
+    expect(verifyTimestampedHmacSignature(secret, body, header, {}, nowMs)).toBe(false);
+  });
+
+  test("missing or garbled timestamp fails", () => {
+    expect(verifyTimestampedHmacSignature(secret, body, `v1=${sign(timestamp)}`, {}, nowMs)).toBe(
+      false,
+    );
+    expect(
+      verifyTimestampedHmacSignature(
+        secret,
+        body,
+        `t=not-a-number,v1=${sign(timestamp)}`,
+        {},
+        nowMs,
+      ),
+    ).toBe(false);
+  });
+
+  test("multiple signature entries pass when any one matches", () => {
+    const header = `t=${timestamp},v1=deadbeef,v1=${sign(timestamp)}`;
+
+    expect(verifyTimestampedHmacSignature(secret, body, header, {}, nowMs)).toBe(true);
+  });
+
+  test("custom timestamp and signature keys are supported", () => {
+    const header = `ts=${timestamp},sig=${sign(timestamp)}`;
+
+    expect(
+      verifyTimestampedHmacSignature(
+        secret,
+        body,
+        header,
+        { timestampKey: "ts", signatureKey: "sig", toleranceSeconds: 300 },
+        nowMs,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("verifyTokenEquality", () => {
+  test("matching token passes", () => {
+    expect(verifyTokenEquality("shared-token", "shared-token")).toBe(true);
+  });
+
+  test("non-matching token fails", () => {
+    expect(verifyTokenEquality("shared-token", "other-token")).toBe(false);
   });
 });
 
@@ -311,6 +399,152 @@ describe("handleWebhookTrigger — custom hmacHeader", () => {
     );
 
     expect(result.runId).toBeDefined();
+  });
+
+  test("explicit hmac-sha256 verification does not use fallback headers", async () => {
+    const secret = "explicit-hmac-secret";
+    const workflow = makeWorkflow({
+      triggers: [
+        {
+          type: "webhook",
+          hmacSecret: secret,
+          verification: { format: "hmac-sha256", header: "X-Primary-Signature" },
+        },
+      ],
+    });
+
+    const body = '{"event":"explicit"}';
+    try {
+      await handleWebhookTrigger(
+        workflow.id,
+        body,
+        { "x-signature": signRaw(secret, body) },
+        registry,
+      );
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(WebhookError);
+      expect((err as WebhookError).statusCode).toBe(401);
+    }
+  });
+});
+
+describe("handleWebhookTrigger — verification formats", () => {
+  function signTimestamped(secret: string, body: string, timestamp: number): string {
+    return crypto.createHmac("sha256", secret).update(`${timestamp}.${body}`).digest("hex");
+  }
+
+  test("timestamped-hmac-sha256 starts workflow for Superagent-shaped request", async () => {
+    const secret = "superagent-secret";
+    const timestamp = Math.floor(Date.now() / 1000);
+    const workflow = makeWorkflow({
+      triggers: [
+        {
+          type: "webhook",
+          hmacSecret: secret,
+          verification: {
+            format: "timestamped-hmac-sha256",
+            header: "X-Superagent-Signature",
+            toleranceSeconds: 300,
+          },
+        },
+      ],
+    });
+
+    const body = '{"type":"finding.triage_completed","finding":{"id":"finding-123"}}';
+    const result = await handleWebhookTrigger(
+      workflow.id,
+      body,
+      {
+        "x-superagent-signature": `t=${timestamp},v1=${signTimestamped(secret, body, timestamp)}`,
+      },
+      registry,
+    );
+
+    expect(result.runId).toBeDefined();
+    const run = getWorkflowRun(result.runId);
+    expect(run).not.toBeNull();
+    expect(run!.triggerData).toEqual({
+      type: "finding.triage_completed",
+      finding: { id: "finding-123" },
+    });
+  });
+
+  test("timestamped-hmac-sha256 rejects signatures on fallback headers", async () => {
+    const secret = "timestamped-no-fallback-secret";
+    const timestamp = Math.floor(Date.now() / 1000);
+    const workflow = makeWorkflow({
+      triggers: [
+        {
+          type: "webhook",
+          hmacSecret: secret,
+          verification: {
+            format: "timestamped-hmac-sha256",
+            header: "X-Superagent-Signature",
+          },
+        },
+      ],
+    });
+
+    const body = '{"event":"fallback-blocked"}';
+    try {
+      await handleWebhookTrigger(
+        workflow.id,
+        body,
+        { "x-signature": `t=${timestamp},v1=${signTimestamped(secret, body, timestamp)}` },
+        registry,
+      );
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(WebhookError);
+      expect((err as WebhookError).statusCode).toBe(401);
+    }
+  });
+
+  test("token-equality starts workflow when shared token matches", async () => {
+    const workflow = makeWorkflow({
+      triggers: [
+        {
+          type: "webhook",
+          hmacSecret: "gitlab-token",
+          verification: { format: "token-equality", header: "X-Gitlab-Token" },
+        },
+      ],
+    });
+
+    const result = await handleWebhookTrigger(
+      workflow.id,
+      '{"event":"push"}',
+      { "x-gitlab-token": "gitlab-token" },
+      registry,
+    );
+
+    expect(result.runId).toBeDefined();
+  });
+
+  test("token-equality rejects a wrong token", async () => {
+    const workflow = makeWorkflow({
+      triggers: [
+        {
+          type: "webhook",
+          hmacSecret: "gitlab-token",
+          verification: { format: "token-equality", header: "X-Gitlab-Token" },
+        },
+      ],
+    });
+
+    try {
+      await handleWebhookTrigger(
+        workflow.id,
+        '{"event":"push"}',
+        { "x-gitlab-token": "wrong-token" },
+        registry,
+      );
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(WebhookError);
+      expect((err as WebhookError).statusCode).toBe(401);
+    }
   });
 });
 

--- a/src/tests/workflow-triggers-v2.test.ts
+++ b/src/tests/workflow-triggers-v2.test.ts
@@ -194,8 +194,13 @@ describe("verifyTokenEquality", () => {
     expect(verifyTokenEquality("shared-token", "shared-token")).toBe(true);
   });
 
-  test("non-matching token fails", () => {
-    expect(verifyTokenEquality("shared-token", "other-token")).toBe(false);
+  test("same-length non-matching token fails", () => {
+    expect(verifyTokenEquality("shared-token", "shared-tokem")).toBe(false);
+  });
+
+  test("wrong-length non-matching token fails without throwing", () => {
+    expect(() => verifyTokenEquality("shared-token", "short")).not.toThrow();
+    expect(verifyTokenEquality("shared-token", "short")).toBe(false);
   });
 });
 

--- a/src/tools/workflows/create-workflow.ts
+++ b/src/tools/workflows/create-workflow.ts
@@ -29,6 +29,11 @@ export const registerCreateWorkflowTool = (server: McpServer) => {
         "- TRIGGER SCHEMA: Optional 'triggerSchema' is a JSON-Schema object that validates incoming trigger payloads. " +
         "Supported keywords: type, required, properties, enum, const, items (recursive into arrays). " +
         "Other JSON-Schema keywords (oneOf/anyOf/$ref/pattern/format/additionalProperties) are silently ignored.\n" +
+        "- WEBHOOK VERIFICATION: Webhook triggers use hmacSecret for all verification formats. " +
+        "Omit verification for legacy HMAC-SHA256 over the raw body with fallback header scanning; " +
+        "or set verification to { format: 'hmac-sha256', header }, { format: 'timestamped-hmac-sha256', header, toleranceSeconds? }, " +
+        "or { format: 'token-equality', header }. Example: { type: 'webhook', hmacSecret: 'secret.SUPERAGENT_WEBHOOK_SECRET', " +
+        "verification: { format: 'timestamped-hmac-sha256', header: 'X-Superagent-Signature', toleranceSeconds: 300 } }.\n" +
         "- WAIT NODE: type 'wait' pauses a workflow for a duration or until a named workflowEventBus event arrives. " +
         "See runbooks/workflows.md#wait-nodes for config shapes, ordering caveats, and built-in event names.",
       inputSchema: z.object({
@@ -40,7 +45,9 @@ export const registerCreateWorkflowTool = (server: McpServer) => {
         triggers: z
           .array(TriggerConfigSchema)
           .optional()
-          .describe("Optional trigger configurations (webhook, schedule)"),
+          .describe(
+            "Optional trigger configurations (webhook, schedule). Webhook verification formats: legacy omitted verification, hmac-sha256, timestamped-hmac-sha256, token-equality.",
+          ),
         cooldown: CooldownConfigSchema.optional().describe(
           "Optional cooldown configuration to prevent re-triggering too frequently",
         ),

--- a/src/tools/workflows/update-workflow.ts
+++ b/src/tools/workflows/update-workflow.ts
@@ -23,13 +23,22 @@ export const registerUpdateWorkflowTool = (server: McpServer) => {
         "Creates a version snapshot before applying changes. " +
         "TRIGGER SCHEMA: pass 'triggerSchema' as a JSON-Schema object to set/replace, or 'null' to clear. " +
         "Supported JSON-Schema keywords: type, required, properties, enum, const, items (recursive into arrays). " +
-        "Other JSON-Schema keywords (oneOf/anyOf/$ref/pattern/format/additionalProperties) are silently ignored.",
+        "Other JSON-Schema keywords (oneOf/anyOf/$ref/pattern/format/additionalProperties) are silently ignored. " +
+        "WEBHOOK VERIFICATION: webhook triggers use hmacSecret for all verification formats. " +
+        "Omit verification for legacy HMAC-SHA256 over the raw body with fallback header scanning; " +
+        "or set verification to { format: 'hmac-sha256', header }, { format: 'timestamped-hmac-sha256', header, toleranceSeconds? }, " +
+        "or { format: 'token-equality', header }.",
       inputSchema: z.object({
         id: z.string().uuid().describe("Workflow ID to update"),
         name: z.string().optional().describe("New name for the workflow"),
         description: z.string().optional().describe("New description"),
         definition: WorkflowDefinitionSchema.optional().describe("New workflow definition"),
-        triggers: z.array(TriggerConfigSchema).optional().describe("New trigger configurations"),
+        triggers: z
+          .array(TriggerConfigSchema)
+          .optional()
+          .describe(
+            "New trigger configurations. Webhook verification formats: legacy omitted verification, hmac-sha256, timestamped-hmac-sha256, token-equality.",
+          ),
         cooldown: CooldownConfigSchema.optional()
           .nullable()
           .describe("New cooldown configuration (null to remove)"),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1430,11 +1430,58 @@ export interface PatchResult {
 
 // --- Trigger Configuration ---
 
+// Presets only: Slack-style separate timestamp headers, asymmetric signatures,
+// and generic signature-template DSLs are intentionally out of scope for v1.
+export const WebhookVerificationSchema = z.discriminatedUnion("format", [
+  z.object({
+    format: z.literal("hmac-sha256"),
+    header: z
+      .string()
+      .default("X-Hub-Signature-256")
+      .describe(
+        "Header containing HMAC-SHA256 over the raw request body. Accepts sha256=<hex> or bare hex.",
+      ),
+  }),
+  z.object({
+    format: z.literal("timestamped-hmac-sha256"),
+    header: z
+      .string()
+      .min(1)
+      .describe(
+        "Header containing comma-separated timestamp/signature pairs such as t=<timestamp>,v1=<hex>.",
+      ),
+    timestampKey: z.string().default("t").describe("Timestamp field key in the signature header"),
+    signatureKey: z
+      .string()
+      .default("v1")
+      .describe("Signature field key in the signature header; multiple entries are allowed"),
+    toleranceSeconds: z
+      .number()
+      .int()
+      .positive()
+      .default(300)
+      .describe("Maximum allowed clock skew, in seconds, for replay protection"),
+  }),
+  z.object({
+    format: z.literal("token-equality"),
+    header: z.string().min(1).describe("Header containing the shared token to compare"),
+  }),
+]);
+export type WebhookVerification = z.infer<typeof WebhookVerificationSchema>;
+
 export const TriggerConfigSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("webhook"),
     hmacSecret: z.string().optional(),
-    hmacHeader: z.string().default("X-Hub-Signature-256"),
+    hmacHeader: z
+      .string()
+      .default("X-Hub-Signature-256")
+      .describe(
+        "Legacy HMAC header for webhook verification. Prefer verification.header for new workflows.",
+      ),
+    verification: WebhookVerificationSchema.optional().describe(
+      "Optional webhook verification format. Omit to keep legacy HMAC-SHA256 behavior with fallback header scanning.",
+    ),
   }),
   z.object({
     type: z.literal("schedule"),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1469,25 +1469,35 @@ export const WebhookVerificationSchema = z.discriminatedUnion("format", [
 ]);
 export type WebhookVerification = z.infer<typeof WebhookVerificationSchema>;
 
-export const TriggerConfigSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("webhook"),
-    hmacSecret: z.string().optional(),
-    hmacHeader: z
-      .string()
-      .default("X-Hub-Signature-256")
-      .describe(
-        "Legacy HMAC header for webhook verification. Prefer verification.header for new workflows.",
+export const TriggerConfigSchema = z
+  .discriminatedUnion("type", [
+    z.object({
+      type: z.literal("webhook"),
+      hmacSecret: z.string().optional(),
+      hmacHeader: z
+        .string()
+        .default("X-Hub-Signature-256")
+        .describe(
+          "Legacy HMAC header for webhook verification. Prefer verification.header for new workflows.",
+        ),
+      verification: WebhookVerificationSchema.optional().describe(
+        "Optional webhook verification format. Omit to keep legacy HMAC-SHA256 behavior with fallback header scanning.",
       ),
-    verification: WebhookVerificationSchema.optional().describe(
-      "Optional webhook verification format. Omit to keep legacy HMAC-SHA256 behavior with fallback header scanning.",
-    ),
-  }),
-  z.object({
-    type: z.literal("schedule"),
-    scheduleId: z.string().uuid(),
-  }),
-]);
+    }),
+    z.object({
+      type: z.literal("schedule"),
+      scheduleId: z.string().uuid(),
+    }),
+  ])
+  .superRefine((trigger, ctx) => {
+    if (trigger.type === "webhook" && trigger.verification && !trigger.hmacSecret) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "hmacSecret is required when verification is configured",
+        path: ["hmacSecret"],
+      });
+    }
+  });
 export type TriggerConfig = z.infer<typeof TriggerConfigSchema>;
 
 // --- Cooldown Configuration ---

--- a/src/workflows/triggers.ts
+++ b/src/workflows/triggers.ts
@@ -277,11 +277,9 @@ export function verifyTimestampedHmacSignature(
 }
 
 export function verifyTokenEquality(secret: string, providedToken: string): boolean {
-  try {
-    return crypto.timingSafeEqual(Buffer.from(providedToken), Buffer.from(secret));
-  } catch {
-    return false;
-  }
+  const secretDigest = crypto.createHash("sha256").update(secret).digest();
+  const providedDigest = crypto.createHash("sha256").update(providedToken).digest();
+  return crypto.timingSafeEqual(providedDigest, secretDigest);
 }
 
 function parseSignatureHeader(headerValue: string): Map<string, string[]> {

--- a/src/workflows/triggers.ts
+++ b/src/workflows/triggers.ts
@@ -63,7 +63,17 @@ export function verifyWebhookRequest(
   rawBody: string,
   headers: HeaderBag,
 ): void {
-  if (!trigger.hmacSecret) return;
+  if (!trigger.hmacSecret) {
+    // `verification` without a secret can never actually check anything — fail closed
+    // instead of silently accepting unauthenticated requests on a trigger that looks protected.
+    if (trigger.verification) {
+      throw new WebhookError(
+        "Webhook trigger has `verification` configured but no `hmacSecret`; refusing to accept unverified requests",
+        500,
+      );
+    }
+    return;
+  }
 
   const secret = resolveHmacSecret(trigger.hmacSecret);
   const verification = trigger.verification;
@@ -139,10 +149,16 @@ export async function handleWebhookTrigger(
   // Find webhook trigger in triggers[]
   const webhookTrigger = workflow.triggers.find((t: TriggerConfig) => t.type === "webhook");
 
-  // If the workflow has a webhook trigger with an hmacSecret, verify against the
-  // RAW body bytes — re-serializing would change whitespace / key order and break
-  // HMAC formats.
-  if (webhookTrigger && webhookTrigger.type === "webhook" && webhookTrigger.hmacSecret) {
+  // If the workflow has a webhook trigger with an hmacSecret or a verification format
+  // configured, verify against the RAW body bytes — re-serializing would change
+  // whitespace / key order and break HMAC formats. Also run when only `verification`
+  // is set (no `hmacSecret`) so that misconfiguration fails closed instead of being
+  // silently skipped.
+  if (
+    webhookTrigger &&
+    webhookTrigger.type === "webhook" &&
+    (webhookTrigger.hmacSecret || webhookTrigger.verification)
+  ) {
     verifyWebhookRequest(
       webhookTrigger,
       typeof payload === "string" ? payload : JSON.stringify(payload),

--- a/src/workflows/triggers.ts
+++ b/src/workflows/triggers.ts
@@ -5,6 +5,8 @@ import { startWorkflowExecution } from "./engine";
 import type { ExecutorRegistry } from "./executors/registry";
 import { resolveInputValue } from "./input";
 
+type WebhookTriggerConfig = Extract<TriggerConfig, { type: "webhook" }>;
+
 /** Header name used to look up an HMAC signature when the trigger configures none. */
 const DEFAULT_HMAC_HEADER = "X-Hub-Signature-256";
 
@@ -56,6 +58,57 @@ function resolveHmacSecret(raw: string): string {
   return raw;
 }
 
+export function verifyWebhookRequest(
+  trigger: WebhookTriggerConfig,
+  rawBody: string,
+  headers: HeaderBag,
+): void {
+  if (!trigger.hmacSecret) return;
+
+  const secret = resolveHmacSecret(trigger.hmacSecret);
+  const verification = trigger.verification;
+
+  if (!verification) {
+    const hmacHeader = trigger.hmacHeader || DEFAULT_HMAC_HEADER;
+    const signature = resolveSignature(headers, hmacHeader);
+    if (!signature) {
+      throw new WebhookError("Missing signature", 401);
+    }
+
+    if (!verifyHmacSignature(secret, rawBody, signature)) {
+      throw new WebhookError("Invalid signature", 401);
+    }
+    return;
+  }
+
+  const header = verification.header || DEFAULT_HMAC_HEADER;
+  const signature = getHeader(headers, header);
+  if (!signature) {
+    throw new WebhookError("Missing signature", 401);
+  }
+
+  let isValid = false;
+  switch (verification.format) {
+    case "hmac-sha256":
+      isValid = verifyHmacSignature(secret, rawBody, signature);
+      break;
+    case "timestamped-hmac-sha256":
+      isValid = verifyTimestampedHmacSignature(secret, rawBody, signature, {
+        timestampKey: verification.timestampKey,
+        signatureKey: verification.signatureKey,
+        toleranceSeconds: verification.toleranceSeconds,
+      });
+      break;
+    case "token-equality":
+      isValid = verifyTokenEquality(secret, signature);
+      break;
+  }
+
+  if (!isValid) {
+    throw new WebhookError("Invalid signature", 401);
+  }
+}
+
 /**
  * Handle an incoming webhook trigger for a workflow.
  *
@@ -86,26 +139,15 @@ export async function handleWebhookTrigger(
   // Find webhook trigger in triggers[]
   const webhookTrigger = workflow.triggers.find((t: TriggerConfig) => t.type === "webhook");
 
-  // If the workflow has a webhook trigger with an hmacSecret, verify the signature
-  // against the RAW body bytes — re-serializing would change whitespace / key order
-  // and break the HMAC.
+  // If the workflow has a webhook trigger with an hmacSecret, verify against the
+  // RAW body bytes — re-serializing would change whitespace / key order and break
+  // HMAC formats.
   if (webhookTrigger && webhookTrigger.type === "webhook" && webhookTrigger.hmacSecret) {
-    const hmacHeader = webhookTrigger.hmacHeader || DEFAULT_HMAC_HEADER;
-    const signature = resolveSignature(headers, hmacHeader);
-    if (!signature) {
-      throw new WebhookError("Missing signature", 401);
-    }
-
-    const secret = resolveHmacSecret(webhookTrigger.hmacSecret);
-    const isValid = verifyHmacSignature(
-      secret,
+    verifyWebhookRequest(
+      webhookTrigger,
       typeof payload === "string" ? payload : JSON.stringify(payload),
-      signature,
+      headers,
     );
-
-    if (!isValid) {
-      throw new WebhookError("Invalid signature", 401);
-    }
   }
 
   // Parse the raw body so downstream nodes can interpolate deep paths
@@ -189,6 +231,78 @@ export function verifyHmacSignature(
       Buffer.from(normalizedProvided, "hex"),
       Buffer.from(expectedHex, "hex"),
     );
+  } catch {
+    return false;
+  }
+}
+
+export function verifyTimestampedHmacSignature(
+  secret: string,
+  body: string,
+  headerValue: string,
+  opts: {
+    timestampKey?: string;
+    signatureKey?: string;
+    toleranceSeconds?: number;
+  } = {},
+  nowMs = Date.now(),
+): boolean {
+  const timestampKey = opts.timestampKey ?? "t";
+  const signatureKey = opts.signatureKey ?? "v1";
+  const toleranceSeconds = opts.toleranceSeconds ?? 300;
+  const parsed = parseSignatureHeader(headerValue);
+  const timestampValue = parsed.get(timestampKey)?.[0];
+  const signatures = parsed.get(signatureKey) ?? [];
+
+  if (!timestampValue || signatures.length === 0 || !/^\d+$/.test(timestampValue)) {
+    return false;
+  }
+
+  const timestampSeconds = Number(timestampValue);
+  if (!Number.isSafeInteger(timestampSeconds)) {
+    return false;
+  }
+
+  const ageSeconds = Math.abs(nowMs / 1000 - timestampSeconds);
+  if (ageSeconds > toleranceSeconds) {
+    return false;
+  }
+
+  const hmac = crypto.createHmac("sha256", secret);
+  hmac.update(`${timestampValue}.${body}`);
+  const expectedHex = hmac.digest("hex");
+  const expected = Buffer.from(expectedHex, "hex");
+
+  return signatures.some((signature) => timingSafeEqualHex(signature, expected));
+}
+
+export function verifyTokenEquality(secret: string, providedToken: string): boolean {
+  try {
+    return crypto.timingSafeEqual(Buffer.from(providedToken), Buffer.from(secret));
+  } catch {
+    return false;
+  }
+}
+
+function parseSignatureHeader(headerValue: string): Map<string, string[]> {
+  const parsed = new Map<string, string[]>();
+  for (const part of headerValue.split(",")) {
+    const trimmed = part.trim();
+    const separatorIndex = trimmed.indexOf("=");
+    if (separatorIndex <= 0) continue;
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const value = trimmed.slice(separatorIndex + 1).trim();
+    const values = parsed.get(key) ?? [];
+    values.push(value);
+    parsed.set(key, values);
+  }
+  return parsed;
+}
+
+function timingSafeEqualHex(providedHex: string, expected: Buffer): boolean {
+  try {
+    return crypto.timingSafeEqual(Buffer.from(providedHex, "hex"), expected);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

- Adds `verification` presets to webhook trigger config: legacy-compatible `hmac-sha256`, Stripe/Superagent-style `timestamped-hmac-sha256`, and `token-equality`.
- Routes webhook verification through a dispatcher while preserving the exported `verifyHmacSignature` behavior for existing Kapso/top-level callers.
- Updates workflow tool descriptions, OpenAPI, docs, and the UI trigger card to show format/header/tolerance-specific verification hints.

## Planning artifacts

- agent-fs shared plan: `thoughts/d454d1a5-4df9-49bd-8a89-e58d6a657dc3/plans/2026-07-08-trigger-config-verification-formats-plan.md`

## Test plan

```bash
bun run lint:fix
bun run tsc:check
bash scripts/check-db-boundary.sh
bun test src/tests/workflow-triggers-v2.test.ts
(cd apps/ui && COREPACK_ENABLE_PROJECT_SPEC=0 pnpm lint)
(cd apps/ui && tsc --noEmit)
```

Reviewer-runnable timestamped signature smoke test:

```bash
BODY='{"type":"finding.triage_completed","finding":{"id":"finding-123"}}'
TS="$(date +%s)"
SECRET='replace-with-trigger-secret'
SIG="$(printf '%s.%s' "$TS" "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | awk '{print $2}')"
curl -X POST "$API_URL/api/workflows/$WORKFLOW_ID/trigger" \
  -H 'Content-Type: application/json' \
  -H "X-Superagent-Signature: t=$TS,v1=$SIG" \
  --data "$BODY"
```

Legacy compatibility smoke test:

```bash
BODY='{"event":"legacy"}'
SECRET='replace-with-trigger-secret'
SIG="$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | awk '{print $2}')"
curl -X POST "$API_URL/api/workflows/$WORKFLOW_ID/trigger" \
  -H 'Content-Type: application/json' \
  -H "X-Signature: $SIG" \
  --data "$BODY"
```
