### PR TITLE
docs(ui): impeccable design context + home critique baseline

### DIFF
--- a/apps/ui/.impeccable/critique/2026-07-10T16-10-49Z__src-pages-home-unified-home-tsx.md
+++ b/apps/ui/.impeccable/critique/2026-07-10T16-10-49Z__src-pages-home-unified-home-tsx.md
@@ -1,0 +1,67 @@
+---
+target: home
+total_score: 28
+p0_count: 0
+p1_count: 3
+timestamp: 2026-07-10T16-10-49Z
+slug: src-pages-home-unified-home-tsx
+---
+Method: dual-agent (A: design review, Opus · B: detector + browser evidence, Sonnet)
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Rich live feedback (pulse, "now" line, counts); empty state falsely implies nothing ever happened |
+| 2 | Match System / Real World | 3 | "superseded", raw token counts, zoom presets are dense for non-dev operators |
+| 3 | User Control and Freedom | 3 | Zoom/pause/reset/load-older present, but unreachable from the empty state |
+| 4 | Consistency and Standards | 3 | Home bypasses `PageHeader`; hand-rolled `h1 text-2xl` off the headline token |
+| 5 | Error Prevention | 3 | Version gate blocks broken states; little to prevent here |
+| 6 | Recognition Rather Than Recall | 2 | No status-color legend; 8 colors carry all meaning, hover-only decode |
+| 7 | Flexibility and Efficiency | 3 | Pinch-zoom, live-follow, virtualization; no zoom hotkeys, no filter by agent/status |
+| 8 | Aesthetic and Minimalist Design | 3 | Populated view dense-but-ordered; empty state is a full-page void |
+| 9 | Error Recovery | 3 | API-dead callout near-exemplary; task-fetch failure masked as "no activity" |
+| 10 | Help and Documentation | 2 | No legend, no "what am I looking at", no docs link |
+| **Total** | | **28/40** | **Good (low end)** |
+
+## Anti-Patterns Verdict
+
+**LLM assessment:** Not slop — passes the Linear/Vercel trust test. No card-grid templates, no eyebrows, no gradient text, no glassmorphism. Amber genuinely rationed to the One-Voice rule (live pulse, "now" line only). The timeline is a real custom artifact (interval-graph row packing, cluster chips, drift-transform live-follow). The risk runs the other way: **under-designed emptiness** — the control center's front door opens on a greeting and a void with no action.
+
+**Deterministic scan:** 9 findings, all `design-system-font-size` — off-ramp `text-[10px]`/`text-[11px]` literals, all in `src/components/dashboard/agent-activity-timeline.tsx` (lines 533, 1103, 1142, 1156, 1187, 1205, 1226, 1263, 1277). No mechanical false positives (all live JSX className literals). Converges with the human review's contrast concern on 10px muted text over tinted fills. `unified-home.tsx`, `alert-callout.tsx`, `skeleton.tsx`: clean.
+
+**Visual overlays:** Injection succeeded on the live page; a manually-triggered `impeccableScan()` reported 6 anti-patterns in the rendered (empty-state) DOM via console. Overlay server started and cleanly stopped.
+
+## Overall Impression
+
+The populated timeline is the strongest surface in the app — genuinely mission-control — but the page most operators will actually see (quiet window, first run) is a dead-end void that hides existing history, offers zero steering actions, and teaches nothing. Biggest opportunity: make the home never-empty and give it its primary verb.
+
+## Priority Issues
+
+- **[P1] The empty state is a dead end that lies.** `visibleTasks.length === 0` renders a terminal `EmptyState` before the toolbar exists, so "Load older" / zoom are unreachable. 58 real tasks sat ~30h old, just outside the 24h window, while the copy claimed "No task activity yet." Also masks task-fetch errors as emptiness. **Fix:** always render the toolbar; window-aware copy ("No activity in the last 8h — load older / widen to 7d") with working actions; distinguish `isError` from empty.
+- **[P1] No primary action — the control center spectates, not steers.** No "New task" anywhere on `/`, contradicting Design Principle #1. **Fix:** primary action in a `PageHeader` action slot + as the empty-state CTA.
+- **[P1] No status-color legend.** Eight semantic colors, meaning hover-only; WCAG 1.4.1 color-alone violation; non-dev operators can't read the chart. **Fix:** compact always-visible legend; status in each bar's accessible name.
+- **[P2] Home bypasses `PageHeader` and the headline token.** Hand-rolled `h1 text-2xl` on the most-visited route; breaks type rhythm and forfeits the action slot. **Fix:** render greeting through `PageHeader`.
+- **[P2] Two sequential onboarding gates before any value.** Connection form → identity modal → void. **Fix:** collapse to one step (auto-accept generated connection name), make identity deferrable.
+
+## Persona Red Flags
+
+**Alex (power user):** two forced gates, no skip; no zoom/pan hotkeys (+/-/0); no filter-by-agent/status on a 1,200-task chart; no quick-create path.
+
+**Sam (accessibility):** status by color alone (1.4.1) with hover-only decode; keyboard/SR coherence of absolutely-positioned bars in a scroll region unproven; `animate-ping`/`shimmer-bar` reduced-motion degradation unverified; 10px labels on tinted fills at contrast risk (matches detector findings).
+
+**Morgan (non-developer operator, from PRODUCT.md):** lands on a Gantt with "30s/2m/8h" presets, "clusters", a "now" line — zero explanation; "superseded"/raw token counts are jargon; no plain-language fleet summary ("3 agents idle · 0 running · 1 approval waiting") — the one thing she most needs.
+
+## Minor Observations
+
+- Empty-state clock icon too small for a full-viewport card; weak central mass.
+- Three near-identical zoom icon buttons; window label separated from them; "8h" vs "(24h window)" vocabulary mismatch.
+- Sidebar fixed 255px at 900px viewport (~28% of width); no collapse below ~1024px.
+- Version-gate copy leaks "API 1.76+" with no upgrade guidance.
+- Greeting uses raw username; long-name truncation untested.
+
+## Questions to Consider
+
+1. What if the home led with a one-line plain-language fleet state ("3 agents idle · 0 running · 1 approval waiting · $0 today") and made the timeline the second glance?
+2. Should the window auto-widen to the most recent activity so the first glance is never empty when history exists?
+3. What's the one action an operator should take from this page in under 5 seconds — and why is there currently no button for it?

