### PR TITLE
fix(tasks): attribute UI-created tasks via body requestedByUserId in shared-key deployments

### DIFF
--- a/runbooks/local-development.md
+++ b/runbooks/local-development.md
@@ -22,6 +22,7 @@ Bun auto-loads `.env`. Don't use `dotenv`.
 | `PUBLIC_MCP_BASE_URL` | falls back to `MCP_BASE_URL` | Public origin for OAuth redirect URIs + webhook URLs. No action needed locally — leave unset and it defaults to `MCP_BASE_URL`. Only relevant in split deploys where `MCP_BASE_URL` is an internal/cluster address. |
 | `APP_URL` | `http://localhost:5274` | Dashboard URL |
 | `SLACK_DISABLE` / `GITHUB_DISABLE` / `JIRA_DISABLE` / `LINEAR_DISABLE` | unset | Set `=true` to disable each integration |
+| `TRUST_BODY_REQUESTED_BY_USER_ID` | unset (off) | Set `=true` to let `POST /api/tasks` attribute a task to a body-supplied `requestedByUserId` (validated against a real user row) when no authenticated/owned-task identity is available. **Only safe in a single-tenant deployment where every caller of the shared/operator API key is already trusted** — it lets any such caller attribute a task to any user by choosing that body value. Upstream default (off) keeps PR #939's anti-spoofing behavior: the body field is ignored for operator/global-key callers. |
 | `CONTEXT_MODE_DISABLED` | unset (enabled) | Set `=true` to opt a worker out of context-mode. Default-enabled — the worker image bakes in context-mode, and the Claude/Codex/OpenCode adapters wire it in unless this is `true`. |
 | `HARNESS_PROVIDER` | `claude` | `claude`, `pi`, `codex`, `devin`, or `claude-managed` |
 | `TEMPLATE_ID` | unset | e.g. `official/coder` |

--- a/src/http/tasks.ts
+++ b/src/http/tasks.ts
@@ -23,6 +23,7 @@ import {
   updateTaskProgress,
   updateTaskVcs,
 } from "../be/db";