--- a/apps/ui/.impeccable/design.json
+++ b/apps/ui/.impeccable/design.json
@@ -1,0 +1,181 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-07-10T00:00:00Z",
+  "title": "Design System: Agent Swarm Dashboard",
+  "extensions": {
+    "colorMeta": {
+      "hive-amber": {
+        "role": "primary",
+        "displayName": "Hive Amber",
+        "canonical": "oklch(0.555 0.163 48.998)",
+        "darkValue": "oklch(0.769 0.188 70.08)",
+        "tonalRamp": ["oklch(0.2 0.09 49)", "oklch(0.3 0.12 49)", "oklch(0.42 0.15 49)", "oklch(0.555 0.163 49)", "oklch(0.666 0.179 58)", "oklch(0.769 0.188 70)", "oklch(0.87 0.12 78)", "oklch(0.95 0.05 84)"]
+      },
+      "background": {
+        "role": "neutral",
+        "displayName": "Field",
+        "canonical": "oklch(1 0 0)",
+        "darkValue": "oklch(0.141 0.005 285.823)",
+        "tonalRamp": ["oklch(0.141 0.005 286)", "oklch(0.21 0.006 286)", "oklch(0.274 0.006 286)", "oklch(0.442 0.01 286)", "oklch(0.552 0.016 286)", "oklch(0.705 0.015 286)", "oklch(0.92 0.004 286)", "oklch(1 0 0)"]
+      },
+      "surface": {
+        "role": "neutral",
+        "displayName": "Recessed Surface",
+        "canonical": "oklch(0.985 0.0015 286)",
+        "darkValue": "oklch(0.185 0.006 286)",
+        "tonalRamp": ["oklch(0.185 0.006 286)", "oklch(0.25 0.005 286)", "oklch(0.35 0.005 286)", "oklch(0.5 0.004 286)", "oklch(0.65 0.003 286)", "oklch(0.8 0.002 286)", "oklch(0.92 0.002 286)", "oklch(0.985 0.0015 286)"]
+      },
+      "muted-foreground": {
+        "role": "neutral",
+        "displayName": "Quiet Ink",
+        "canonical": "oklch(0.552 0.016 285.938)",
+        "darkValue": "oklch(0.705 0.015 286.067)",
+        "tonalRamp": ["oklch(0.2 0.016 286)", "oklch(0.3 0.016 286)", "oklch(0.4 0.016 286)", "oklch(0.552 0.016 286)", "oklch(0.65 0.015 286)", "oklch(0.705 0.015 286)", "oklch(0.85 0.01 286)", "oklch(0.95 0.005 286)"]
+      },
+      "border": {
+        "role": "neutral",
+        "displayName": "Structural Line",
+        "canonical": "oklch(0.92 0.004 286.32)",
+        "darkValue": "oklch(1 0 0 / 10%)",
+        "tonalRamp": ["oklch(0.25 0.004 286)", "oklch(0.35 0.004 286)", "oklch(0.5 0.004 286)", "oklch(0.65 0.004 286)", "oklch(0.78 0.004 286)", "oklch(0.86 0.004 286)", "oklch(0.92 0.004 286)", "oklch(0.97 0.002 286)"]
+      },
+      "status-success": {
+        "role": "secondary",
+        "displayName": "Success Emerald",
+        "canonical": "oklch(0.696 0.17 162.48)",
+        "darkValue": "oklch(0.765 0.177 163.223)",
+        "tonalRamp": ["oklch(0.25 0.08 162)", "oklch(0.38 0.11 162)", "oklch(0.5 0.14 162)", "oklch(0.596 0.145 163)", "oklch(0.696 0.17 162)", "oklch(0.765 0.177 163)", "oklch(0.87 0.12 163)", "oklch(0.95 0.05 163)"]
+      },
+      "status-error": {
+        "role": "secondary",
+        "displayName": "Failure Red",
+        "canonical": "oklch(0.637 0.237 25.331)",
+        "darkValue": "oklch(0.704 0.191 22.216)",
+        "tonalRamp": ["oklch(0.25 0.1 25)", "oklch(0.38 0.15 25)", "oklch(0.5 0.2 26)", "oklch(0.577 0.245 27)", "oklch(0.637 0.237 25)", "oklch(0.704 0.191 22)", "oklch(0.85 0.09 22)", "oklch(0.95 0.03 22)"]
+      },
+      "status-info": {
+        "role": "secondary",
+        "displayName": "Info Sky",
+        "canonical": "oklch(0.685 0.169 237.323)",
+        "darkValue": "oklch(0.746 0.16 232.661)",
+        "tonalRamp": ["oklch(0.25 0.08 237)", "oklch(0.38 0.11 237)", "oklch(0.5 0.14 240)", "oklch(0.588 0.158 242)", "oklch(0.685 0.169 237)", "oklch(0.746 0.16 233)", "oklch(0.87 0.09 233)", "oklch(0.95 0.03 233)"]
+      },
+      "status-paused": {
+        "role": "secondary",
+        "displayName": "Paused Blue",
+        "canonical": "oklch(0.623 0.214 259.815)",
+        "darkValue": "oklch(0.707 0.165 254.624)",
+        "tonalRamp": ["oklch(0.25 0.1 260)", "oklch(0.38 0.15 260)", "oklch(0.5 0.2 261)", "oklch(0.546 0.245 263)", "oklch(0.623 0.214 260)", "oklch(0.707 0.165 255)", "oklch(0.87 0.08 255)", "oklch(0.95 0.03 255)"]
+      }
+    },
+    "typographyMeta": {
+      "headline": { "displayName": "Headline", "purpose": "Route-page titles via PageHeader (text-xl font-semibold). Fixed rem scale, never fluid." },
+      "body": { "displayName": "Body", "purpose": "Default reading size (text-sm) for descriptions, forms, cells. Prose caps at 65-75ch." },
+      "label": { "displayName": "Label", "purpose": "InfoRow uppercase tracked labels and quiet metadata (text-xs)." },
+      "mono": { "displayName": "Machine Voice", "purpose": "Space Mono for IDs, logs, code, costs — anything the system produced." }
+    },
+    "shadows": [
+      { "name": "whisper", "value": "0 1px 2px 0 rgb(0 0 0 / 0.05)", "purpose": "shadow-xs on buttons and inputs — barely-there lift on interactive controls." },
+      { "name": "resting-card", "value": "0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)", "purpose": "shadow-sm on Card containers at rest. Borders, not shadows, define structure." }
+    ],
+    "motion": [
+      { "name": "control-transition", "value": "all 150ms ease", "purpose": "Default state transitions on buttons/inputs (transition-all)." },
+      { "name": "shimmer-slide", "value": "shimmer-slide 2s linear infinite", "purpose": "Liveness indicator on in-progress agent work only. Must degrade to a static indicator under prefers-reduced-motion." }
+    ],
+    "breakpoints": [
+      { "name": "sm", "value": "640px" },
+      { "name": "md", "value": "768px" },
+      { "name": "lg", "value": "1024px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Hive Amber primary action — one per surface.",
+      "html": "<button class=\"ds-btn ds-btn-primary\">Create Task</button>",
+      "css": ".ds-btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; height: 36px; padding: 8px 16px; border: none; border-radius: 0.5rem; font-family: 'Space Grotesk', sans-serif; font-size: 0.875rem; font-weight: 500; cursor: pointer; transition: all 150ms ease; white-space: nowrap; } .ds-btn:focus-visible { outline: none; box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-ring, oklch(0.555 0.163 49)) 50%, transparent); } .ds-btn-primary { background: var(--color-primary, oklch(0.555 0.163 48.998)); color: var(--color-primary-foreground, oklch(0.985 0 0)); } .ds-btn-primary:hover { background: color-mix(in oklab, var(--color-primary, oklch(0.555 0.163 48.998)) 90%, transparent); }"
+    },
+    {
+      "name": "Outline Button",
+      "kind": "button",
+      "refersTo": "button-outline",
+      "description": "Secondary bordered action.",
+      "html": "<button class=\"ds-btn ds-btn-outline\">Cancel</button>",
+      "css": ".ds-btn-outline { background: var(--color-background, oklch(1 0 0)); color: var(--color-foreground, oklch(0.141 0.005 285.823)); border: 1px solid var(--color-border, oklch(0.92 0.004 286.32)); box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); } .ds-btn-outline:hover { background: var(--color-accent, oklch(0.967 0.001 286.375)); }"
+    },
+    {
+      "name": "Destructive Outline Button",
+      "kind": "button",
+      "refersTo": "button-destructive-outline",
+      "description": "Red-outlined destructive action (delete/remove/disconnect); always confirms via dialog.",
+      "html": "<button class=\"ds-btn ds-btn-destructive-outline\">Delete</button>",
+      "css": ".ds-btn-destructive-outline { background: var(--color-background, oklch(1 0 0)); color: var(--color-status-error, oklch(0.637 0.237 25.331)); border: 1px solid color-mix(in oklab, var(--color-status-error, oklch(0.637 0.237 25.331)) 30%, transparent); box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); } .ds-btn-destructive-outline:hover { background: color-mix(in oklab, var(--color-status-error, oklch(0.637 0.237 25.331)) 10%, transparent); }"
+    },
+    {
+      "name": "Input",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "36px transparent-bg field with the shared amber focus ring.",
+      "html": "<input class=\"ds-input\" placeholder=\"Search tasks...\" />",
+      "css": ".ds-input { height: 36px; width: 100%; min-width: 0; padding: 4px 12px; background: transparent; border: 1px solid var(--color-input, oklch(0.92 0.004 286.32)); border-radius: 0.5rem; font-family: 'Space Grotesk', sans-serif; font-size: 0.875rem; color: var(--color-foreground, oklch(0.141 0.005 285.823)); box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); transition: color 150ms ease, box-shadow 150ms ease; outline: none; } .ds-input::placeholder { color: var(--color-muted-foreground, oklch(0.552 0.016 285.938)); } .ds-input:focus-visible { border-color: var(--color-ring, oklch(0.555 0.163 48.998)); box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-ring, oklch(0.555 0.163 48.998)) 50%, transparent); }"
+    },
+    {
+      "name": "Tag Badge",
+      "kind": "chip",
+      "refersTo": "badge-tag",
+      "description": "The system status chip — 9px uppercase, semantically toned.",
+      "html": "<span class=\"ds-tag ds-tag-info\">QUEUED</span> <span class=\"ds-tag ds-tag-active\">RUNNING</span> <span class=\"ds-tag ds-tag-success\">COMPLETED</span>",
+      "css": ".ds-tag { display: inline-flex; align-items: center; height: 20px; padding: 0 6px; margin-right: 4px; border: 1px solid var(--color-border, oklch(0.92 0.004 286.32)); border-radius: 0.375rem; font-family: 'Space Grotesk', sans-serif; font-size: 9px; font-weight: 500; line-height: 1; letter-spacing: 0.02em; text-transform: uppercase; color: var(--color-foreground, oklch(0.141 0.005 285.823)); } .ds-tag-info { border-color: color-mix(in oklab, var(--color-status-info, oklch(0.685 0.169 237.323)) 30%, transparent); color: var(--color-status-info-strong, oklch(0.588 0.158 241.966)); } .ds-tag-active { border-color: color-mix(in oklab, var(--color-status-active, oklch(0.769 0.188 70.08)) 30%, transparent); color: var(--color-status-active-strong, oklch(0.666 0.179 58.318)); } .ds-tag-success { border-color: color-mix(in oklab, var(--color-status-success, oklch(0.696 0.17 162.48)) 30%, transparent); color: var(--color-status-success-strong, oklch(0.596 0.145 163.225)); }"
+    },
+    {
+      "name": "Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "Bordered section container, border-first depth.",
+      "html": "<div class=\"ds-card\"><div class=\"ds-card-title\">Agent Fleet</div><p class=\"ds-card-body\">4 agents idle, 2 busy. Memory compounds with every run.</p></div>",
+      "css": ".ds-card { display: flex; flex-direction: column; gap: 12px; padding: 24px; background: var(--color-card, oklch(1 0 0)); color: var(--color-foreground, oklch(0.141 0.005 285.823)); border: 1px solid var(--color-border, oklch(0.92 0.004 286.32)); border-radius: 0.75rem; box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1); font-family: 'Space Grotesk', sans-serif; } .ds-card-title { font-size: 1rem; font-weight: 600; line-height: 1; } .ds-card-body { margin: 0; font-size: 0.875rem; line-height: 1.5; color: var(--color-muted-foreground, oklch(0.552 0.016 285.938)); }"
+    },
+    {
+      "name": "Info Row",
+      "kind": "custom",
+      "refersTo": "badge-tag",
+      "description": "Uppercase label + value pair used across detail pages and rails.",
+      "html": "<div class=\"ds-info-row\"><span class=\"ds-info-label\">Harness</span><p class=\"ds-info-value\">claude-code v2.1</p></div>",
+      "css": ".ds-info-row { display: flex; flex-direction: column; gap: 4px; font-family: 'Space Grotesk', sans-serif; } .ds-info-label { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.025em; color: var(--color-muted-foreground, oklch(0.552 0.016 285.938)); } .ds-info-value { margin: 0; font-size: 0.875rem; color: var(--color-foreground, oklch(0.141 0.005 285.823)); }"
+    }
+  ],
+  "narrative": {
+    "northStar": "Mission Control",
+    "overview": "This is the console an operator trusts while a fleet of autonomous coding agents does real work. The system is flight-deck steady: a quiet zinc neutral field in light and dark, dense-but-ordered readouts, and one voice of color — Hive Amber — reserved for what is interactive or alive right now. Status is a language here, not decoration: eight semantic status tones and eleven workflow action tones carry all meaning-bearing color, so a screen full of running agents reads as an ordered fleet, not an alarm board. The system explicitly rejects enterprise admin sprawl and AI-startup gradient slop. Nothing shimmers unless something is genuinely running. Composure comes from borders and tonal layering rather than shadow drama; utility comes from crisp, small-radius controls that recede until needed.",
+    "keyCharacteristics": [
+      "One accent (Hive Amber) for interaction and liveness; everything else is zinc neutral or a named status tone.",
+      "Flat, border-defined depth; shadows are whispers (shadow-xs/shadow-sm), never structure.",
+      "Utilitarian and crisp controls: 36px-tall inputs/buttons, 6-8px radii, exact state vocabulary.",
+      "Single-family typography (Space Grotesk) with Space Mono for IDs, logs, and machine output.",
+      "Dual-theme by design: every token has a light and dark value; nothing is hardcoded to either."
+    ],
+    "rules": [
+      { "name": "The Token-Only Rule", "body": "Raw Tailwind palette literals (bg-emerald-500, text-amber-400, bg-[#0d1117]) are forbidden in app code — the check:tokens lint gate fails the build on them. New colors enter the system only as named tokens in globals.css.", "section": "colors" },
+      { "name": "The One Voice Rule", "body": "Hive Amber speaks for interaction and liveness only. If amber appears on something that is neither actionable nor currently active, it is wrong.", "section": "colors" },
+      { "name": "The Machine-Voice Rule", "body": "If a human wrote it, it's Space Grotesk; if the system produced it (IDs, logs, code, raw payloads), it's Space Mono. Never mix within one value.", "section": "typography" },
+      { "name": "The Border-First Rule", "body": "If a container needs definition, reach for border-border or a tonal step (surface/card), never a bigger shadow. A shadow that reads as 'elevation strategy' is a bug.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do use named tokens for every color: bg-status-success, text-status-error-strong, bg-action-script/10. The lint gate enforces it.",
+      "Do compose from the primitives catalog (Button, Badge size=\"tag\", StatusBadge, DataGrid, DetailPageBody, SettingsRow, EmptyState) before writing a raw <div> layout.",
+      "Do keep one focus language: 3px ring-ring/50 amber ring on every focusable control.",
+      "Do use skeletons (Skeleton, PageSkeleton) for loading and EmptyState (icon + title + description + action) for empty lists — empty states teach the interface.",
+      "Do hold WCAG 2.1 AA in both themes: ≥4.5:1 body contrast, keyboard access, prefers-reduced-motion alternatives (the shimmer must degrade to a static indicator)."
+    ],
+    "donts": [
+      "Don't hardcode theme colors — no bg-zinc-950, no dark: palette variants, no hex literals. Both themes are first-class.",
+      "Don't drift toward 'AI-startup gradient slop': no purple gradients, no glassmorphism, no sparkle theater around agent work.",
+      "Don't rebuild 'enterprise admin sprawl': no nested config mazes; primary actions live in the PageHeader, destructive ones confirm via AlertDialog, not click-again.",
+      "Don't use HTML <Table> for data lists — DataGrid is a hard rule.",
+      "Don't spend Hive Amber on decoration or inactive states; if it's not actionable or alive, it isn't amber.",
+      "Don't animate anything that isn't conveying state. No orchestrated page loads, no decorative motion — the operator is in a task."
+    ]
+  }
+}

--- a/apps/ui/.impeccable/design.json
+++ b/apps/ui/.impeccable/design.json
@@ -9,78 +9,187 @@
         "displayName": "Hive Amber",
         "canonical": "oklch(0.555 0.163 48.998)",
         "darkValue": "oklch(0.769 0.188 70.08)",
-        "tonalRamp": ["oklch(0.2 0.09 49)", "oklch(0.3 0.12 49)", "oklch(0.42 0.15 49)", "oklch(0.555 0.163 49)", "oklch(0.666 0.179 58)", "oklch(0.769 0.188 70)", "oklch(0.87 0.12 78)", "oklch(0.95 0.05 84)"]
+        "tonalRamp": [
+          "oklch(0.2 0.09 49)",
+          "oklch(0.3 0.12 49)",
+          "oklch(0.42 0.15 49)",
+          "oklch(0.555 0.163 49)",
+          "oklch(0.666 0.179 58)",
+          "oklch(0.769 0.188 70)",
+          "oklch(0.87 0.12 78)",
+          "oklch(0.95 0.05 84)"
+        ]
       },
       "background": {
         "role": "neutral",
         "displayName": "Field",
         "canonical": "oklch(1 0 0)",
         "darkValue": "oklch(0.141 0.005 285.823)",
-        "tonalRamp": ["oklch(0.141 0.005 286)", "oklch(0.21 0.006 286)", "oklch(0.274 0.006 286)", "oklch(0.442 0.01 286)", "oklch(0.552 0.016 286)", "oklch(0.705 0.015 286)", "oklch(0.92 0.004 286)", "oklch(1 0 0)"]
+        "tonalRamp": [
+          "oklch(0.141 0.005 286)",
+          "oklch(0.21 0.006 286)",
+          "oklch(0.274 0.006 286)",
+          "oklch(0.442 0.01 286)",
+          "oklch(0.552 0.016 286)",
+          "oklch(0.705 0.015 286)",
+          "oklch(0.92 0.004 286)",
+          "oklch(1 0 0)"
+        ]
       },
       "surface": {
         "role": "neutral",
         "displayName": "Recessed Surface",
         "canonical": "oklch(0.985 0.0015 286)",
         "darkValue": "oklch(0.185 0.006 286)",
-        "tonalRamp": ["oklch(0.185 0.006 286)", "oklch(0.25 0.005 286)", "oklch(0.35 0.005 286)", "oklch(0.5 0.004 286)", "oklch(0.65 0.003 286)", "oklch(0.8 0.002 286)", "oklch(0.92 0.002 286)", "oklch(0.985 0.0015 286)"]
+        "tonalRamp": [
+          "oklch(0.185 0.006 286)",
+          "oklch(0.25 0.005 286)",
+          "oklch(0.35 0.005 286)",
+          "oklch(0.5 0.004 286)",
+          "oklch(0.65 0.003 286)",
+          "oklch(0.8 0.002 286)",
+          "oklch(0.92 0.002 286)",
+          "oklch(0.985 0.0015 286)"
+        ]
       },
       "muted-foreground": {
         "role": "neutral",
         "displayName": "Quiet Ink",
         "canonical": "oklch(0.552 0.016 285.938)",
         "darkValue": "oklch(0.705 0.015 286.067)",
-        "tonalRamp": ["oklch(0.2 0.016 286)", "oklch(0.3 0.016 286)", "oklch(0.4 0.016 286)", "oklch(0.552 0.016 286)", "oklch(0.65 0.015 286)", "oklch(0.705 0.015 286)", "oklch(0.85 0.01 286)", "oklch(0.95 0.005 286)"]
+        "tonalRamp": [
+          "oklch(0.2 0.016 286)",
+          "oklch(0.3 0.016 286)",
+          "oklch(0.4 0.016 286)",
+          "oklch(0.552 0.016 286)",
+          "oklch(0.65 0.015 286)",
+          "oklch(0.705 0.015 286)",
+          "oklch(0.85 0.01 286)",
+          "oklch(0.95 0.005 286)"
+        ]
       },
       "border": {
         "role": "neutral",
         "displayName": "Structural Line",
         "canonical": "oklch(0.92 0.004 286.32)",
         "darkValue": "oklch(1 0 0 / 10%)",
-        "tonalRamp": ["oklch(0.25 0.004 286)", "oklch(0.35 0.004 286)", "oklch(0.5 0.004 286)", "oklch(0.65 0.004 286)", "oklch(0.78 0.004 286)", "oklch(0.86 0.004 286)", "oklch(0.92 0.004 286)", "oklch(0.97 0.002 286)"]
+        "tonalRamp": [
+          "oklch(0.25 0.004 286)",
+          "oklch(0.35 0.004 286)",
+          "oklch(0.5 0.004 286)",
+          "oklch(0.65 0.004 286)",
+          "oklch(0.78 0.004 286)",
+          "oklch(0.86 0.004 286)",
+          "oklch(0.92 0.004 286)",
+          "oklch(0.97 0.002 286)"
+        ]
       },
       "status-success": {
         "role": "secondary",
         "displayName": "Success Emerald",
         "canonical": "oklch(0.696 0.17 162.48)",
         "darkValue": "oklch(0.765 0.177 163.223)",
-        "tonalRamp": ["oklch(0.25 0.08 162)", "oklch(0.38 0.11 162)", "oklch(0.5 0.14 162)", "oklch(0.596 0.145 163)", "oklch(0.696 0.17 162)", "oklch(0.765 0.177 163)", "oklch(0.87 0.12 163)", "oklch(0.95 0.05 163)"]
+        "tonalRamp": [
+          "oklch(0.25 0.08 162)",
+          "oklch(0.38 0.11 162)",
+          "oklch(0.5 0.14 162)",
+          "oklch(0.596 0.145 163)",
+          "oklch(0.696 0.17 162)",
+          "oklch(0.765 0.177 163)",
+          "oklch(0.87 0.12 163)",
+          "oklch(0.95 0.05 163)"
+        ]
       },
       "status-error": {
         "role": "secondary",
         "displayName": "Failure Red",
         "canonical": "oklch(0.637 0.237 25.331)",
         "darkValue": "oklch(0.704 0.191 22.216)",
-        "tonalRamp": ["oklch(0.25 0.1 25)", "oklch(0.38 0.15 25)", "oklch(0.5 0.2 26)", "oklch(0.577 0.245 27)", "oklch(0.637 0.237 25)", "oklch(0.704 0.191 22)", "oklch(0.85 0.09 22)", "oklch(0.95 0.03 22)"]
+        "tonalRamp": [
+          "oklch(0.25 0.1 25)",
+          "oklch(0.38 0.15 25)",
+          "oklch(0.5 0.2 26)",
+          "oklch(0.577 0.245 27)",
+          "oklch(0.637 0.237 25)",
+          "oklch(0.704 0.191 22)",
+          "oklch(0.85 0.09 22)",
+          "oklch(0.95 0.03 22)"
+        ]
       },
       "status-info": {
         "role": "secondary",
         "displayName": "Info Sky",
         "canonical": "oklch(0.685 0.169 237.323)",
         "darkValue": "oklch(0.746 0.16 232.661)",
-        "tonalRamp": ["oklch(0.25 0.08 237)", "oklch(0.38 0.11 237)", "oklch(0.5 0.14 240)", "oklch(0.588 0.158 242)", "oklch(0.685 0.169 237)", "oklch(0.746 0.16 233)", "oklch(0.87 0.09 233)", "oklch(0.95 0.03 233)"]
+        "tonalRamp": [
+          "oklch(0.25 0.08 237)",
+          "oklch(0.38 0.11 237)",
+          "oklch(0.5 0.14 240)",
+          "oklch(0.588 0.158 242)",
+          "oklch(0.685 0.169 237)",
+          "oklch(0.746 0.16 233)",
+          "oklch(0.87 0.09 233)",
+          "oklch(0.95 0.03 233)"
+        ]
       },
       "status-paused": {
         "role": "secondary",
         "displayName": "Paused Blue",
         "canonical": "oklch(0.623 0.214 259.815)",
         "darkValue": "oklch(0.707 0.165 254.624)",
-        "tonalRamp": ["oklch(0.25 0.1 260)", "oklch(0.38 0.15 260)", "oklch(0.5 0.2 261)", "oklch(0.546 0.245 263)", "oklch(0.623 0.214 260)", "oklch(0.707 0.165 255)", "oklch(0.87 0.08 255)", "oklch(0.95 0.03 255)"]
+        "tonalRamp": [
+          "oklch(0.25 0.1 260)",
+          "oklch(0.38 0.15 260)",
+          "oklch(0.5 0.2 261)",
+          "oklch(0.546 0.245 263)",
+          "oklch(0.623 0.214 260)",
+          "oklch(0.707 0.165 255)",
+          "oklch(0.87 0.08 255)",
+          "oklch(0.95 0.03 255)"
+        ]
       }
     },
     "typographyMeta": {
-      "headline": { "displayName": "Headline", "purpose": "Route-page titles via PageHeader (text-xl font-semibold). Fixed rem scale, never fluid." },
-      "body": { "displayName": "Body", "purpose": "Default reading size (text-sm) for descriptions, forms, cells. Prose caps at 65-75ch." },
-      "label": { "displayName": "Label", "purpose": "InfoRow uppercase tracked labels and quiet metadata (text-xs)." },
-      "mono": { "displayName": "Machine Voice", "purpose": "Space Mono for IDs, logs, code, costs — anything the system produced." }
+      "headline": {
+        "displayName": "Headline",
+        "purpose": "Route-page titles via PageHeader (text-xl font-semibold). Fixed rem scale, never fluid."
+      },
+      "body": {
+        "displayName": "Body",
+        "purpose": "Default reading size (text-sm) for descriptions, forms, cells. Prose caps at 65-75ch."
+      },
+      "label": {
+        "displayName": "Label",
+        "purpose": "InfoRow uppercase tracked labels and quiet metadata (text-xs)."
+      },
+      "mono": {
+        "displayName": "Machine Voice",
+        "purpose": "Space Mono for IDs, logs, code, costs — anything the system produced."
+      }
     },
     "shadows": [
-      { "name": "whisper", "value": "0 1px 2px 0 rgb(0 0 0 / 0.05)", "purpose": "shadow-xs on buttons and inputs — barely-there lift on interactive controls." },
-      { "name": "resting-card", "value": "0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)", "purpose": "shadow-sm on Card containers at rest. Borders, not shadows, define structure." }
+      {
+        "name": "whisper",
+        "value": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+        "purpose": "shadow-xs on buttons and inputs — barely-there lift on interactive controls."
+      },
+      {
+        "name": "resting-card",
+        "value": "0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)",
+        "purpose": "shadow-sm on Card containers at rest. Borders, not shadows, define structure."
+      }
     ],
     "motion": [
-      { "name": "control-transition", "value": "all 150ms ease", "purpose": "Default state transitions on buttons/inputs (transition-all)." },
-      { "name": "shimmer-slide", "value": "shimmer-slide 2s linear infinite", "purpose": "Liveness indicator on in-progress agent work only. Must degrade to a static indicator under prefers-reduced-motion." }
+      {
+        "name": "control-transition",
+        "value": "all 150ms ease",
+        "purpose": "Default state transitions on buttons/inputs (transition-all)."
+      },
+      {
+        "name": "shimmer-slide",
+        "value": "shimmer-slide 2s linear infinite",
+        "purpose": "Liveness indicator on in-progress agent work only. Must degrade to a static indicator under prefers-reduced-motion."
+      }
     ],
     "breakpoints": [
       { "name": "sm", "value": "640px" },
@@ -157,10 +266,26 @@
       "Dual-theme by design: every token has a light and dark value; nothing is hardcoded to either."
     ],
     "rules": [
-      { "name": "The Token-Only Rule", "body": "Raw Tailwind palette literals (bg-emerald-500, text-amber-400, bg-[#0d1117]) are forbidden in app code — the check:tokens lint gate fails the build on them. New colors enter the system only as named tokens in globals.css.", "section": "colors" },
-      { "name": "The One Voice Rule", "body": "Hive Amber speaks for interaction and liveness only. If amber appears on something that is neither actionable nor currently active, it is wrong.", "section": "colors" },
-      { "name": "The Machine-Voice Rule", "body": "If a human wrote it, it's Space Grotesk; if the system produced it (IDs, logs, code, raw payloads), it's Space Mono. Never mix within one value.", "section": "typography" },
-      { "name": "The Border-First Rule", "body": "If a container needs definition, reach for border-border or a tonal step (surface/card), never a bigger shadow. A shadow that reads as 'elevation strategy' is a bug.", "section": "elevation" }
+      {
+        "name": "The Token-Only Rule",
+        "body": "Raw Tailwind palette literals (bg-emerald-500, text-amber-400, bg-[#0d1117]) are forbidden in app code — the check:tokens lint gate fails the build on them. New colors enter the system only as named tokens in globals.css.",
+        "section": "colors"
+      },
+      {
+        "name": "The One Voice Rule",
+        "body": "Hive Amber speaks for interaction and liveness only. If amber appears on something that is neither actionable nor currently active, it is wrong.",
+        "section": "colors"
+      },
+      {
+        "name": "The Machine-Voice Rule",
+        "body": "If a human wrote it, it's Space Grotesk; if the system produced it (IDs, logs, code, raw payloads), it's Space Mono. Never mix within one value.",
+        "section": "typography"
+      },
+      {
+        "name": "The Border-First Rule",
+        "body": "If a container needs definition, reach for border-border or a tonal step (surface/card), never a bigger shadow. A shadow that reads as 'elevation strategy' is a bug.",
+        "section": "elevation"
+      }
     ],
     "dos": [
       "Do use named tokens for every color: bg-status-success, text-status-error-strong, bg-action-script/10. The lint gate enforces it.",

--- a/apps/ui/.impeccable/live/config.json
+++ b/apps/ui/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["index.html"],
+  "insertBefore": "</body>",
+  "commentSyntax": "html",
+  "cspChecked": true
+}

--- a/apps/ui/CLAUDE.md
+++ b/apps/ui/CLAUDE.md
@@ -2,6 +2,10 @@
 
 React + Vite + shadcn/ui + Tailwind + AG Grid + react-query dashboard for the Agent Swarm API.
 
+## Design Context
+
+Strategic design context lives in [PRODUCT.md](./PRODUCT.md) (register, users, positioning, brand personality, design principles) and the visual system in [DESIGN.md](./DESIGN.md) (tokens, typography, elevation, component doctrine). Read them before designing or restyling any UI surface.
+
 <important if="you are running the ui dev server, building it, or setting up ui locally">
 
 ## Quick start

--- a/apps/ui/DESIGN.md
+++ b/apps/ui/DESIGN.md
@@ -1,0 +1,228 @@
+---
+name: Agent Swarm Dashboard
+description: Mission-control dashboard for steering a fleet of coding agents — calm, capable, transparent.
+colors:
+  hive-amber: "oklch(0.555 0.163 48.998)"
+  hive-amber-dark: "oklch(0.769 0.188 70.08)"
+  background: "oklch(1 0 0)"
+  background-dark: "oklch(0.141 0.005 285.823)"
+  foreground: "oklch(0.141 0.005 285.823)"
+  card: "oklch(1 0 0)"
+  card-dark: "oklch(0.21 0.006 285.885)"
+  surface: "oklch(0.985 0.0015 286)"
+  muted: "oklch(0.967 0.001 286.375)"
+  muted-foreground: "oklch(0.552 0.016 285.938)"
+  border: "oklch(0.92 0.004 286.32)"
+  destructive: "oklch(0.577 0.245 27.325)"
+  status-success: "oklch(0.696 0.17 162.48)"
+  status-active: "oklch(0.769 0.188 70.08)"
+  status-error: "oklch(0.637 0.237 25.331)"
+  status-info: "oklch(0.685 0.169 237.323)"
+  status-pending: "oklch(0.795 0.184 86.047)"
+  status-warning: "oklch(0.705 0.213 47.604)"
+  status-paused: "oklch(0.623 0.214 259.815)"
+  status-neutral: "oklch(0.552 0.016 285.938)"
+typography:
+  headline:
+    fontFamily: "Space Grotesk, sans-serif"
+    fontSize: "1.25rem"
+    fontWeight: 600
+    lineHeight: 1.4
+  title:
+    fontFamily: "Space Grotesk, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 600
+    lineHeight: 1
+  body:
+    fontFamily: "Space Grotesk, sans-serif"
+    fontSize: "0.875rem"
+    fontWeight: 400
+    lineHeight: 1.5
+  label:
+    fontFamily: "Space Grotesk, sans-serif"
+    fontSize: "0.75rem"
+    fontWeight: 500
+    letterSpacing: "0.025em"
+  mono:
+    fontFamily: "Space Mono, monospace"
+    fontSize: "0.8125rem"
+    fontWeight: 400
+rounded:
+  sm: "0.375rem"
+  md: "0.5rem"
+  lg: "0.625rem"
+  xl: "0.75rem"
+spacing:
+  xs: "0.25rem"
+  sm: "0.5rem"
+  md: "1rem"
+  lg: "1.5rem"
+components:
+  button-primary:
+    backgroundColor: "{colors.hive-amber}"
+    textColor: "oklch(0.985 0 0)"
+    rounded: "{rounded.md}"
+    height: "2.25rem"
+    padding: "0.5rem 1rem"
+  button-outline:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.foreground}"
+    rounded: "{rounded.md}"
+    height: "2.25rem"
+    padding: "0.5rem 1rem"
+  button-destructive-outline:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.status-error}"
+    rounded: "{rounded.md}"
+    height: "2.25rem"
+    padding: "0.5rem 1rem"
+  input:
+    backgroundColor: "transparent"
+    textColor: "{colors.foreground}"
+    rounded: "{rounded.md}"
+    height: "2.25rem"
+    padding: "0.25rem 0.75rem"
+  badge-tag:
+    textColor: "{colors.muted-foreground}"
+    rounded: "{rounded.sm}"
+    height: "1.25rem"
+    padding: "0 0.375rem"
+  card:
+    backgroundColor: "{colors.card}"
+    textColor: "{colors.foreground}"
+    rounded: "{rounded.xl}"
+    padding: "1.5rem 0"
+---
+
+# Design System: Agent Swarm Dashboard
+
+## 1. Overview
+
+**Creative North Star: "Mission Control"**
+
+This is the console an operator trusts while a fleet of autonomous coding agents does real work. The system is flight-deck steady: a quiet zinc neutral field in light and dark, dense-but-ordered readouts, and one voice of color — Hive Amber — reserved for what is interactive or alive right now. Status is a language here, not decoration: eight semantic status tones and eleven workflow action tones carry all meaning-bearing color, so a screen full of running agents reads as an ordered fleet, not an alarm board.
+
+The system explicitly rejects PRODUCT.md's anti-references: no enterprise admin sprawl and no AI-startup gradient slop. Nothing shimmers unless something is genuinely running (the shimmer is a literal liveness indicator, the one theatrical move the system allows itself, and it means "work in progress"). Composure comes from borders and tonal layering rather than shadow drama; utility comes from crisp, small-radius controls that recede until needed.
+
+**Key Characteristics:**
+- One accent (Hive Amber) for interaction and liveness; everything else is zinc neutral or a named status tone.
+- Flat, border-defined depth; shadows are whispers (`shadow-xs`/`shadow-sm`), never structure.
+- Utilitarian and crisp controls: 36px-tall inputs/buttons, 6–8px radii, exact state vocabulary.
+- Single-family typography (Space Grotesk) with Space Mono for IDs, logs, and machine output.
+- Dual-theme by design: every token has a light and dark value; nothing is hardcoded to either.
+
+## 2. Colors
+
+A zinc-neutral field with one amber voice and a strictly named status vocabulary — restrained, semantic, theme-paired.
+
+### Primary
+- **Hive Amber** (oklch(0.555 0.163 48.998) light / oklch(0.769 0.188 70.08) dark): the brand and the pulse. Primary buttons, focus rings, selection, active/busy status, the live dot. It marks what you can act on and what is working right now — never used as decoration or large-area fill.
+
+### Neutral
+- **Background** (oklch(1 0 0) light / oklch(0.141 0.005 285.823) dark): the page field.
+- **Card** (oklch(1 0 0) light / oklch(0.21 0.006 285.885) dark): bordered section containers; in dark mode one tonal step above background.
+- **Surface** (oklch(0.985 0.0015 286) light / oklch(0.185 0.006 286) dark): the recessed step between background and card — nested blocks (e.g. tool-call rows in the session-log viewer) read as layered, not flat.
+- **Muted / Accent** (oklch(0.967 0.001 286.375) light / oklch(0.274 0.006 286.033) dark): hover fills, secondary buttons, quiet panels.
+- **Muted Foreground** (oklch(0.552 0.016 285.938) light / oklch(0.705 0.015 286.067) dark): secondary text, labels, descriptions.
+- **Border** (oklch(0.92 0.004 286.32) light / oklch(1 0 0 / 10%) dark): the structural line that does the work shadows would do elsewhere. Dark-mode borders are white-alpha, so they layer on any surface.
+
+### Status vocabulary (semantic, tokenized)
+Eight canonical tones, each with a `-strong` text-emphasis variant and a `-foreground` for text on the fill. Light mode uses the 500 stop for fills and 600 for emphasis text; dark mode collapses both to the 400 stop.
+
+- **Success** (emerald, oklch(0.696 0.17 162.48)): idle, completed, healthy, approved.
+- **Active** (amber, oklch(0.769 0.188 70.08)): busy, running, in progress — the working hive.
+- **Error** (red, oklch(0.637 0.237 25.331)): failed, unhealthy, rejected.
+- **Info** (sky, oklch(0.685 0.169 237.323)): informational chips.
+- **Pending** (yellow, oklch(0.795 0.184 86.047)): pending, waiting, starting.
+- **Warning** (orange, oklch(0.705 0.213 47.604)): timeouts, threshold warnings.
+- **Paused** (blue, oklch(0.623 0.214 259.815)): paused, reviewing.
+- **Neutral** (zinc, oklch(0.552 0.016 285.938)): offline, backlog, cancelled, skipped.
+
+Eleven `action-*` tokens (violet, cyan, teal, orange, indigo, pink, purple, blue, amber, yellow, sky) color workflow node types the same way: colored border/text with a `/10` translucent fill. All defined in `src/styles/globals.css`.
+
+### Named Rules
+**The Token-Only Rule.** Raw Tailwind palette literals (`bg-emerald-500`, `text-amber-400`, `bg-[#0d1117]`) are forbidden in app code — the `check:tokens` lint gate fails the build on them. New colors enter the system only as named tokens in `globals.css`.
+
+**The One Voice Rule.** Hive Amber speaks for interaction and liveness only. If amber appears on something that is neither actionable nor currently active, it is wrong.
+
+## 3. Typography
+
+**Body/UI Font:** Space Grotesk (with sans-serif fallback)
+**Mono Font:** Space Mono (with monospace fallback)
+
+**Character:** One family carries the whole interface — Space Grotesk's slightly technical geometry gives the console its voice without a display font shouting over the data. Space Mono marks machine territory: session IDs, log output, code, version strings.
+
+### Hierarchy
+- **Headline** (600, 1.25rem / `text-xl`): route-page titles via `PageHeader`. Fixed rem scale — nothing fluid, nothing clamped.
+- **Title** (600, 1rem, leading-none): card and section titles (`CardTitle`).
+- **Body** (400, 0.875rem / `text-sm`, 1.5): the default reading size for descriptions, form text, table cells. Prose runs at 65–75ch max.
+- **Label** (500, 0.75rem / `text-xs`, uppercase + tracking-wide): `InfoRow` definition labels and quiet metadata.
+- **Tag** (500, 9px, uppercase): the `Badge size="tag"` chip — the smallest voice in the system, reserved for status/kind chips.
+- **Mono** (400, ~0.8125rem): IDs, logs, costs, tokens — anything the machine produced.
+
+### Named Rules
+**The Machine-Voice Rule.** If a human wrote it, it's Space Grotesk; if the system produced it (IDs, logs, code, raw payloads), it's Space Mono. Never mix within one value.
+
+## 4. Elevation
+
+Flat and border-defined. Depth is conveyed by tonal layering — background → surface (recessed) → card — and by the border token, which does the structural work. Shadows exist only as whispers: `shadow-xs` on buttons and inputs, `shadow-sm` on cards. They suggest physicality; they never establish hierarchy. Dark mode drops even that pretense and relies entirely on tonal steps plus white-alpha borders.
+
+### Shadow Vocabulary
+- **Whisper** (`shadow-xs`): buttons, inputs — barely-there lift on interactive controls.
+- **Resting card** (`shadow-sm`): `Card` containers at rest.
+
+### Named Rules
+**The Border-First Rule.** If a container needs definition, reach for `border-border` or a tonal step (surface/card), never a bigger shadow. A shadow that reads as "elevation strategy" is a bug.
+
+## 5. Components
+
+Utilitarian and crisp: small radii (6–10px), 36px control heights, restrained fills, and a complete state vocabulary (default, hover, focus-visible ring, disabled at 50% opacity, aria-invalid) on every interactive element.
+
+### Buttons
+- **Shape:** gently rounded (`rounded-md`, 0.5rem); heights 24/32/36/40px (`xs`/`sm`/`default`/`lg`), square icon variants.
+- **Primary:** Hive Amber fill, near-white text, `hover:bg-primary/90`.
+- **Outline:** background fill + border, `shadow-xs`, hovers to the muted accent; dark mode uses translucent input fills (`dark:bg-input/30`).
+- **Destructive-outline:** the canonical red-outlined action — `border-status-error/30 text-status-error hover:bg-status-error/10` — always paired with an `AlertDialog` confirmation.
+- **Focus:** 3px `ring-ring/50` ring with `border-ring` — amber, consistent everywhere.
+- **Ghost / Secondary / Link:** muted-fill hover, secondary-fill, and amber underline text respectively.
+
+### Chips (Badge)
+- **Style:** `size="tag"` is the system chip — 9px uppercase, 20px tall, 6px horizontal padding.
+- **State:** semantic tone via status tokens (`border-status-info/30 text-status-info-strong`), never raw palette classes. `StatusBadge` maps all 18 entity statuses to the right tone.
+
+### Cards / Containers
+- **Corner Style:** `rounded-xl` (0.75rem).
+- **Background:** `card` token; nested/recessed blocks step down to `surface`.
+- **Shadow Strategy:** `shadow-sm` at rest (see Elevation); border does the definition.
+- **Border:** always (`border-border`).
+- **Internal Padding:** 24px vertical rhythm (`py-6`, `gap-6`, `px-6` on sections).
+
+### Inputs / Fields
+- **Style:** transparent background (translucent `input/30` in dark), `border-input`, `rounded-md`, 36px tall, `shadow-xs`.
+- **Focus:** same 3px amber ring as buttons — one focus language across the app.
+- **Error / Disabled:** `aria-invalid` ring + destructive border; disabled at 50% opacity, cursor blocked.
+
+### Navigation
+- **Style:** shadcn `Sidebar` shell (`app-sidebar.tsx`) on the sidebar token layer — one tonal step off the content field, amber for the active item; top-level `PageHeader` per route; global ⌘K `CommandMenu` for keyboard-first navigation.
+
+### Signature Components
+- **DataGrid** (AG Grid wrapper): the mandatory surface for every data list — themed via `ag-grid.css` to the token system, fills remaining page height, row-click drill-down with `stopPropagation` on inline actions.
+- **Detail-page rail:** `DetailPageBody` (1fr main + fixed 280px rail) with `QuickStats` → `Relationships` → `DangerZone` in order — the canonical anatomy of every entity detail page.
+- **Shimmer liveness:** `.shimmer-text` / `.shimmer-bar` — a sliding gradient that means, literally, "an agent is working right now." The system's one animated flourish, and it's semantic.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** use named tokens for every color: `bg-status-success`, `text-status-error-strong`, `bg-action-script/10`. The lint gate enforces it.
+- **Do** compose from the primitives catalog (`Button`, `Badge size="tag"`, `StatusBadge`, `DataGrid`, `DetailPageBody`, `SettingsRow`, `EmptyState`) before writing a raw `<div>` layout.
+- **Do** keep one focus language: 3px `ring-ring/50` amber ring on every focusable control.
+- **Do** use skeletons (`Skeleton`, `PageSkeleton`) for loading and `EmptyState` (icon + title + description + action) for empty lists — empty states teach the interface.
+- **Do** hold WCAG 2.1 AA in both themes: ≥4.5:1 body contrast, keyboard access, `prefers-reduced-motion` alternatives (the shimmer must degrade to a static indicator).
+
+### Don't:
+- **Don't** hardcode theme colors — no `bg-zinc-950`, no `dark:` palette variants, no hex literals. Both themes are first-class.
+- **Don't** drift toward "AI-startup gradient slop" (PRODUCT.md's words): no purple gradients, no glassmorphism, no sparkle theater around agent work.
+- **Don't** rebuild "enterprise admin sprawl": no nested config mazes; primary actions live in the `PageHeader`, destructive ones confirm via `AlertDialog`, not click-again.
+- **Don't** use HTML `<Table>` for data lists — `DataGrid` is a hard rule.
+- **Don't** spend Hive Amber on decoration or inactive states; if it's not actionable or alive, it isn't amber.
+- **Don't** animate anything that isn't conveying state. No orchestrated page loads, no decorative motion — the operator is in a task.