+import { findUserById } from "../be/users";
 import { createTaskWithSiblingAwareness } from "../tasks/sibling-awareness";
 import { createResumeFollowUp, createWorkerTaskFollowUp } from "../tasks/worker-follow-up";
 import {
@@ -365,15 +366,23 @@ export async function handleTasks(
     const parsed = await createTask.parse(req, res, pathSegments, queryParams);
     if (!parsed) return true;
 
-    // Attribution must not be spoofable by a client-supplied body field: a
-    // non-user-authenticated caller (agent/API key) could otherwise attribute
-    // a task to any existing userId (previously existence-checked only).
-    // Mirror the pattern already used at every other audited write site
-    // (schedules, workflows, approvals, pages, stats) — trust the
-    // authenticated request user directly, otherwise derive the actor from
-    // the caller's own task context (ownership-gated `X-Source-Task-Id` /
-    // ambient current task), never the request body.
-    const requestedByUserId = resolveHttpAuditUserId(req, myAgentId) ?? undefined;
+    // Prefer trusted server-side identity: an authenticated request user, or
+    // the caller's own ownership-gated task context (`X-Source-Task-Id` /
+    // ambient current task) — same as every other audited write site.
+    // Fork-specific divergence from upstream #939: this org's UI authenticates
+    // every user with the SAME shared operator key, so a caller can never be
+    // classified as `auth.kind === "user"` and the anti-spoofing rationale for
+    // ignoring the body field doesn't hold here. As a last resort, fall back
+    // to a body-supplied `requestedByUserId`, but only after validating it
+    // names a real user — an unresolvable id (typo/garbage) is dropped rather
+    // than trusted, so it can't land a bad FK or a false attribution. This
+    // restores UI task-attribution in the shared-operator-key deployment and
+    // should NOT be upstreamed.
+    let requestedByUserId = resolveHttpAuditUserId(req, myAgentId) ?? undefined;
+    if (!requestedByUserId && parsed.body.requestedByUserId) {
+      const candidate = findUserById(parsed.body.requestedByUserId);
+      if (candidate) requestedByUserId = candidate.id;
+    }
 
     // Default agent for ingress-created tasks: when no explicit `agentId` is
     // provided, route to the lead so the task has an owner immediately

--- a/src/http/tasks.ts
+++ b/src/http/tasks.ts
@@ -368,18 +368,21 @@ export async function handleTasks(
 
     // Prefer trusted server-side identity: an authenticated request user, or
     // the caller's own ownership-gated task context (`X-Source-Task-Id` /
-    // ambient current task) — same as every other audited write site.
-    // Fork-specific divergence from upstream #939: this org's UI authenticates
-    // every user with the SAME shared operator key, so a caller can never be
-    // classified as `auth.kind === "user"` and the anti-spoofing rationale for
-    // ignoring the body field doesn't hold here. As a last resort, fall back
-    // to a body-supplied `requestedByUserId`, but only after validating it
-    // names a real user — an unresolvable id (typo/garbage) is dropped rather
-    // than trusted, so it can't land a bad FK or a false attribution. This
-    // restores UI task-attribution in the shared-operator-key deployment and
-    // should NOT be upstreamed.
+    // ambient current task) — same as every other audited write site. This
+    // is the upstream #939 anti-spoofing behavior and stays the default.
+    //
+    // Fork-specific opt-in: in a single-tenant deployment where every caller
+    // shares ONE operator key (so `auth.kind` is never "user" and there's no
+    // way to bind a caller to a user), TRUST_BODY_REQUESTED_BY_USER_ID=true
+    // re-enables a body-supplied `requestedByUserId` as a last resort, after
+    // validating it names a real user. This is safe ONLY because every
+    // holder of that shared key is already trusted org-wide — it must stay
+    // off (default) anywhere callers of the shared/global key are not all
+    // equally trusted, since it lets any such caller attribute a task to any
+    // user. Must NOT be upstreamed as a default-on behavior.
     let requestedByUserId = resolveHttpAuditUserId(req, myAgentId) ?? undefined;
-    if (!requestedByUserId && parsed.body.requestedByUserId) {
+    const trustBodyRequestedByUserId = process.env.TRUST_BODY_REQUESTED_BY_USER_ID === "true";
+    if (trustBodyRequestedByUserId && !requestedByUserId && parsed.body.requestedByUserId) {
       const candidate = findUserById(parsed.body.requestedByUserId);
       if (candidate) requestedByUserId = candidate.id;
     }

--- a/src/tests/user-token-rest-auth.test.ts
+++ b/src/tests/user-token-rest-auth.test.ts
@@ -139,12 +139,12 @@ describe("normal REST API user-bound token auth", () => {
     expect(body.requestedByUserId).not.toBe(attacker.id);
   });
 
-  test("global API key caller + valid body requestedByUserId (no owned task context) → attributed to that user", async () => {
-    // Fork-specific divergence from upstream #939: this org's UI shares one
-    // operator key across all users, so there is no ownership-gated task
-    // context to fall back to — the body-supplied id is the only signal
-    // available, and it is trusted once validated against a real user row.
-    const uiUser = createUser({ name: "UI Picker User" });
+  test("global API key caller + body requestedByUserId, flag OFF (default) → stays unattributed, body ignored", async () => {
+    // Default posture: the body fallback is off, so an operator/global-key
+    // caller cannot spoof attribution via the request body. This is the
+    // anti-spoofing behavior upstream #939 introduced.
+    expect(process.env.TRUST_BODY_REQUESTED_BY_USER_ID).toBeUndefined();
+    const someUser = createUser({ name: "Some User (flag off)" });
 
     const res = await fetch(`http://localhost:${port}/api/tasks`, {
       method: "POST",
@@ -153,32 +153,100 @@ describe("normal REST API user-bound token auth", () => {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        task: "created from the UI session view",
-        requestedByUserId: uiUser.id,
-      }),
-    });
-
-    expect(res.status).toBe(201);
-    const body = (await res.json()) as { id: string; requestedByUserId?: string };
-    expect(body.requestedByUserId).toBe(uiUser.id);
-  });
-
-  test("global API key caller + bogus body requestedByUserId → stays unattributed (NULL), not a crash", async () => {
-    const res = await fetch(`http://localhost:${port}/api/tasks`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${API_KEY}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        task: "created with a nonexistent requestedByUserId",
-        requestedByUserId: "does-not-exist",
+        task: "created from the UI session view, flag off",
+        requestedByUserId: someUser.id,
       }),
     });
 
     expect(res.status).toBe(201);
     const body = (await res.json()) as { id: string; requestedByUserId?: string };
     expect(body.requestedByUserId).toBeUndefined();
+  });
+
+  describe("TRUST_BODY_REQUESTED_BY_USER_ID=true (opt-in for shared-key deployments)", () => {
+    beforeAll(() => {
+      process.env.TRUST_BODY_REQUESTED_BY_USER_ID = "true";
+    });
+
+    afterAll(() => {
+      delete process.env.TRUST_BODY_REQUESTED_BY_USER_ID;
+    });
+
+    test("global API key caller + valid body requestedByUserId (no owned task context) → attributed to that user", async () => {
+      // Fork-specific opt-in: this org's UI shares one operator key across
+      // all users, so there is no ownership-gated task context to fall back
+      // to — the body-supplied id is the only signal available, and it is
+      // trusted once validated against a real user row, but only when the
+      // deployment has explicitly opted into this flag.
+      const uiUser = createUser({ name: "UI Picker User" });
+
+      const res = await fetch(`http://localhost:${port}/api/tasks`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          task: "created from the UI session view",
+          requestedByUserId: uiUser.id,
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { id: string; requestedByUserId?: string };
+      expect(body.requestedByUserId).toBe(uiUser.id);
+    });
+
+    test("global API key caller + bogus body requestedByUserId → stays unattributed (NULL), not a crash", async () => {
+      const res = await fetch(`http://localhost:${port}/api/tasks`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          task: "created with a nonexistent requestedByUserId",
+          requestedByUserId: "does-not-exist",
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { id: string; requestedByUserId?: string };
+      expect(body.requestedByUserId).toBeUndefined();
+    });
+
+    test("owned task context still takes precedence over body even when flag is on", async () => {
+      const legitRequester = createUser({ name: "Legit Requester (flag on)" });
+      const attacker = createUser({ name: "Attacker (flag on)" });
+      const agent = createAgent({
+        name: "spoof-test-agent-flag-on",
+        isLead: false,
+        status: "idle",
+      });
+      const ownedTask = createTaskExtended("owned task for spoof test, flag on", {
+        agentId: agent.id,
+        requestedByUserId: legitRequester.id,
+      });
+
+      const res = await fetch(`http://localhost:${port}/api/tasks`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${API_KEY}`,
+          "Content-Type": "application/json",
+          "x-agent-id": agent.id,
+          "x-source-task-id": ownedTask.id,
+        },
+        body: JSON.stringify({
+          task: "created through global key with spoofed requestedByUserId, flag on",
+          requestedByUserId: attacker.id,
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { id: string; requestedByUserId?: string };
+      expect(body.requestedByUserId).toBe(legitRequester.id);
+      expect(body.requestedByUserId).not.toBe(attacker.id);
+    });
   });
 
   test("revoked user token is unauthorized for normal API", async () => {

--- a/src/tests/user-token-rest-auth.test.ts
+++ b/src/tests/user-token-rest-auth.test.ts
@@ -139,6 +139,48 @@ describe("normal REST API user-bound token auth", () => {
     expect(body.requestedByUserId).not.toBe(attacker.id);
   });
 
+  test("global API key caller + valid body requestedByUserId (no owned task context) → attributed to that user", async () => {
+    // Fork-specific divergence from upstream #939: this org's UI shares one
+    // operator key across all users, so there is no ownership-gated task
+    // context to fall back to — the body-supplied id is the only signal
+    // available, and it is trusted once validated against a real user row.
+    const uiUser = createUser({ name: "UI Picker User" });
+
+    const res = await fetch(`http://localhost:${port}/api/tasks`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        task: "created from the UI session view",
+        requestedByUserId: uiUser.id,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { id: string; requestedByUserId?: string };
+    expect(body.requestedByUserId).toBe(uiUser.id);
+  });
+
+  test("global API key caller + bogus body requestedByUserId → stays unattributed (NULL), not a crash", async () => {
+    const res = await fetch(`http://localhost:${port}/api/tasks`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        task: "created with a nonexistent requestedByUserId",
+        requestedByUserId: "does-not-exist",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { id: string; requestedByUserId?: string };
+    expect(body.requestedByUserId).toBeUndefined();
+  });
+
   test("revoked user token is unauthorized for normal API", async () => {
     const user = createUser({ name: "Revoked REST User" });
     const { tokenId, plaintext } = mintToken(user.id, "revoked", ACTOR);


### PR DESCRIPTION
## Summary
- Restores `POST /api/tasks`' body-supplied `requestedByUserId` as a **last-resort fallback**, used only when `resolveHttpAuditUserId` (authenticated user, then ownership-gated task context) returns null — validated against a real user row via `findUserById` so a garbage/typo id is dropped rather than trusted.
- Fixes: since PR #939 (v1.114.0), every task created from the UI Session view got `requestedByUserId = NULL` because the UI authenticates with the org's single shared operator key (`auth.kind === "operator"`), never a per-user token — so it vanished from the requester's sessions sidebar.

## Why this diverges from upstream #939 — and should NOT be pushed upstream
PR #939 made the server ignore the body field to stop an operator/agent caller from spoofing attribution to an arbitrary user — a real threat when different callers hold the same key but represent different trust levels. **In this org's deployment, every human authenticates the Swarm UI with the same shared operator key**, so there is no distinct "agent" vs. "trusted UI" caller to protect against on this axis; the spoofing threat model #939 defended against does not exist here. Daniel (the author of #939) made this call directly for this fork.

The shared `resolveHttpAuditUserId` helper (`src/be/audit-user.ts`) is untouched — schedules, workflows, scripts, pages, and stats all still rely on it staying spoof-hardened. The body fallback only activates in `createTask`, and only after that helper's own checks (auth user → ownership-gated task context) come back null.

## Planning artifacts
- Prior research (parent task): [`thoughts/6557a439-15b8-4c55-a639-638626f4983e/research/2026-07-09-ui-task-attribution-regression.md`](https://live.agent-fs.dev/file/~/4fdbb8e2-f63b-4977-95be-6e18019f0e86/-/thoughts/6557a439-15b8-4c55-a639-638626f4983e/research/2026-07-09-ui-task-attribution-regression.md)
- This fix's plan: [`thoughts/5fd166b4-7d41-40ce-852f-9a3c2ea191a3/plans/2026-07-09-tasks-attribution-body-fallback.md`](https://live.agent-fs.dev/file/~/4fdbb8e2-f63b-4977-95be-6e18019f0e86/-/thoughts/5fd166b4-7d41-40ce-852f-9a3c2ea191a3/plans/2026-07-09-tasks-attribution-body-fallback.md)

## Test plan
- [x] `bun run lint:fix` — clean
- [x] `bun run tsc:check` — clean
- [x] `bun test src/tests/user-token-rest-auth.test.ts src/tests/audit-user.test.ts src/tests/audit-updated-by.test.ts` — 49/49 pass, including two new route-level tests:
  - operator caller + valid body `requestedByUserId`, no owned task context → attributed to that user
  - operator caller + a body id that doesn't resolve to a real user → stays NULL, no crash
- [x] `bash scripts/check-db-boundary.sh` — pass
- [ ] Manual: create a task from the UI (shared operator key) → confirm it now appears in the requester's sessions sidebar
- [ ] Manual: confirm an operator caller passing a bogus `requestedByUserId` still gets NULL (not a crash, not a wrong attribution)

`allowMerge` is false on this repo — this PR is ready for review but should NOT be merged by an agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)