--- a/apps/ui/PRODUCT.md
+++ b/apps/ui/PRODUCT.md
@@ -1,0 +1,44 @@
+# Product
+
+## Register
+
+product
+
+## Platform
+
+web
+
+## Users
+
+People running an agent swarm — and they are not only developers. The primary user is an operator (a dev, a lead, or a less technical teammate) who has delegated real work to a fleet of coding agents and comes to the dashboard to steer it: assign and review tasks, manage workflows, schedules, and approvals, and check on agents while doing other work. They may be self-hosting or on cloud.agent-swarm.dev, and they interact with the swarm the way they would with remote colleagues.
+
+## Product Purpose
+
+The dashboard is the control center for an agent swarm. It is the primary surface for creating and steering work — tasks, workflows, schedules, approvals — across every harness (Claude Code, Codex, Gemini CLI, Devin), with monitoring, session logs, costs, and memory in the same pane. A successful session is one where the operator confidently directed the swarm's work: created or redirected tasks, approved what needed approving, and understood what their agents did and what it cost.
+
+## Positioning
+
+The control center for an AI agent swarm that compounds daily — a lead coordinates, workers ship in isolated containers, memory compounds with every run, and this is where you steer all of it.
+
+## Brand Personality
+
+Calm, capable, transparent. The operator is trusting autonomous agents with real work; the interface answers with steady mission-control composure — nothing hidden, nothing theatrical. A busy swarm should never produce a busy screen.
+
+## Anti-references
+
+- Enterprise admin sprawl (Salesforce/Jira-style nested config mazes, ten clicks to anything).
+- AI-startup gradient slop (purple gradients, sparkles, glassmorphism, "magic" theater around what agents do).
+
+Positive references for the right feel: Linear (crisp, fast, restrained color, density without clutter) and the Vercel dashboard (quiet monochrome plus one accent, excellent detail pages).
+
+## Design Principles
+
+1. **Steering over spectating.** This is a control center, not a read-only monitor — every screen should surface the next action (create, approve, redirect, retry), not just data.
+2. **Transparency builds trust.** Show what agents actually did: full session logs, costs, context, memory. Never dress agent work up as magic.
+3. **Earned familiarity.** Linear/Vercel-grade conventions — consistent primitives, restrained color, standard affordances. The tool disappears into the task.
+4. **Legible beyond developers.** Operators may not be engineers. Plain language, clear statuses, and explanations win over jargon and raw payloads.
+5. **Calm under load.** Dozens of agents and tasks in flight must still read as an ordered fleet — hierarchy and status semantics absorb the volume.
+
+## Accessibility & Inclusion
+
+WCAG 2.1 AA: ≥4.5:1 body-text contrast in both light and dark themes, full keyboard navigability, and `prefers-reduced-motion` respected across the app.


### PR DESCRIPTION
## Summary
- Adds captured design context for the dashboard (`apps/ui`) via `/impeccable init`:
  - **PRODUCT.md** — register `product`/`web`; users = swarm operators (not only devs); purpose = control center; positioning aligned with the landing repo; personality *calm, capable, transparent*; anti-references (enterprise admin sprawl, AI-startup gradient slop); WCAG 2.1 AA target.
  - **DESIGN.md** — scan-mode capture of the real visual system ("Mission Control" north star, Hive Amber one-voice rule, token-only rule, status/action token vocabulary, flat border-first elevation, component doctrine).
  - **`.impeccable/design.json`** — machine-readable sidecar (tonal ramps, motion/shadow tokens, component snippets).
  - **`.impeccable/live/config.json`** — live-mode config (Vite SPA shell, CSP checked: none).
  - **CLAUDE.md** — short Design Context pointer section.
- Adds the first `/impeccable critique` baseline snapshot for the home page (`28/40`, 3×P1: lying terminal empty state, no primary steering action, no status-color legend) under `.impeccable/critique/` — the backlog for the upcoming polish/harden passes.

## Notes
- **Docs/config only — no UI code changes**, so no qa-use session/screenshots (nothing rendered changed).
- Verified: root `bun run lint` clean, `apps/ui` `bun run lint` clean + `bunx tsc -b` clean.