### PR TITLE
feat: extension system — event subscriptions (Layer 1) + script-backed tools (Layer 3)

### DIFF
--- a/.non-audit-tables
+++ b/.non-audit-tables
@@ -25,6 +25,8 @@ script_embeddings
 seed_state
 session_costs
 session_logs
+subscription_deliveries
+swarm_events
 task_context_snapshots
 tracker_agent_mapping
 tracker_sync

--- a/MCP.md
+++ b/MCP.md
@@ -1478,6 +1478,19 @@ Posts a message to a channel for cross-agent communication.
 | `replyTo` | `uuid` | No | - | Message ID to reply to (for threading). |
 | `mentions` | `array` | No | - | Agent IDs to @mention (they'll see it in unread). |
 
+### script-tools
+
+**Manage Script-Backed Tools**
+
+Publish a global catalog script as an agent-visible MCP tool (lead only), unpublish, enable/disable, or list. Published tools become callable on the next MCP session; the script receives the tool call arguments as its args.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `action` | `publish \| unpublish \| enable \| disable \| list` | Yes | - | - |
+| `toolName` | `string` | No | - | Tool name (^[a-z][a-z0-9_-]{2,63}$). Required for all actions except 'list'. Must not collide with a built-in tool. |
+| `scriptName` | `string` | No | - | Global catalog script to back the tool. Required for 'publish'. |
+| `description` | `string` | No | - | Tool description shown to agents. Required for 'publish'. |
+
 ### read-messages
 
 **Read Messages**

--- a/MCP.md
+++ b/MCP.md
@@ -1421,32 +1421,6 @@ List KV entries in the resolved namespace (optionally filtered by key prefix). E
 
 *Tools not assigned to a capability group*
 
-### create_metric
-
-**Create or update a metric**
-
-Stores a config-driven dashboard backed by read-only SQL widget queries. Calls are upsert-by-(agent, slug), mirroring create_page: same slug updates the existing dashboard and snapshots the prior JSON definition.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `title` | `string` | Yes | - | Human-readable dashboard title. |
-| `slug` | `string` | No | - | URL-safe slug. Defaults to the kebab-cased title. |
-| `description` | `string` | No | - | Short description shown in the dashboard. |
-| `definition` | `unknown` | Yes | - | Dashboard JSON definition: a list of widgets, each with SELECT/WITH SQL and viz config. |
-
-### post-message
-
-**Post Message**
-
-Posts a message to a channel for cross-agent communication.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `channel` | `string` | No | "general" | Channel name (default: 'general'). |
-| `content` | `string` | Yes | - | Message content. |
-| `replyTo` | `uuid` | No | - | Message ID to reply to (for threading). |
-| `mentions` | `array` | No | - | Agent IDs to @mention (they'll see it in unread). |
-
 ### launch-script-run
 
 **Launch Script Run**
@@ -1478,6 +1452,32 @@ Posts a message to a channel for cross-agent communication.
 | `limit` | `number` | No | 50 | Maximum runs to return. |
 | `offset` | `number` | No | 0 | Pagination offset. |
 
+### create_metric
+
+**Create or update a metric**
+
+Stores a config-driven dashboard backed by read-only SQL widget queries. Calls are upsert-by-(agent, slug), mirroring create_page: same slug updates the existing dashboard and snapshots the prior JSON definition.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `title` | `string` | Yes | - | Human-readable dashboard title. |
+| `slug` | `string` | No | - | URL-safe slug. Defaults to the kebab-cased title. |
+| `description` | `string` | No | - | Short description shown in the dashboard. |
+| `definition` | `unknown` | Yes | - | Dashboard JSON definition: a list of widgets, each with SELECT/WITH SQL and viz config. |
+
+### post-message
+
+**Post Message**
+
+Posts a message to a channel for cross-agent communication.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `channel` | `string` | No | "general" | Channel name (default: 'general'). |
+| `content` | `string` | Yes | - | Message content. |
+| `replyTo` | `uuid` | No | - | Message ID to reply to (for threading). |
+| `mentions` | `array` | No | - | Agent IDs to @mention (they'll see it in unread). |
+
 ### read-messages
 
 **Read Messages**
@@ -1493,199 +1493,6 @@ Reads messages from a channel. If no channel is specified, returns unread messag
 | `mentionsOnly` | `boolean` | No | false | Only return messages that @mention you. |
 | `markAsRead` | `boolean` | No | true | Update your read position after fetching (default: true). |
 
-### tracker-map-agent
-
-**Map Agent to Tracker User**
-
-Map a swarm agent to an external tracker user (for assignment sync).
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `provider` | `string` | Yes | - | Tracker provider (e.g. 'linear', 'jira') |
-| `agentId` | `string` | Yes | - | The swarm agent ID |
-| `externalUserId` | `string` | Yes | - | The external user ID in the tracker |
-| `agentName` | `string` | Yes | - | Display name for the agent mapping |
-
-### tracker-unlink
-
-**Unlink Tracker Sync**
-
-Remove a tracker sync mapping by ID.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `syncId` | `string` | Yes | - | The tracker sync mapping ID to remove |
-
-### tracker-status
-
-**Tracker Status**
-
-Show all connected trackers and their OAuth status (token expiry, workspace info). Proactively refreshes near-expiry tokens before reporting, so the returned `tokenExpiresAt` reflects the row that subsequent API calls (and direct DB reads) will see.
-
-*No parameters*
-
-### tracker-link-task
-
-**Link Task to Tracker**
-
-Link a swarm task to an external tracker issue.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `provider` | `string` | Yes | - | Tracker provider (e.g. 'linear', 'jira') |
-| `swarmTaskId` | `string` | Yes | - | The swarm task ID to link |
-| `externalId` | `string` | Yes | - | The external issue ID in the tracker |
-| `externalIdentifier` | `string` | No | - | Human-readable identifier (e.g. 'ENG-42') |
-| `externalUrl` | `string` | No | - | URL to the external issue |
-
-### tracker-sync-status
-
-**Tracker Sync Status**
-
-Show all tracker sync mappings with their state.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `provider` | `string` | No | - | Filter by provider (e.g. 'linear', 'jira') |
-| `entityType` | `task` | No | - | Filter by entity type |
-
-### skill-install
-
-**Install Skill**
-
-Install/assign a skill to an agent. Leads can install for other agents.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `skillId` | `string` | Yes | - | ID of the skill to install |
-| `agentId` | `string` | No | - | Target agent (default: calling agent). Lead can install for others. |
-
-### skill-uninstall
-
-**Uninstall Skill**
-
-Remove a skill from an agent.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `skillId` | `string` | Yes | - | ID of the skill to uninstall |
-| `agentId` | `string` | No | - | Target agent (default: calling agent) |
-
-### skill-publish
-
-**Publish Skill**
-
-Publish a personal skill to swarm scope. Creates an approval task for the lead agent.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `skillId` | `string` | Yes | - | ID of the personal skill to publish |
-
-### skill-delete
-
-**Delete Skill**
-
-Delete a skill. Only the owning agent or lead can delete.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `skillId` | `string` | Yes | - | ID of the skill to delete |
-
-### skill-sync-remote
-
-**Sync Remote Skills**
-
-Check and update remote skills from their GitHub sources. Compares content and updates if changed.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `skillId` | `string` | No | - | Sync a specific skill, or all remote skills if omitted |
-| `force` | `boolean` | No | false | Force re-fetch even if hash matches |
-
-### skill-install-remote
-
-**Install Remote Skill**
-
-Fetch and install a remote skill from a GitHub repository. Fetches SKILL.md via GitHub raw content API.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `sourceRepo` | `string` | Yes | - | GitHub repo (e.g. "vercel-labs/skills") |
-| `sourcePath` | `string` | No | - | Path within repo (e.g. "skills/nextjs") |
-| `scope` | `global \| swarm` | No | "global" | Scope for the installed skill |
-| `isComplex` | `boolean` | No | false | If true, registers for npx install (metadata only) |
-
-### skill-get
-
-**Get Skill**
-
-Get full skill content by ID or name. Name resolution checks agent scope first, then swarm, then global.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `skillId` | `string` | No | - | Skill ID |
-| `name` | `string` | No | - | Skill name (resolved with precedence) |
-
-### skill-get-file
-
-**Get Skill File**
-
-Fetch a bundled reference file from a complex skill by skillId and relative path. Use this when the file is not available on disk.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `skillId` | `string` | Yes | - | Skill ID |
-| `path` | `string` | Yes | - | Relative path, e.g. references/animations.md |
-
-### skill-search
-
-**Search Skills**
-
-Search skills by keyword (name and description).
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `query` | `string` | Yes | - | Search query |
-| `limit` | `number` | No | 20 | - |
-
-### skill-update
-
-**Update Skill**
-
-Update a skill's content or settings. Re-parses frontmatter if content changes.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `skillId` | `string` | No | - | Skill ID to update |
-| `content` | `string` | No | - | New SKILL.md content (re-parses frontmatter) |
-| `isEnabled` | `boolean` | No | - | Toggle enabled/disabled |
-| `scope` | `agent \| swarm` | No | - | Scope: agent (personal) or swarm (shared). Only leads can promote a skill to swarm scope (used by the skill-approval flow). |
-
-### skill-list
-
-**List Skills**
-
-List available skills with optional filters.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `type` | `remote \| personal` | No | - | Filter by type |
-| `scope` | `global \| swarm \| agent` | No | - | Filter by scope |
-| `agentId` | `string` | No | - | Filter by owning agent |
-| `installedOnly` | `boolean` | No | - | Only show skills installed for calling agent |
-| `includeContent` | `boolean` | No | false | Include full content (default false) |
-
-### skill-create
-
-**Create Skill**
-
-Create a personal skill from SKILL.md content. Parses frontmatter for name, description, and metadata.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `content` | `string` | Yes | - | Full SKILL.md content (YAML frontmatter + markdown body) |
-| `scope` | `agent \| swarm` | No | "agent" | Scope: agent (personal) or swarm (shared). Default: agent |
-
 ### mcp-server-get
 
 **Get MCP Server**
@@ -1696,6 +1503,17 @@ Get MCP server details by ID or name. Name resolution uses scope cascade: agent 
 |-----------|------|----------|---------|-------------|
 | `id` | `string` | No | - | MCP server ID |
 | `name` | `string` | No | - | MCP server name (resolved with scope cascade) |
+
+### mcp-server-uninstall
+
+**Uninstall MCP Server**
+
+Uninstall an MCP server from an agent. Self-uninstall is always allowed; cross-agent requires lead.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `mcpServerId` | `string` | Yes | - | ID of the MCP server to uninstall |
+| `agentId` | `string` | No | - | Target agent (default: calling agent) |
 
 ### mcp-server-create
 
@@ -1728,29 +1546,15 @@ Install an MCP server for an agent. Self-install is always allowed; cross-agent 
 | `mcpServerId` | `string` | Yes | - | ID of the MCP server to install |
 | `agentId` | `string` | No | - | Target agent (default: calling agent). Lead can install for others. |
 
-### mcp-server-uninstall
+### mcp-server-delete
 
-**Uninstall MCP Server**
+**Delete MCP Server**
 
-Uninstall an MCP server from an agent. Self-uninstall is always allowed; cross-agent requires lead.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `mcpServerId` | `string` | Yes | - | ID of the MCP server to uninstall |
-| `agentId` | `string` | No | - | Target agent (default: calling agent) |
-
-### mcp-server-list
-
-**List MCP Servers**
-
-List MCP servers with optional filters. Use installedOnly to see servers installed for the calling agent.
+Delete an MCP server definition. Only the owning agent or lead can delete.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `scope` | `global \| swarm \| agent` | No | - | Filter by scope |
-| `transport` | `stdio \| http \| sse` | No | - | Filter by transport type |
-| `search` | `string` | No | - | Search by name or description |
-| `installedOnly` | `boolean` | No | - | Only show servers installed for the calling agent |
+| `id` | `string` | Yes | - | ID of the MCP server to delete |
 
 ### mcp-server-update
 
@@ -1773,13 +1577,248 @@ Update an MCP server's configuration. Only the owner or lead can update.
 | `extraAuthorizeParams` | `string` | No | - | JSON object string of extra OAuth authorize-request params, e.g. {"access_type":"offline","prompt":"consent"} |
 | `isEnabled` | `boolean` | No | - | Toggle enabled/disabled |
 
-### mcp-server-delete
+### mcp-server-list
 
-**Delete MCP Server**
+**List MCP Servers**
 
-Delete an MCP server definition. Only the owning agent or lead can delete.
+List MCP servers with optional filters. Use installedOnly to see servers installed for the calling agent.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `id` | `string` | Yes | - | ID of the MCP server to delete |
+| `scope` | `global \| swarm \| agent` | No | - | Filter by scope |
+| `transport` | `stdio \| http \| sse` | No | - | Filter by transport type |
+| `search` | `string` | No | - | Search by name or description |
+| `installedOnly` | `boolean` | No | - | Only show servers installed for the calling agent |
+
+### skill-search
+
+**Search Skills**
+
+Search skills by keyword (name and description).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | `string` | Yes | - | Search query |
+| `limit` | `number` | No | 20 | - |
+
+### skill-install
+
+**Install Skill**
+
+Install/assign a skill to an agent. Leads can install for other agents.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `skillId` | `string` | Yes | - | ID of the skill to install |
+| `agentId` | `string` | No | - | Target agent (default: calling agent). Lead can install for others. |
+
+### skill-install-remote
+
+**Install Remote Skill**
+
+Fetch and install a remote skill from a GitHub repository. Fetches SKILL.md via GitHub raw content API.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sourceRepo` | `string` | Yes | - | GitHub repo (e.g. "vercel-labs/skills") |
+| `sourcePath` | `string` | No | - | Path within repo (e.g. "skills/nextjs") |
+| `scope` | `global \| swarm` | No | "global" | Scope for the installed skill |
+| `isComplex` | `boolean` | No | false | If true, registers for npx install (metadata only) |
+
+### skill-list
+
+**List Skills**
+
+List available skills with optional filters.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `type` | `remote \| personal` | No | - | Filter by type |
+| `scope` | `global \| swarm \| agent` | No | - | Filter by scope |
+| `agentId` | `string` | No | - | Filter by owning agent |
+| `installedOnly` | `boolean` | No | - | Only show skills installed for calling agent |
+| `includeContent` | `boolean` | No | false | Include full content (default false) |
+
+### skill-sync-remote
+
+**Sync Remote Skills**
+
+Check and update remote skills from their GitHub sources. Compares content and updates if changed.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `skillId` | `string` | No | - | Sync a specific skill, or all remote skills if omitted |
+| `force` | `boolean` | No | false | Force re-fetch even if hash matches |
+
+### skill-publish
+
+**Publish Skill**
+
+Publish a personal skill to swarm scope. Creates an approval task for the lead agent.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `skillId` | `string` | Yes | - | ID of the personal skill to publish |
+
+### skill-get
+
+**Get Skill**
+
+Get full skill content by ID or name. Name resolution checks agent scope first, then swarm, then global.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `skillId` | `string` | No | - | Skill ID |
+| `name` | `string` | No | - | Skill name (resolved with precedence) |
+
+### skill-update
+
+**Update Skill**
+
+Update a skill's content or settings. Re-parses frontmatter if content changes.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `skillId` | `string` | No | - | Skill ID to update |
+| `content` | `string` | No | - | New SKILL.md content (re-parses frontmatter) |
+| `isEnabled` | `boolean` | No | - | Toggle enabled/disabled |
+| `scope` | `agent \| swarm` | No | - | Scope: agent (personal) or swarm (shared). Only leads can promote a skill to swarm scope (used by the skill-approval flow). |
+
+### skill-delete
+
+**Delete Skill**
+
+Delete a skill. Only the owning agent or lead can delete.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `skillId` | `string` | Yes | - | ID of the skill to delete |
+
+### skill-create
+
+**Create Skill**
+
+Create a personal skill from SKILL.md content. Parses frontmatter for name, description, and metadata.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `content` | `string` | Yes | - | Full SKILL.md content (YAML frontmatter + markdown body) |
+| `scope` | `agent \| swarm` | No | "agent" | Scope: agent (personal) or swarm (shared). Default: agent |
+
+### skill-get-file
+
+**Get Skill File**
+
+Fetch a bundled reference file from a complex skill by skillId and relative path. Use this when the file is not available on disk.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `skillId` | `string` | Yes | - | Skill ID |
+| `path` | `string` | Yes | - | Relative path, e.g. references/animations.md |
+
+### skill-uninstall
+
+**Uninstall Skill**
+
+Remove a skill from an agent.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `skillId` | `string` | Yes | - | ID of the skill to uninstall |
+| `agentId` | `string` | No | - | Target agent (default: calling agent) |
+
+### list-subscriptions
+
+**List Event Subscriptions**
+
+List event subscriptions (event pattern → script/workflow bindings), optionally with recent delivery attempts per subscription.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabledOnly` | `boolean` | No | false | - |
+| `includeDeliveries` | `boolean` | No | false | Include the 5 most recent deliveries per subscription |
+
+### delete-subscription
+
+**Delete Event Subscription**
+
+Delete an event subscription by name. Pending deliveries are not executed.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | `string` | Yes | - | Subscription name to delete |
+
+### create-subscription
+
+**Create Event Subscription**
+
+Subscribe a catalog script or workflow to swarm events (task lifecycle, GitHub/GitLab webhooks, approvals, …). When a matching event fires, the target runs with the event payload. Delivery is at-least-once with retries.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | `string` | Yes | - | Unique name for the subscription (e.g., 'triage-failed-tasks') |
+| `description` | `string` | No | - | Human-readable description |
+| `eventPattern` | `string` | Yes | - | Glob over dot-separated event names: '*' matches one segment, '**' (last segment only) matches the rest. Examples: 'task.completed', 'task.*', 'github.**'. |
+| `filter` | `unknown` | No | - | Optional payload filter (wait-node filter language): object of dot-path → expected value for deep-equal matching, or a string expression over the event payload. |
+| `targetType` | `unknown` | Yes | - | What to run when the event fires: 'script' (global catalog script, receives the event as args.event) or 'workflow' (triggered with { event, subscriptionId } as trigger data). |
+| `scriptName` | `string` | No | - | Catalog script name (global scope). Required when targetType is 'script'. |
+| `scriptArgs` | `object` | No | - | Extra JSON args merged into the script invocation (event wins on key 'event'). |
+| `workflowId` | `string` | No | - | Workflow ID to trigger. Required when targetType is 'workflow'. |
+| `enabled` | `boolean` | No | true | - |
+
+### tracker-status
+
+**Tracker Status**
+
+Show all connected trackers and their OAuth status (token expiry, workspace info). Proactively refreshes near-expiry tokens before reporting, so the returned `tokenExpiresAt` reflects the row that subsequent API calls (and direct DB reads) will see.
+
+*No parameters*
+
+### tracker-map-agent
+
+**Map Agent to Tracker User**
+
+Map a swarm agent to an external tracker user (for assignment sync).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `provider` | `string` | Yes | - | Tracker provider (e.g. 'linear', 'jira') |
+| `agentId` | `string` | Yes | - | The swarm agent ID |
+| `externalUserId` | `string` | Yes | - | The external user ID in the tracker |
+| `agentName` | `string` | Yes | - | Display name for the agent mapping |
+
+### tracker-link-task
+
+**Link Task to Tracker**
+
+Link a swarm task to an external tracker issue.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `provider` | `string` | Yes | - | Tracker provider (e.g. 'linear', 'jira') |
+| `swarmTaskId` | `string` | Yes | - | The swarm task ID to link |
+| `externalId` | `string` | Yes | - | The external issue ID in the tracker |
+| `externalIdentifier` | `string` | No | - | Human-readable identifier (e.g. 'ENG-42') |
+| `externalUrl` | `string` | No | - | URL to the external issue |
+
+### tracker-unlink
+
+**Unlink Tracker Sync**
+
+Remove a tracker sync mapping by ID.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `syncId` | `string` | Yes | - | The tracker sync mapping ID to remove |
+
+### tracker-sync-status
+
+**Tracker Sync Status**
+
+Show all tracker sync mappings with their state.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `provider` | `string` | No | - | Filter by provider (e.g. 'linear', 'jira') |
+| `entityType` | `task` | No | - | Filter by entity type |
 

--- a/MCP.md
+++ b/MCP.md
@@ -1727,6 +1727,21 @@ Remove a skill from an agent.
 | `skillId` | `string` | Yes | - | ID of the skill to uninstall |
 | `agentId` | `string` | No | - | Target agent (default: calling agent) |
 
+### patch-subscription
+
+**Patch Event Subscription**
+
+Update fields of an event subscription: pause/resume (enabled), description, eventPattern, filter, or scriptArgs. Target (script/workflow) is immutable — delete and recreate to retarget.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | `string` | Yes | - | Subscription name to patch |
+| `description` | `string` | No | - | - |
+| `eventPattern` | `string` | No | - | - |
+| `filter` | `unknown` | No | - | New payload filter; pass null to clear |
+| `scriptArgs` | `unknown` | No | - | New extra script args; pass null to clear |
+| `enabled` | `boolean` | No | - | false pauses the subscription |
+
 ### list-subscriptions
 
 **List Event Subscriptions**

--- a/runbooks/workflows.md
+++ b/runbooks/workflows.md
@@ -265,16 +265,19 @@ For `task.completed` specifically, the canonical payload shape lives in `src/be/
 
 ### What's NOT yet on the bus
 
+Now on the bus (in addition to the table above): Slack messages (`slack.message`, `src/slack/handlers.ts`), Linear webhooks (`linear.<type>.<action>`, e.g. `linear.issue.update` — `src/linear/webhook.ts`), and Jira webhooks (`jira.<event>` with the `jira:` prefix stripped, e.g. `jira.issue_updated` — `src/jira/webhook.ts`).
+
 The following sources do **not** currently emit on `workflowEventBus`. Hooking each one in is a one-line `workflowEventBus.emit(name, payload)` follow-up in the relevant handler — tracked as separate plans:
 
-- Slack messages (`src/slack/`)
-- Linear webhooks (`src/linear/`, `src/http/trackers/linear.ts`)
-- Jira webhooks (`src/jira/`, `src/http/trackers/jira.ts`)
 - Sentry alerts
 - Stripe events
 - Claude-managed callbacks
 
 Until those land, fire signals manually via the HTTP endpoints above.
+
+### Event subscriptions
+
+Beyond in-run `wait` nodes, standing bindings live in the `subscriptions` table (`create-subscription` / `list-subscriptions` / `patch-subscription` / `delete-subscription` MCP tools, or `swarm.subscription_*` from scripts): an event-name glob (`*` = one segment, `**` = rest) plus optional wait-filter-language payload filter, targeting a global catalog script (event injected as `args.event`) or a workflow (trigger data `{ event, subscriptionId, subscriptionName }`, `triggerType: "subscription"`). Delivery is at-least-once via the `subscription_deliveries` outbox (3 attempts, journal pruned after 14/30 days). See `src/subscriptions/`.
 
 ### Filters (event mode)
 

--- a/scripts/check-rbac-coverage.ts
+++ b/scripts/check-rbac-coverage.ts
@@ -58,6 +58,8 @@ const PIN_REASON =
   "no hard authorization gate at the slice-1 pin (plan Appendix A) — open to all authenticated agents";
 
 const UNGATED_TOOL_FILES: Record<string, string> = {
+  "src/tools/subscriptions/list-subscriptions.ts":
+    "read-only listing of event subscriptions — no mutation, mirrors list-schedules posture",
   "src/tools/create-channel.ts": PIN_REASON,
   "src/tools/create-metric.ts": PIN_REASON,
   "src/tools/create-page.ts": PIN_REASON,

--- a/scripts/check-rbac-coverage.ts
+++ b/scripts/check-rbac-coverage.ts
@@ -60,6 +60,8 @@ const PIN_REASON =
 const UNGATED_TOOL_FILES: Record<string, string> = {
   "src/tools/subscriptions/list-subscriptions.ts":
     "read-only listing of event subscriptions — no mutation, mirrors list-schedules posture",
+  "src/tools/dynamic-script-tools.ts":
+    "dynamic registration of published script-backed tools — publishing is lead-gated via tool.publish in script-tools.ts; execution is open to agents by design (scripts run sandboxed)",
   "src/tools/create-channel.ts": PIN_REASON,
   "src/tools/create-metric.ts": PIN_REASON,
   "src/tools/create-page.ts": PIN_REASON,

--- a/scripts/check-sdk-tool-registration.ts
+++ b/scripts/check-sdk-tool-registration.ts
@@ -31,6 +31,7 @@ const EXCLUDED_TOOLS: Record<string, string> = {
   "skill-install-remote": "admin-only remote skill management",
   "skill-sync-remote": "admin-only remote skill management",
   "swarm_x": "external command router — dispatches to third-party services",
+  "script-tools": "script-backed tool publishing — lead-only admin surface; scripts already invoke scripts directly via script_run",
 };
 
 const sdkToolNames = new Set(Object.values(SDK_TOOL_NAME_MAP));

--- a/scripts/check-sdk-tool-registration.ts
+++ b/scripts/check-sdk-tool-registration.ts
@@ -31,9 +31,6 @@ const EXCLUDED_TOOLS: Record<string, string> = {
   "skill-install-remote": "admin-only remote skill management",
   "skill-sync-remote": "admin-only remote skill management",
   "swarm_x": "external command router — dispatches to third-party services",
-  "create-subscription": "extension-system spike — SDK exposure deferred until subscriptions design settles",
-  "list-subscriptions": "extension-system spike — SDK exposure deferred until subscriptions design settles",
-  "delete-subscription": "extension-system spike — SDK exposure deferred until subscriptions design settles",
 };
 
 const sdkToolNames = new Set(Object.values(SDK_TOOL_NAME_MAP));

--- a/scripts/check-sdk-tool-registration.ts
+++ b/scripts/check-sdk-tool-registration.ts
@@ -31,6 +31,9 @@ const EXCLUDED_TOOLS: Record<string, string> = {
   "skill-install-remote": "admin-only remote skill management",
   "skill-sync-remote": "admin-only remote skill management",
   "swarm_x": "external command router — dispatches to third-party services",
+  "create-subscription": "extension-system spike — SDK exposure deferred until subscriptions design settles",
+  "list-subscriptions": "extension-system spike — SDK exposure deferred until subscriptions design settles",
+  "delete-subscription": "extension-system spike — SDK exposure deferred until subscriptions design settles",
 };
 
 const sdkToolNames = new Set(Object.values(SDK_TOOL_NAME_MAP));

--- a/scripts/spike-script-spawn-latency.ts
+++ b/scripts/spike-script-spawn-latency.ts
@@ -1,0 +1,39 @@
+/**
+ * Extension-system spike: measure end-to-end latency of a minimal script
+ * through the scripts-runtime sandbox (Bun.spawn + ulimit preamble + stdin
+ * config + eval harness). Answers the research doc's open question of whether
+ * a synchronous `tool.before_call` hook can afford a per-call sandbox spawn.
+ *
+ * Run: AGENT_SWARM_API_KEY=123123 bun scripts/spike-script-spawn-latency.ts
+ */
+import { runScript } from "../src/scripts-runtime/loader";
+
+const WARMUP = 2;
+const RUNS = 10;
+const source = `export default async function run() { return { ok: true }; }`;
+
+async function once(): Promise<number> {
+  const start = performance.now();
+  const out = await runScript({
+    source,
+    args: {},
+    fsMode: "none",
+    agentId: "spike-latency",
+    timeoutMs: 10_000,
+  });
+  const elapsed = performance.now() - start;
+  if (out.exitCode !== 0 || out.error) {
+    throw new Error(`script failed: exit=${out.exitCode} err=${out.error} stderr=${out.stderr}`);
+  }
+  return elapsed;
+}
+
+for (let i = 0; i < WARMUP; i++) await once();
+
+const samples: number[] = [];
+for (let i = 0; i < RUNS; i++) samples.push(await once());
+samples.sort((a, b) => a - b);
+
+const p = (q: number) => samples[Math.min(samples.length - 1, Math.floor(q * samples.length))];
+console.log(`scripts-runtime spawn latency over ${RUNS} runs (after ${WARMUP} warmup):`);
+console.log(`  min=${samples[0]?.toFixed(0)}ms p50=${p(0.5)?.toFixed(0)}ms p95=${p(0.95)?.toFixed(0)}ms max=${samples[samples.length - 1]?.toFixed(0)}ms`);

--- a/src/be/migrations/117_swarm_events_subscriptions.sql
+++ b/src/be/migrations/117_swarm_events_subscriptions.sql
@@ -27,6 +27,8 @@ CREATE TABLE IF NOT EXISTS subscriptions (
     workflowId TEXT,
     enabled INTEGER NOT NULL DEFAULT 1,
     createdByAgentId TEXT,
+    created_by TEXT,
+    updated_by TEXT,
     createdAt TEXT NOT NULL,
     updatedAt TEXT NOT NULL,
     CHECK (targetType != 'script' OR scriptName IS NOT NULL),

--- a/src/be/migrations/117_swarm_events_subscriptions.sql
+++ b/src/be/migrations/117_swarm_events_subscriptions.sql
@@ -1,0 +1,55 @@
+-- 117_swarm_events_subscriptions.sql
+-- SPIKE (extension system, Layer 1): durable event journal + subscriptions +
+-- delivery outbox. Events emitted on the workflow event bus are persisted to
+-- swarm_events; enabled subscriptions matching the event name (glob) and
+-- optional filter enqueue a subscription_deliveries row; a poller executes
+-- the subscription target (catalog script or workflow) at-least-once.
+
+CREATE TABLE IF NOT EXISTS swarm_events (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    data TEXT,
+    emittedAt TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_swarm_events_name_emitted
+    ON swarm_events(name, emittedAt);
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT,
+    eventPattern TEXT NOT NULL,
+    filter TEXT,
+    targetType TEXT NOT NULL CHECK (targetType IN ('script', 'workflow')),
+    scriptName TEXT,
+    scriptArgs TEXT,
+    workflowId TEXT,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    createdByAgentId TEXT,
+    createdAt TEXT NOT NULL,
+    updatedAt TEXT NOT NULL,
+    CHECK (targetType != 'script' OR scriptName IS NOT NULL),
+    CHECK (targetType != 'workflow' OR workflowId IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_enabled
+    ON subscriptions(enabled);
+
+CREATE TABLE IF NOT EXISTS subscription_deliveries (
+    id TEXT PRIMARY KEY,
+    subscriptionId TEXT NOT NULL,
+    eventId TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'running', 'succeeded', 'failed')),
+    attempts INTEGER NOT NULL DEFAULT 0,
+    claimedAt TEXT,
+    finishedAt TEXT,
+    error TEXT,
+    result TEXT,
+    createdAt TEXT NOT NULL,
+    UNIQUE (subscriptionId, eventId)
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscription_deliveries_status
+    ON subscription_deliveries(status, createdAt);

--- a/src/be/migrations/118_script_tools.sql
+++ b/src/be/migrations/118_script_tools.sql
@@ -10,6 +10,8 @@ CREATE TABLE IF NOT EXISTS script_tools (
     description TEXT NOT NULL,
     enabled INTEGER NOT NULL DEFAULT 1,
     createdByAgentId TEXT,
+    created_by TEXT,
+    updated_by TEXT,
     createdAt TEXT NOT NULL,
     updatedAt TEXT NOT NULL
 );

--- a/src/be/migrations/118_script_tools.sql
+++ b/src/be/migrations/118_script_tools.sql
@@ -1,0 +1,17 @@
+-- 118_script_tools.sql
+-- Extension system, Layer 3: publish a global catalog script as an
+-- agent-visible MCP tool. Rows are read at MCP server creation time
+-- (per-session), so newly published tools appear on the next session.
+
+CREATE TABLE IF NOT EXISTS script_tools (
+    id TEXT PRIMARY KEY,
+    toolName TEXT NOT NULL UNIQUE,
+    scriptName TEXT NOT NULL,
+    description TEXT NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    createdByAgentId TEXT,
+    createdAt TEXT NOT NULL,
+    updatedAt TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_script_tools_enabled ON script_tools(enabled);

--- a/src/be/script-tools-db.ts
+++ b/src/be/script-tools-db.ts
@@ -1,0 +1,84 @@
+import type { ScriptTool } from "../types";
+import { getDb } from "./db";
+
+interface ScriptToolRow {
+  id: string;
+  toolName: string;
+  scriptName: string;
+  description: string;
+  enabled: number;
+  createdByAgentId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function rowToScriptTool(row: ScriptToolRow): ScriptTool {
+  return {
+    id: row.id,
+    toolName: row.toolName,
+    scriptName: row.scriptName,
+    description: row.description,
+    enabled: row.enabled === 1,
+    createdByAgentId: row.createdByAgentId ?? undefined,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function createScriptTool(args: {
+  toolName: string;
+  scriptName: string;
+  description: string;
+  enabled?: boolean;
+  createdByAgentId?: string;
+}): ScriptTool {
+  const now = new Date().toISOString();
+  const id = crypto.randomUUID();
+  getDb()
+    .prepare(
+      `INSERT INTO script_tools
+         (id, toolName, scriptName, description, enabled, createdByAgentId, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      args.toolName,
+      args.scriptName,
+      args.description,
+      args.enabled === false ? 0 : 1,
+      args.createdByAgentId ?? null,
+      now,
+      now,
+    );
+  const created = getScriptToolByName(args.toolName);
+  if (!created) throw new Error("Failed to create script tool");
+  return created;
+}
+
+export function getScriptToolByName(toolName: string): ScriptTool | null {
+  const row = getDb()
+    .prepare("SELECT * FROM script_tools WHERE toolName = ?")
+    .get(toolName) as ScriptToolRow | null;
+  return row ? rowToScriptTool(row) : null;
+}
+
+export function listScriptTools(args?: { enabledOnly?: boolean }): ScriptTool[] {
+  const rows = (
+    args?.enabledOnly
+      ? getDb().prepare("SELECT * FROM script_tools WHERE enabled = 1 ORDER BY toolName")
+      : getDb().prepare("SELECT * FROM script_tools ORDER BY toolName")
+  ).all() as ScriptToolRow[];
+  return rows.map(rowToScriptTool);
+}
+
+export function deleteScriptTool(toolName: string): boolean {
+  const res = getDb().prepare("DELETE FROM script_tools WHERE toolName = ?").run(toolName);
+  return res.changes > 0;
+}
+
+export function setScriptToolEnabled(toolName: string, enabled: boolean): boolean {
+  const res = getDb()
+    .prepare("UPDATE script_tools SET enabled = ?, updatedAt = ? WHERE toolName = ?")
+    .run(enabled ? 1 : 0, new Date().toISOString(), toolName);
+  return res.changes > 0;
+}

--- a/src/be/script-tools-db.ts
+++ b/src/be/script-tools-db.ts
@@ -8,6 +8,8 @@ interface ScriptToolRow {
   description: string;
   enabled: number;
   createdByAgentId: string | null;
+  created_by: string | null;
+  updated_by: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -20,6 +22,8 @@ function rowToScriptTool(row: ScriptToolRow): ScriptTool {
     description: row.description,
     enabled: row.enabled === 1,
     createdByAgentId: row.createdByAgentId ?? undefined,
+    createdBy: row.created_by ?? undefined,
+    updatedBy: row.updated_by ?? undefined,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -31,14 +35,15 @@ export function createScriptTool(args: {
   description: string;
   enabled?: boolean;
   createdByAgentId?: string;
+  createdBy?: string;
 }): ScriptTool {
   const now = new Date().toISOString();
   const id = crypto.randomUUID();
   getDb()
     .prepare(
       `INSERT INTO script_tools
-         (id, toolName, scriptName, description, enabled, createdByAgentId, createdAt, updatedAt)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+         (id, toolName, scriptName, description, enabled, createdByAgentId, created_by, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       id,
@@ -47,6 +52,7 @@ export function createScriptTool(args: {
       args.description,
       args.enabled === false ? 0 : 1,
       args.createdByAgentId ?? null,
+      args.createdBy ?? null,
       now,
       now,
     );
@@ -76,9 +82,15 @@ export function deleteScriptTool(toolName: string): boolean {
   return res.changes > 0;
 }
 
-export function setScriptToolEnabled(toolName: string, enabled: boolean): boolean {
+export function setScriptToolEnabled(
+  toolName: string,
+  enabled: boolean,
+  updatedBy?: string,
+): boolean {
   const res = getDb()
-    .prepare("UPDATE script_tools SET enabled = ?, updatedAt = ? WHERE toolName = ?")
-    .run(enabled ? 1 : 0, new Date().toISOString(), toolName);
+    .prepare(
+      "UPDATE script_tools SET enabled = ?, updated_by = COALESCE(?, updated_by), updatedAt = ? WHERE toolName = ?",
+    )
+    .run(enabled ? 1 : 0, updatedBy ?? null, new Date().toISOString(), toolName);
   return res.changes > 0;
 }

--- a/src/be/scripts/run-global.ts
+++ b/src/be/scripts/run-global.ts
@@ -1,0 +1,44 @@
+import { runScript } from "../../scripts-runtime/loader";
+import {
+  getScriptApiConnectionDescriptors,
+  getScriptMcpConnectionDescriptors,
+} from "../script-connections";
+import { buildScriptCredentialBindings } from "../script-credential-broker";
+import { getScript } from "./db";
+
+/**
+ * Run a global catalog script server-side with the standard credential/
+ * connection wiring. Shared by the subscription dispatcher and script-backed
+ * tools (the scheduler has its own older copy of this pattern).
+ * Throws on non-zero exit / runtime error.
+ */
+export async function runGlobalScriptByName(input: {
+  scriptName: string;
+  args: unknown;
+  agentId: string;
+  timeoutMs?: number;
+}): Promise<{ result: unknown; stdout: string }> {
+  const script = getScript({ name: input.scriptName, scope: "global" });
+  if (!script) {
+    throw new Error(`Script '${input.scriptName}' not found`);
+  }
+  const output = await runScript({
+    source: script.source,
+    args: input.args,
+    fsMode: "none",
+    agentId: input.agentId,
+    egressSecrets: await buildScriptCredentialBindings({ agentId: input.agentId }),
+    apiConnections: getScriptApiConnectionDescriptors({ agentId: input.agentId }),
+    mcpConnections: getScriptMcpConnectionDescriptors({ agentId: input.agentId }),
+    timeoutMs: input.timeoutMs ?? 60_000,
+  });
+  if (output.exitCode !== 0 || output.error) {
+    throw new Error(
+      output.stderr ||
+        `Script '${input.scriptName}' exited with code ${output.exitCode}${
+          output.error ? ` (${output.error})` : ""
+        }`,
+    );
+  }
+  return { result: output.result, stdout: output.stdout };
+}

--- a/src/be/scripts/typecheck.ts
+++ b/src/be/scripts/typecheck.ts
@@ -81,6 +81,8 @@ export interface SwarmSdk {
   repo_list(args?: Record<string, unknown>): Promise<unknown>;
   // --- schedules ---
   schedule_list(args?: Record<string, unknown>): Promise<unknown>;
+  // --- subscriptions ---
+  subscription_list(args?: { enabledOnly?: boolean; includeDeliveries?: boolean }): Promise<unknown>;
   // --- scripts ---
   script_search(args: { query?: string; scope?: ScriptScope; limit?: number }): Promise<unknown>;
   script_run(args: { name?: string; source?: string; args?: unknown; intent?: string; scope?: ScriptScope; fsMode?: ScriptFsMode; idempotencyKey?: string }): Promise<unknown>;
@@ -165,8 +167,14 @@ export interface SwarmSdk {
   // --- write: schedules ---
   schedule_create(args: Record<string, unknown>): Promise<unknown>;
   schedule_update(args: Record<string, unknown>): Promise<unknown>;
+  schedule_patch(args: Record<string, unknown>): Promise<unknown>;
   schedule_delete(args: { id: string }): Promise<unknown>;
   schedule_runNow(args: { id: string }): Promise<unknown>;
+
+  // --- write: subscriptions ---
+  subscription_create(args: { name: string; eventPattern: string; targetType: "script" | "workflow"; scriptName?: string; scriptArgs?: Record<string, unknown>; workflowId?: string; filter?: unknown; description?: string; enabled?: boolean }): Promise<unknown>;
+  subscription_patch(args: { name: string; description?: string; eventPattern?: string; filter?: unknown; scriptArgs?: Record<string, unknown> | null; enabled?: boolean }): Promise<unknown>;
+  subscription_delete(args: { name: string }): Promise<unknown>;
 
   // --- write: workflows ---
   workflow_create(args: Record<string, unknown>): Promise<unknown>;

--- a/src/be/subscriptions-db.ts
+++ b/src/be/subscriptions-db.ts
@@ -3,7 +3,7 @@ import type {
   SubscriptionDelivery,
   SubscriptionDeliveryStatus,
   SubscriptionTargetType,
-  SwarmEvent,
+  SwarmBusEvent,
 } from "../subscriptions/types";
 import { getDb } from "./db";
 
@@ -115,6 +115,48 @@ export function setSubscriptionEnabled(id: string, enabled: boolean): boolean {
   return res.changes > 0;
 }
 
+export function updateSubscription(
+  id: string,
+  patch: {
+    description?: string;
+    eventPattern?: string;
+    filter?: unknown | null;
+    scriptArgs?: Record<string, unknown> | null;
+    enabled?: boolean;
+  },
+): Subscription | null {
+  const sets: string[] = [];
+  const values: unknown[] = [];
+  if (patch.description !== undefined) {
+    sets.push("description = ?");
+    values.push(patch.description);
+  }
+  if (patch.eventPattern !== undefined) {
+    sets.push("eventPattern = ?");
+    values.push(patch.eventPattern);
+  }
+  if (patch.filter !== undefined) {
+    sets.push("filter = ?");
+    values.push(patch.filter === null ? null : JSON.stringify(patch.filter));
+  }
+  if (patch.scriptArgs !== undefined) {
+    sets.push("scriptArgs = ?");
+    values.push(patch.scriptArgs === null ? null : JSON.stringify(patch.scriptArgs));
+  }
+  if (patch.enabled !== undefined) {
+    sets.push("enabled = ?");
+    values.push(patch.enabled ? 1 : 0);
+  }
+  if (sets.length === 0) return getSubscriptionById(id);
+  sets.push("updatedAt = ?");
+  values.push(new Date().toISOString());
+  values.push(id);
+  getDb()
+    .prepare(`UPDATE subscriptions SET ${sets.join(", ")} WHERE id = ?`)
+    .run(...(values as (string | number | null)[]));
+  return getSubscriptionById(id);
+}
+
 export function deleteSubscription(id: string): boolean {
   const res = getDb().prepare("DELETE FROM subscriptions WHERE id = ?").run(id);
   return res.changes > 0;
@@ -122,8 +164,8 @@ export function deleteSubscription(id: string): boolean {
 
 // --- events -----------------------------------------------------------------
 
-export function recordSwarmEvent(name: string, data: unknown): SwarmEvent {
-  const event: SwarmEvent = {
+export function recordSwarmBusEvent(name: string, data: unknown): SwarmBusEvent {
+  const event: SwarmBusEvent = {
     id: crypto.randomUUID(),
     name,
     data,
@@ -135,7 +177,7 @@ export function recordSwarmEvent(name: string, data: unknown): SwarmEvent {
   return event;
 }
 
-export function getSwarmEventById(id: string): SwarmEvent | null {
+export function getSwarmBusEventById(id: string): SwarmBusEvent | null {
   const row = getDb().prepare("SELECT * FROM swarm_events WHERE id = ?").get(id) as {
     id: string;
     name: string;
@@ -273,4 +315,34 @@ export function listDeliveriesForSubscription(
     )
     .all(subscriptionId, limit) as DeliveryRow[];
   return rows.map(rowToDelivery);
+}
+
+/**
+ * Journal retention: prune finished deliveries (succeeded after 14 days,
+ * failed after 30) and swarm_events rows that no delivery references anymore.
+ * Called opportunistically from the dispatcher (~hourly).
+ */
+export function pruneSubscriptionJournal(now = new Date()): {
+  deliveries: number;
+  events: number;
+} {
+  const iso = (daysAgo: number) => new Date(now.getTime() - daysAgo * 86_400_000).toISOString();
+  const db = getDb();
+  const deliveries =
+    db
+      .prepare(
+        `DELETE FROM subscription_deliveries
+         WHERE (status = 'succeeded' AND finishedAt < ?)
+            OR (status = 'failed' AND finishedAt < ?)`,
+      )
+      .run(iso(14), iso(30)).changes ?? 0;
+  const events =
+    db
+      .prepare(
+        `DELETE FROM swarm_events
+         WHERE emittedAt < ?
+           AND id NOT IN (SELECT eventId FROM subscription_deliveries)`,
+      )
+      .run(iso(30)).changes ?? 0;
+  return { deliveries, events };
 }

--- a/src/be/subscriptions-db.ts
+++ b/src/be/subscriptions-db.ts
@@ -1,0 +1,276 @@
+import type {
+  Subscription,
+  SubscriptionDelivery,
+  SubscriptionDeliveryStatus,
+  SubscriptionTargetType,
+  SwarmEvent,
+} from "../subscriptions/types";
+import { getDb } from "./db";
+
+// SPIKE (extension system, Layer 1): CRUD for swarm_events / subscriptions /
+// subscription_deliveries. Kept out of db.ts, following src/be/scripts/db.ts.
+
+interface SubscriptionRow {
+  id: string;
+  name: string;
+  description: string | null;
+  eventPattern: string;
+  filter: string | null;
+  targetType: string;
+  scriptName: string | null;
+  scriptArgs: string | null;
+  workflowId: string | null;
+  enabled: number;
+  createdByAgentId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function rowToSubscription(row: SubscriptionRow): Subscription {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description ?? undefined,
+    eventPattern: row.eventPattern,
+    filter: row.filter ? JSON.parse(row.filter) : undefined,
+    targetType: row.targetType as SubscriptionTargetType,
+    scriptName: row.scriptName ?? undefined,
+    scriptArgs: row.scriptArgs ? JSON.parse(row.scriptArgs) : undefined,
+    workflowId: row.workflowId ?? undefined,
+    enabled: row.enabled === 1,
+    createdByAgentId: row.createdByAgentId ?? undefined,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function createSubscription(args: {
+  name: string;
+  description?: string;
+  eventPattern: string;
+  filter?: unknown;
+  targetType: SubscriptionTargetType;
+  scriptName?: string;
+  scriptArgs?: Record<string, unknown>;
+  workflowId?: string;
+  enabled?: boolean;
+  createdByAgentId?: string;
+}): Subscription {
+  const now = new Date().toISOString();
+  const id = crypto.randomUUID();
+  getDb()
+    .prepare(
+      `INSERT INTO subscriptions
+         (id, name, description, eventPattern, filter, targetType, scriptName,
+          scriptArgs, workflowId, enabled, createdByAgentId, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      args.name,
+      args.description ?? null,
+      args.eventPattern,
+      args.filter === undefined ? null : JSON.stringify(args.filter),
+      args.targetType,
+      args.scriptName ?? null,
+      args.scriptArgs === undefined ? null : JSON.stringify(args.scriptArgs),
+      args.workflowId ?? null,
+      args.enabled === false ? 0 : 1,
+      args.createdByAgentId ?? null,
+      now,
+      now,
+    );
+  const created = getSubscriptionById(id);
+  if (!created) throw new Error("Failed to create subscription");
+  return created;
+}
+
+export function getSubscriptionById(id: string): Subscription | null {
+  const row = getDb()
+    .prepare("SELECT * FROM subscriptions WHERE id = ?")
+    .get(id) as SubscriptionRow | null;
+  return row ? rowToSubscription(row) : null;
+}
+
+export function getSubscriptionByName(name: string): Subscription | null {
+  const row = getDb()
+    .prepare("SELECT * FROM subscriptions WHERE name = ?")
+    .get(name) as SubscriptionRow | null;
+  return row ? rowToSubscription(row) : null;
+}
+
+export function listSubscriptions(args?: { enabledOnly?: boolean }): Subscription[] {
+  const rows = (
+    args?.enabledOnly
+      ? getDb().prepare("SELECT * FROM subscriptions WHERE enabled = 1 ORDER BY name")
+      : getDb().prepare("SELECT * FROM subscriptions ORDER BY name")
+  ).all() as SubscriptionRow[];
+  return rows.map(rowToSubscription);
+}
+
+export function setSubscriptionEnabled(id: string, enabled: boolean): boolean {
+  const res = getDb()
+    .prepare("UPDATE subscriptions SET enabled = ?, updatedAt = ? WHERE id = ?")
+    .run(enabled ? 1 : 0, new Date().toISOString(), id);
+  return res.changes > 0;
+}
+
+export function deleteSubscription(id: string): boolean {
+  const res = getDb().prepare("DELETE FROM subscriptions WHERE id = ?").run(id);
+  return res.changes > 0;
+}
+
+// --- events -----------------------------------------------------------------
+
+export function recordSwarmEvent(name: string, data: unknown): SwarmEvent {
+  const event: SwarmEvent = {
+    id: crypto.randomUUID(),
+    name,
+    data,
+    emittedAt: new Date().toISOString(),
+  };
+  getDb()
+    .prepare("INSERT INTO swarm_events (id, name, data, emittedAt) VALUES (?, ?, ?, ?)")
+    .run(event.id, event.name, data === undefined ? null : JSON.stringify(data), event.emittedAt);
+  return event;
+}
+
+export function getSwarmEventById(id: string): SwarmEvent | null {
+  const row = getDb().prepare("SELECT * FROM swarm_events WHERE id = ?").get(id) as {
+    id: string;
+    name: string;
+    data: string | null;
+    emittedAt: string;
+  } | null;
+  if (!row) return null;
+  return {
+    id: row.id,
+    name: row.name,
+    data: row.data ? JSON.parse(row.data) : undefined,
+    emittedAt: row.emittedAt,
+  };
+}
+
+// --- deliveries -------------------------------------------------------------
+
+interface DeliveryRow {
+  id: string;
+  subscriptionId: string;
+  eventId: string;
+  status: string;
+  attempts: number;
+  claimedAt: string | null;
+  finishedAt: string | null;
+  error: string | null;
+  result: string | null;
+  createdAt: string;
+}
+
+function rowToDelivery(row: DeliveryRow): SubscriptionDelivery {
+  return {
+    id: row.id,
+    subscriptionId: row.subscriptionId,
+    eventId: row.eventId,
+    status: row.status as SubscriptionDeliveryStatus,
+    attempts: row.attempts,
+    claimedAt: row.claimedAt ?? undefined,
+    finishedAt: row.finishedAt ?? undefined,
+    error: row.error ?? undefined,
+    result: row.result ? JSON.parse(row.result) : undefined,
+    createdAt: row.createdAt,
+  };
+}
+
+export function createDelivery(subscriptionId: string, eventId: string): SubscriptionDelivery {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  getDb()
+    .prepare(
+      `INSERT INTO subscription_deliveries (id, subscriptionId, eventId, createdAt)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT (subscriptionId, eventId) DO NOTHING`,
+    )
+    .run(id, subscriptionId, eventId, now);
+  const row = getDb()
+    .prepare("SELECT * FROM subscription_deliveries WHERE subscriptionId = ? AND eventId = ?")
+    .get(subscriptionId, eventId) as DeliveryRow;
+  return rowToDelivery(row);
+}
+
+/**
+ * Atomically claim up to `limit` pending deliveries (pending → running).
+ * The UPDATE-with-subselect is atomic per statement under SQLite, which is
+ * enough to prevent double-claims across this process's timers; multi-replica
+ * claim/lease semantics are out of scope for the spike (gap #12 in the
+ * research doc).
+ */
+export function claimPendingDeliveries(limit: number): SubscriptionDelivery[] {
+  const now = new Date().toISOString();
+  const db = getDb();
+  const claimed = db
+    .prepare(
+      `UPDATE subscription_deliveries
+       SET status = 'running', claimedAt = ?, attempts = attempts + 1
+       WHERE id IN (
+         SELECT id FROM subscription_deliveries
+         WHERE status = 'pending'
+         ORDER BY createdAt
+         LIMIT ?
+       )
+       RETURNING *`,
+    )
+    .all(now, limit) as DeliveryRow[];
+  return claimed.map(rowToDelivery);
+}
+
+export function finishDelivery(
+  id: string,
+  outcome:
+    | { status: "succeeded"; result?: unknown }
+    | { status: "failed"; error: string; retry: boolean },
+): void {
+  const now = new Date().toISOString();
+  if (outcome.status === "succeeded") {
+    getDb()
+      .prepare(
+        `UPDATE subscription_deliveries
+         SET status = 'succeeded', finishedAt = ?, result = ?, error = NULL
+         WHERE id = ?`,
+      )
+      .run(now, outcome.result === undefined ? null : JSON.stringify(outcome.result), id);
+    return;
+  }
+  if (outcome.retry) {
+    getDb()
+      .prepare("UPDATE subscription_deliveries SET status = 'pending', error = ? WHERE id = ?")
+      .run(outcome.error, id);
+    return;
+  }
+  getDb()
+    .prepare(
+      `UPDATE subscription_deliveries
+       SET status = 'failed', finishedAt = ?, error = ?
+       WHERE id = ?`,
+    )
+    .run(now, outcome.error, id);
+}
+
+export function getDeliveryById(id: string): SubscriptionDelivery | null {
+  const row = getDb()
+    .prepare("SELECT * FROM subscription_deliveries WHERE id = ?")
+    .get(id) as DeliveryRow | null;
+  return row ? rowToDelivery(row) : null;
+}
+
+export function listDeliveriesForSubscription(
+  subscriptionId: string,
+  limit = 20,
+): SubscriptionDelivery[] {
+  const rows = getDb()
+    .prepare(
+      `SELECT * FROM subscription_deliveries
+       WHERE subscriptionId = ? ORDER BY createdAt DESC LIMIT ?`,
+    )
+    .all(subscriptionId, limit) as DeliveryRow[];
+  return rows.map(rowToDelivery);
+}

--- a/src/be/subscriptions-db.ts
+++ b/src/be/subscriptions-db.ts
@@ -22,6 +22,8 @@ interface SubscriptionRow {
   workflowId: string | null;
   enabled: number;
   createdByAgentId: string | null;
+  created_by: string | null;
+  updated_by: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -39,6 +41,8 @@ function rowToSubscription(row: SubscriptionRow): Subscription {
     workflowId: row.workflowId ?? undefined,
     enabled: row.enabled === 1,
     createdByAgentId: row.createdByAgentId ?? undefined,
+    createdBy: row.created_by ?? undefined,
+    updatedBy: row.updated_by ?? undefined,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -55,6 +59,7 @@ export function createSubscription(args: {
   workflowId?: string;
   enabled?: boolean;
   createdByAgentId?: string;
+  createdBy?: string;
 }): Subscription {
   const now = new Date().toISOString();
   const id = crypto.randomUUID();
@@ -62,8 +67,8 @@ export function createSubscription(args: {
     .prepare(
       `INSERT INTO subscriptions
          (id, name, description, eventPattern, filter, targetType, scriptName,
-          scriptArgs, workflowId, enabled, createdByAgentId, createdAt, updatedAt)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          scriptArgs, workflowId, enabled, createdByAgentId, created_by, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       id,
@@ -77,6 +82,7 @@ export function createSubscription(args: {
       args.workflowId ?? null,
       args.enabled === false ? 0 : 1,
       args.createdByAgentId ?? null,
+      args.createdBy ?? null,
       now,
       now,
     );
@@ -123,6 +129,7 @@ export function updateSubscription(
     filter?: unknown | null;
     scriptArgs?: Record<string, unknown> | null;
     enabled?: boolean;
+    updatedBy?: string;
   },
 ): Subscription | null {
   const sets: string[] = [];
@@ -148,6 +155,10 @@ export function updateSubscription(
     values.push(patch.enabled ? 1 : 0);
   }
   if (sets.length === 0) return getSubscriptionById(id);
+  if (patch.updatedBy !== undefined) {
+    sets.push("updated_by = ?");
+    values.push(patch.updatedBy);
+  }
   sets.push("updatedAt = ?");
   values.push(new Date().toISOString());
   values.push(id);

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -616,6 +616,13 @@ httpServer
       });
     }
 
+    // Start event-subscription dispatcher (extension-system spike; unless disabled)
+    if (process.env.SUBSCRIPTIONS_DISABLE !== "true") {
+      const { startSubscriptionDispatcher } = await import("../subscriptions/dispatcher");
+      const subIntervalMs = Number(process.env.SUBSCRIPTIONS_INTERVAL_MS) || 2000;
+      startSubscriptionDispatcher(subIntervalMs);
+    }
+
     // Start heartbeat triage (unless disabled)
     if (process.env.HEARTBEAT_DISABLE !== "true") {
       const { startHeartbeat } = await import("../heartbeat");

--- a/src/jira/webhook.ts
+++ b/src/jira/webhook.ts
@@ -14,6 +14,7 @@
 
 import { createHash, timingSafeEqual } from "node:crypto";
 import { hasTrackerDelivery, markTrackerDelivery } from "../be/db-queries/tracker";
+import { workflowEventBus } from "../workflows/event-bus";
 import { handleCommentEvent, handleIssueDeleteEvent, handleIssueEvent } from "./sync";
 
 /**
@@ -115,6 +116,12 @@ export async function handleJiraWebhook(
   }
 
   const event = String(parsed.webhookEvent ?? "");
+
+  // Surface on the workflow event bus (wait nodes + subscriptions),
+  // e.g. "jira.issue_updated", "jira.comment_created".
+  if (event) {
+    workflowEventBus.emit(`jira.${event.replace(/^jira:/, "")}`, parsed);
+  }
 
   // Fire-and-forget heavy work; return 200 immediately.
   void dispatchAndRecord(event, parsed, deliveryId).catch((err) => {

--- a/src/linear/webhook.ts
+++ b/src/linear/webhook.ts
@@ -1,4 +1,5 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
+import { workflowEventBus } from "../workflows/event-bus";
 import {
   handleAgentSessionEvent,
   handleAgentSessionPrompted,
@@ -90,6 +91,13 @@ export async function handleLinearWebhook(
 
   // 3. Parse and dispatch
   const event = JSON.parse(rawBody) as Record<string, unknown>;
+
+  // Surface on the workflow event bus (wait nodes + subscriptions),
+  // e.g. "linear.issue.update", "linear.comment.create".
+  workflowEventBus.emit(
+    `linear.${String(event.type ?? "unknown").toLowerCase()}.${String(event.action ?? "unknown")}`,
+    event,
+  );
 
   // Fire-and-forget for heavy work
   processWebhookEvent(event, deliveryId ?? undefined).catch((err) => {

--- a/src/rbac/legacy-policy.ts
+++ b/src/rbac/legacy-policy.ts
@@ -195,4 +195,5 @@ export const LEGACY_POLICY = {
   "script.api.rotate": leadOnly,
   "script.api.delete": leadOnly,
   "subscription.write": anyAuthenticated,
+  "tool.publish": leadOnly,
 } as const satisfies Record<PermissionVerb, LegacyRule>;

--- a/src/rbac/legacy-policy.ts
+++ b/src/rbac/legacy-policy.ts
@@ -194,4 +194,5 @@ export const LEGACY_POLICY = {
   "script.api.update": leadOnly,
   "script.api.rotate": leadOnly,
   "script.api.delete": leadOnly,
+  "subscription.write": anyAuthenticated,
 } as const satisfies Record<PermissionVerb, LegacyRule>;

--- a/src/rbac/legacy-policy.ts
+++ b/src/rbac/legacy-policy.ts
@@ -195,5 +195,6 @@ export const LEGACY_POLICY = {
   "script.api.rotate": leadOnly,
   "script.api.delete": leadOnly,
   "subscription.write": anyAuthenticated,
+  "subscription.mutate.any": leadOrResourceOwner,
   "tool.publish": leadOnly,
 } as const satisfies Record<PermissionVerb, LegacyRule>;

--- a/src/rbac/permissions.ts
+++ b/src/rbac/permissions.ts
@@ -225,6 +225,10 @@ export const PERMISSIONS = {
     description: "Create, modify, pause, or delete event subscriptions.",
     namespace: "subscription",
   },
+  "tool.publish": {
+    description: "Publish, unpublish, or toggle script-backed MCP tools.",
+    namespace: "tool",
+  },
 } as const satisfies Record<string, { description: string; namespace: string }>;
 
 export type PermissionVerb = keyof typeof PERMISSIONS;

--- a/src/rbac/permissions.ts
+++ b/src/rbac/permissions.ts
@@ -221,6 +221,10 @@ export const PERMISSIONS = {
     description: "Delete an external script API endpoint.",
     namespace: "script",
   },
+  "subscription.write": {
+    description: "Create, modify, pause, or delete event subscriptions.",
+    namespace: "subscription",
+  },
 } as const satisfies Record<string, { description: string; namespace: string }>;
 
 export type PermissionVerb = keyof typeof PERMISSIONS;

--- a/src/rbac/permissions.ts
+++ b/src/rbac/permissions.ts
@@ -222,7 +222,11 @@ export const PERMISSIONS = {
     namespace: "script",
   },
   "subscription.write": {
-    description: "Create, modify, pause, or delete event subscriptions.",
+    description: "Create event subscriptions.",
+    namespace: "subscription",
+  },
+  "subscription.mutate.any": {
+    description: "Modify, pause, or delete event subscriptions beyond the caller's own.",
     namespace: "subscription",
   },
   "tool.publish": {

--- a/src/scripts-runtime/sdk-allowlist.ts
+++ b/src/scripts-runtime/sdk-allowlist.ts
@@ -27,6 +27,12 @@ export const SDK_TOOL_NAME_MAP = {
   repo_list: "get-repos",
   repo_update: "update-repo",
 
+  // ── subscriptions ──
+  subscription_create: "create-subscription",
+  subscription_list: "list-subscriptions",
+  subscription_patch: "patch-subscription",
+  subscription_delete: "delete-subscription", // destructive
+
   // ── schedules ──
   schedule_list: "list-schedules",
   schedule_create: "create-schedule",

--- a/src/scripts-runtime/types/stdlib.d.ts
+++ b/src/scripts-runtime/types/stdlib.d.ts
@@ -26,6 +26,17 @@ declare module "swarm-sdk" {
     | { [key: string]: JsonValue };
   export type ScriptScope = "agent" | "global";
   export type ScriptFsMode = "none" | "workspace-rw";
+  export type ScriptApiRawOptions = { raw: true };
+  export type ScriptApiDefaultOptions = { raw?: false };
+
+  export interface ScriptApiRawResult {
+    ok: boolean;
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+    url: string;
+    response: Response;
+  }
 
   export interface Redacted<T> {
     readonly __redactedBrand?: T;
@@ -77,16 +88,11 @@ declare module "swarm-sdk" {
     // --- repos ---
     repo_list(args?: Record<string, unknown>): Promise<unknown>;
     // --- schedules ---
-    schedule_list(args?: {
-      enabled?: boolean;
-      name?: string;
-      scheduleType?: "recurring" | "one_time";
-      targetType?: "agent-task" | "workflow" | "script";
-      workflowId?: string;
-      scriptName?: string;
-      hideCompleted?: boolean;
-      consecutiveErrorsMin?: number;
-      lastRunStatus?: "failed" | "succeeded";
+    schedule_list(args?: Record<string, unknown>): Promise<unknown>;
+    // --- subscriptions ---
+    subscription_list(args?: {
+      enabledOnly?: boolean;
+      includeDeliveries?: boolean;
     }): Promise<unknown>;
     // --- scripts ---
     script_search(args: { query?: string; scope?: ScriptScope; limit?: number }): Promise<unknown>;
@@ -161,12 +167,7 @@ declare module "swarm-sdk" {
     }): Promise<unknown>;
     context_diff(args: { versionId: string; compareToVersionId?: string }): Promise<unknown>;
     // --- workflows ---
-    workflow_list(args?: {
-      enabled?: boolean;
-      includeFull?: boolean;
-      consecutiveErrorsMin?: number;
-      lastRunStatus?: "running" | "waiting" | "completed" | "failed" | "skipped" | "cancelled";
-    }): Promise<unknown>;
+    workflow_list(args?: { enabled?: boolean; includeFull?: boolean }): Promise<unknown>;
     workflow_get(args: { id: string }): Promise<unknown>;
     workflow_listRuns(args: {
       workflowId: string;
@@ -266,6 +267,28 @@ declare module "swarm-sdk" {
     schedule_patch(args: Record<string, unknown>): Promise<unknown>;
     schedule_delete(args: { id: string }): Promise<unknown>;
     schedule_runNow(args: { id: string }): Promise<unknown>;
+
+    // --- write: subscriptions ---
+    subscription_create(args: {
+      name: string;
+      eventPattern: string;
+      targetType: "script" | "workflow";
+      scriptName?: string;
+      scriptArgs?: Record<string, unknown>;
+      workflowId?: string;
+      filter?: unknown;
+      description?: string;
+      enabled?: boolean;
+    }): Promise<unknown>;
+    subscription_patch(args: {
+      name: string;
+      description?: string;
+      eventPattern?: string;
+      filter?: unknown;
+      scriptArgs?: Record<string, unknown> | null;
+      enabled?: boolean;
+    }): Promise<unknown>;
+    subscription_delete(args: { name: string }): Promise<unknown>;
 
     // --- write: workflows ---
     workflow_create(args: Record<string, unknown>): Promise<unknown>;

--- a/src/scripts-runtime/types/swarm-sdk.d.ts
+++ b/src/scripts-runtime/types/swarm-sdk.d.ts
@@ -70,16 +70,11 @@ declare module "swarm-sdk" {
     // --- repos ---
     repo_list(args?: Record<string, unknown>): Promise<unknown>;
     // --- schedules ---
-    schedule_list(args?: {
-      enabled?: boolean;
-      name?: string;
-      scheduleType?: "recurring" | "one_time";
-      targetType?: "agent-task" | "workflow" | "script";
-      workflowId?: string;
-      scriptName?: string;
-      hideCompleted?: boolean;
-      consecutiveErrorsMin?: number;
-      lastRunStatus?: "failed" | "succeeded";
+    schedule_list(args?: Record<string, unknown>): Promise<unknown>;
+    // --- subscriptions ---
+    subscription_list(args?: {
+      enabledOnly?: boolean;
+      includeDeliveries?: boolean;
     }): Promise<unknown>;
     // --- scripts ---
     script_search(args: { query?: string; scope?: ScriptScope; limit?: number }): Promise<unknown>;
@@ -154,12 +149,7 @@ declare module "swarm-sdk" {
     }): Promise<unknown>;
     context_diff(args: { versionId: string; compareToVersionId?: string }): Promise<unknown>;
     // --- workflows ---
-    workflow_list(args?: {
-      enabled?: boolean;
-      includeFull?: boolean;
-      consecutiveErrorsMin?: number;
-      lastRunStatus?: "running" | "waiting" | "completed" | "failed" | "skipped" | "cancelled";
-    }): Promise<unknown>;
+    workflow_list(args?: { enabled?: boolean; includeFull?: boolean }): Promise<unknown>;
     workflow_get(args: { id: string }): Promise<unknown>;
     workflow_listRuns(args: {
       workflowId: string;
@@ -259,6 +249,28 @@ declare module "swarm-sdk" {
     schedule_patch(args: Record<string, unknown>): Promise<unknown>;
     schedule_delete(args: { id: string }): Promise<unknown>;
     schedule_runNow(args: { id: string }): Promise<unknown>;
+
+    // --- write: subscriptions ---
+    subscription_create(args: {
+      name: string;
+      eventPattern: string;
+      targetType: "script" | "workflow";
+      scriptName?: string;
+      scriptArgs?: Record<string, unknown>;
+      workflowId?: string;
+      filter?: unknown;
+      description?: string;
+      enabled?: boolean;
+    }): Promise<unknown>;
+    subscription_patch(args: {
+      name: string;
+      description?: string;
+      eventPattern?: string;
+      filter?: unknown;
+      scriptArgs?: Record<string, unknown> | null;
+      enabled?: boolean;
+    }): Promise<unknown>;
+    subscription_delete(args: { name: string }): Promise<unknown>;
 
     // --- write: workflows ---
     workflow_create(args: Record<string, unknown>): Promise<unknown>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import { registerCredentialBindingsTool } from "./tools/credential-bindings";
 import { registerDbQueryTool } from "./tools/db-query";
 import { registerDeleteChannelTool } from "./tools/delete-channel";
 import { registerDeletePageTool } from "./tools/delete-page";
+import { registerDynamicScriptTools } from "./tools/dynamic-script-tools";
 import { registerGetMetricsTool } from "./tools/get-metrics";
 import { registerGetSwarmTool } from "./tools/get-swarm";
 import { registerGetTaskDetailsTool } from "./tools/get-task-details";
@@ -90,6 +91,7 @@ import { registerScriptQueryTypesTool } from "./tools/script-query-types";
 import { registerScriptRunTool } from "./tools/script-run";
 import { registerScriptRunsTools } from "./tools/script-runs";
 import { registerScriptSearchTool } from "./tools/script-search";
+import { registerScriptToolsTool } from "./tools/script-tools";
 import { registerScriptUpsertTool } from "./tools/script-upsert";
 import { registerSendTaskTool } from "./tools/send-task";
 // Skills capability
@@ -354,11 +356,15 @@ export function createServer(opts: { scriptsOnly?: boolean } = {}) {
     registerRunScheduleNowTool(server);
   }
 
-  // Event subscriptions (extension-system spike): event → script/workflow bindings
+  // Event subscriptions (extension system): event → script/workflow bindings
   registerCreateSubscriptionTool(server);
   registerListSubscriptionsTool(server);
   registerPatchSubscriptionTool(server);
   registerDeleteSubscriptionTool(server);
+
+  // Script-backed tools (extension system): management tool + dynamic registrations
+  registerScriptToolsTool(server);
+  registerDynamicScriptTools(server);
 
   // Memory capability - persistent memory with vector search
   if (hasCapability("memory")) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -117,6 +117,11 @@ import { registerSlackStartThreadTool } from "./tools/slack-start-thread";
 import { registerSlackUpdateTool } from "./tools/slack-update";
 import { registerSlackUploadFileTool } from "./tools/slack-upload-file";
 import { registerStoreProgressTool } from "./tools/store-progress";
+import {
+  registerCreateSubscriptionTool,
+  registerDeleteSubscriptionTool,
+  registerListSubscriptionsTool,
+} from "./tools/subscriptions";
 // Swarm config tools
 import {
   registerDeleteConfigTool,
@@ -347,6 +352,11 @@ export function createServer(opts: { scriptsOnly?: boolean } = {}) {
     registerDeleteScheduleTool(server);
     registerRunScheduleNowTool(server);
   }
+
+  // Event subscriptions (extension-system spike): event → script/workflow bindings
+  registerCreateSubscriptionTool(server);
+  registerListSubscriptionsTool(server);
+  registerDeleteSubscriptionTool(server);
 
   // Memory capability - persistent memory with vector search
   if (hasCapability("memory")) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -121,6 +121,7 @@ import {
   registerCreateSubscriptionTool,
   registerDeleteSubscriptionTool,
   registerListSubscriptionsTool,
+  registerPatchSubscriptionTool,
 } from "./tools/subscriptions";
 // Swarm config tools
 import {
@@ -356,6 +357,7 @@ export function createServer(opts: { scriptsOnly?: boolean } = {}) {
   // Event subscriptions (extension-system spike): event → script/workflow bindings
   registerCreateSubscriptionTool(server);
   registerListSubscriptionsTool(server);
+  registerPatchSubscriptionTool(server);
   registerDeleteSubscriptionTool(server);
 
   // Memory capability - persistent memory with vector search

--- a/src/subscriptions/dispatcher.ts
+++ b/src/subscriptions/dispatcher.ts
@@ -10,9 +10,10 @@ import {
   createDelivery,
   finishDelivery,
   getSubscriptionById,
-  getSwarmEventById,
+  getSwarmBusEventById,
   listSubscriptions,
-  recordSwarmEvent,
+  pruneSubscriptionJournal,
+  recordSwarmBusEvent,
 } from "@/be/subscriptions-db";
 import { runScript } from "@/scripts-runtime/loader";
 import { getExecutorRegistry as getWorkflowExecutorRegistry } from "@/workflows";
@@ -21,7 +22,7 @@ import { workflowEventBus } from "@/workflows/event-bus";
 import type { ExecutorRegistry } from "@/workflows/executors/registry";
 import { matchesFilter } from "@/workflows/wait-filter";
 import { matchesEventPattern } from "./matcher";
-import type { Subscription, SwarmEvent } from "./types";
+import type { Subscription, SwarmBusEvent } from "./types";
 
 // SPIKE (extension system, Layer 1): event → subscription dispatch.
 //
@@ -38,6 +39,9 @@ import type { Subscription, SwarmEvent } from "./types";
 const MAX_ATTEMPTS = 3;
 const CLAIM_BATCH_SIZE = 5;
 const SCRIPT_TIMEOUT_MS = 60_000;
+const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
+
+let lastPruneAt = 0;
 
 let tapInstalled = false;
 let dispatcherTimer: ReturnType<typeof setInterval> | null = null;
@@ -71,7 +75,7 @@ async function captureEvent(name: string, data: unknown): Promise<void> {
   }
   if (matching.length === 0) return;
 
-  const event = recordSwarmEvent(name, data);
+  const event = recordSwarmBusEvent(name, data);
   for (const sub of matching) {
     createDelivery(sub.id, event.id);
   }
@@ -89,7 +93,7 @@ export function initSubscriptions(): void {
   tapInstalled = true;
 }
 
-async function executeScriptTarget(sub: Subscription, event: SwarmEvent): Promise<unknown> {
+async function executeScriptTarget(sub: Subscription, event: SwarmBusEvent): Promise<unknown> {
   if (!sub.scriptName) {
     throw new Error(`Subscription "${sub.name}" has no scriptName (targetType=script)`);
   }
@@ -122,7 +126,7 @@ async function executeScriptTarget(sub: Subscription, event: SwarmEvent): Promis
   return { scriptName: sub.scriptName, exitCode: output.exitCode };
 }
 
-async function executeWorkflowTarget(sub: Subscription, event: SwarmEvent): Promise<unknown> {
+async function executeWorkflowTarget(sub: Subscription, event: SwarmBusEvent): Promise<unknown> {
   if (!sub.workflowId) {
     throw new Error(`Subscription "${sub.name}" has no workflowId (targetType=workflow)`);
   }
@@ -152,10 +156,19 @@ async function executeWorkflowTarget(sub: Subscription, event: SwarmEvent): Prom
 
 /** Exported for tests: one dispatcher tick. Returns number of processed rows. */
 export async function processPendingDeliveries(limit = CLAIM_BATCH_SIZE): Promise<number> {
+  if (Date.now() - lastPruneAt > PRUNE_INTERVAL_MS) {
+    lastPruneAt = Date.now();
+    const pruned = pruneSubscriptionJournal();
+    if (pruned.deliveries || pruned.events) {
+      console.log(
+        `[Subscriptions] Pruned ${pruned.deliveries} deliveries, ${pruned.events} events`,
+      );
+    }
+  }
   const claimed = claimPendingDeliveries(limit);
   for (const delivery of claimed) {
     const sub = getSubscriptionById(delivery.subscriptionId);
-    const event = getSwarmEventById(delivery.eventId);
+    const event = getSwarmBusEventById(delivery.eventId);
     if (!sub || !event) {
       finishDelivery(delivery.id, {
         status: "failed",

--- a/src/subscriptions/dispatcher.ts
+++ b/src/subscriptions/dispatcher.ts
@@ -1,10 +1,5 @@
 import { getWorkflow } from "@/be/db";
-import {
-  getScriptApiConnectionDescriptors,
-  getScriptMcpConnectionDescriptors,
-} from "@/be/script-connections";
-import { buildScriptCredentialBindings } from "@/be/script-credential-broker";
-import { getScript } from "@/be/scripts/db";
+import { runGlobalScriptByName } from "@/be/scripts/run-global";
 import {
   claimPendingDeliveries,
   createDelivery,
@@ -15,7 +10,6 @@ import {
   pruneSubscriptionJournal,
   recordSwarmBusEvent,
 } from "@/be/subscriptions-db";
-import { runScript } from "@/scripts-runtime/loader";
 import { getExecutorRegistry as getWorkflowExecutorRegistry } from "@/workflows";
 import { startWorkflowExecution } from "@/workflows/engine";
 import { workflowEventBus } from "@/workflows/event-bus";
@@ -97,33 +91,16 @@ async function executeScriptTarget(sub: Subscription, event: SwarmBusEvent): Pro
   if (!sub.scriptName) {
     throw new Error(`Subscription "${sub.name}" has no scriptName (targetType=script)`);
   }
-  const script = getScript({ name: sub.scriptName, scope: "global" });
-  if (!script) {
-    throw new Error(`Script '${sub.scriptName}' not found`);
-  }
-  const agentId = sub.createdByAgentId ?? "subscription";
-  const output = await runScript({
-    source: script.source,
+  await runGlobalScriptByName({
+    scriptName: sub.scriptName,
     args: {
       ...(sub.scriptArgs ?? {}),
       event: { id: event.id, name: event.name, data: event.data, emittedAt: event.emittedAt },
     },
-    fsMode: "none",
-    agentId,
-    egressSecrets: await buildScriptCredentialBindings({ agentId }),
-    apiConnections: getScriptApiConnectionDescriptors({ agentId }),
-    mcpConnections: getScriptMcpConnectionDescriptors({ agentId }),
+    agentId: sub.createdByAgentId ?? "subscription",
     timeoutMs: SCRIPT_TIMEOUT_MS,
   });
-  if (output.exitCode !== 0 || output.error) {
-    throw new Error(
-      output.stderr ||
-        `Script '${sub.scriptName}' exited with code ${output.exitCode}${
-          output.error ? ` (${output.error})` : ""
-        }`,
-    );
-  }
-  return { scriptName: sub.scriptName, exitCode: output.exitCode };
+  return { scriptName: sub.scriptName, exitCode: 0 };
 }
 
 async function executeWorkflowTarget(sub: Subscription, event: SwarmBusEvent): Promise<unknown> {

--- a/src/subscriptions/dispatcher.ts
+++ b/src/subscriptions/dispatcher.ts
@@ -1,0 +1,219 @@
+import { getWorkflow } from "@/be/db";
+import {
+  getScriptApiConnectionDescriptors,
+  getScriptMcpConnectionDescriptors,
+} from "@/be/script-connections";
+import { buildScriptCredentialBindings } from "@/be/script-credential-broker";
+import { getScript } from "@/be/scripts/db";
+import {
+  claimPendingDeliveries,
+  createDelivery,
+  finishDelivery,
+  getSubscriptionById,
+  getSwarmEventById,
+  listSubscriptions,
+  recordSwarmEvent,
+} from "@/be/subscriptions-db";
+import { runScript } from "@/scripts-runtime/loader";
+import { getExecutorRegistry as getWorkflowExecutorRegistry } from "@/workflows";
+import { startWorkflowExecution } from "@/workflows/engine";
+import { workflowEventBus } from "@/workflows/event-bus";
+import type { ExecutorRegistry } from "@/workflows/executors/registry";
+import { matchesFilter } from "@/workflows/wait-filter";
+import { matchesEventPattern } from "./matcher";
+import type { Subscription, SwarmEvent } from "./types";
+
+// SPIKE (extension system, Layer 1): event → subscription dispatch.
+//
+// Capture side: an `onAny` tap on the workflow event bus persists every event
+// to swarm_events and enqueues a subscription_deliveries row per matching
+// enabled subscription. Capture is in-process (an event emitted while the API
+// is down is lost with its cause anyway); delivery is durable at-least-once —
+// pending rows survive restarts and are retried up to MAX_ATTEMPTS.
+//
+// Execution side: a scheduler-style poller claims pending deliveries and runs
+// the target — a global catalog script (same invocation pattern as
+// src/scheduler/scheduler.ts executeScheduleScript) or a workflow.
+
+const MAX_ATTEMPTS = 3;
+const CLAIM_BATCH_SIZE = 5;
+const SCRIPT_TIMEOUT_MS = 60_000;
+
+let tapInstalled = false;
+let dispatcherTimer: ReturnType<typeof setInterval> | null = null;
+let executorRegistry: ExecutorRegistry | null = null;
+
+/**
+ * Prefer an explicitly configured registry (boot passes the workflows
+ * singleton; tests pass a stub); fall back to the workflows-module singleton.
+ * Mirrors src/scheduler/scheduler.ts resolveExecutorRegistry().
+ */
+export function setSubscriptionExecutorRegistry(registry: ExecutorRegistry | null): void {
+  executorRegistry = registry;
+}
+
+function resolveExecutorRegistry(): ExecutorRegistry | null {
+  if (executorRegistry) return executorRegistry;
+  try {
+    return getWorkflowExecutorRegistry();
+  } catch {
+    return null;
+  }
+}
+
+async function captureEvent(name: string, data: unknown): Promise<void> {
+  const enabled = listSubscriptions({ enabledOnly: true });
+  const matching: Subscription[] = [];
+  for (const sub of enabled) {
+    if (!matchesEventPattern(sub.eventPattern, name)) continue;
+    if (sub.filter !== undefined && !(await matchesFilter(data, sub.filter))) continue;
+    matching.push(sub);
+  }
+  if (matching.length === 0) return;
+
+  const event = recordSwarmEvent(name, data);
+  for (const sub of matching) {
+    createDelivery(sub.id, event.id);
+  }
+}
+
+function onBusEvent(name: string, data: unknown): void {
+  captureEvent(name, data).catch((err) => {
+    console.error(`[Subscriptions] Failed to capture event '${name}':`, err);
+  });
+}
+
+export function initSubscriptions(): void {
+  if (tapInstalled) return;
+  workflowEventBus.onAny(onBusEvent);
+  tapInstalled = true;
+}
+
+async function executeScriptTarget(sub: Subscription, event: SwarmEvent): Promise<unknown> {
+  if (!sub.scriptName) {
+    throw new Error(`Subscription "${sub.name}" has no scriptName (targetType=script)`);
+  }
+  const script = getScript({ name: sub.scriptName, scope: "global" });
+  if (!script) {
+    throw new Error(`Script '${sub.scriptName}' not found`);
+  }
+  const agentId = sub.createdByAgentId ?? "subscription";
+  const output = await runScript({
+    source: script.source,
+    args: {
+      ...(sub.scriptArgs ?? {}),
+      event: { id: event.id, name: event.name, data: event.data, emittedAt: event.emittedAt },
+    },
+    fsMode: "none",
+    agentId,
+    egressSecrets: await buildScriptCredentialBindings({ agentId }),
+    apiConnections: getScriptApiConnectionDescriptors({ agentId }),
+    mcpConnections: getScriptMcpConnectionDescriptors({ agentId }),
+    timeoutMs: SCRIPT_TIMEOUT_MS,
+  });
+  if (output.exitCode !== 0 || output.error) {
+    throw new Error(
+      output.stderr ||
+        `Script '${sub.scriptName}' exited with code ${output.exitCode}${
+          output.error ? ` (${output.error})` : ""
+        }`,
+    );
+  }
+  return { scriptName: sub.scriptName, exitCode: output.exitCode };
+}
+
+async function executeWorkflowTarget(sub: Subscription, event: SwarmEvent): Promise<unknown> {
+  if (!sub.workflowId) {
+    throw new Error(`Subscription "${sub.name}" has no workflowId (targetType=workflow)`);
+  }
+  const workflow = getWorkflow(sub.workflowId);
+  if (!workflow) {
+    throw new Error(`Workflow ${sub.workflowId} not found`);
+  }
+  if (!workflow.enabled) {
+    throw new Error(`Workflow ${sub.workflowId} is disabled`);
+  }
+  const registry = resolveExecutorRegistry();
+  if (!registry) {
+    throw new Error("Workflow engine not initialized — cannot dispatch subscription to workflow");
+  }
+  const runId = await startWorkflowExecution(
+    workflow,
+    {
+      event: { id: event.id, name: event.name, data: event.data, emittedAt: event.emittedAt },
+      subscriptionId: sub.id,
+      subscriptionName: sub.name,
+    },
+    registry,
+    { triggerType: "subscription" },
+  );
+  return { workflowRunId: runId };
+}
+
+/** Exported for tests: one dispatcher tick. Returns number of processed rows. */
+export async function processPendingDeliveries(limit = CLAIM_BATCH_SIZE): Promise<number> {
+  const claimed = claimPendingDeliveries(limit);
+  for (const delivery of claimed) {
+    const sub = getSubscriptionById(delivery.subscriptionId);
+    const event = getSwarmEventById(delivery.eventId);
+    if (!sub || !event) {
+      finishDelivery(delivery.id, {
+        status: "failed",
+        error: !sub ? "subscription deleted" : "event row missing",
+        retry: false,
+      });
+      continue;
+    }
+    if (!sub.enabled) {
+      finishDelivery(delivery.id, {
+        status: "failed",
+        error: "subscription disabled",
+        retry: false,
+      });
+      continue;
+    }
+    try {
+      const result =
+        sub.targetType === "script"
+          ? await executeScriptTarget(sub, event)
+          : await executeWorkflowTarget(sub, event);
+      finishDelivery(delivery.id, { status: "succeeded", result });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const retry = delivery.attempts < MAX_ATTEMPTS;
+      finishDelivery(delivery.id, { status: "failed", error: message, retry });
+      console.error(
+        `[Subscriptions] Delivery ${delivery.id} (${sub.name} ← ${event.name}) failed` +
+          `${retry ? ", will retry" : ""}: ${message}`,
+      );
+    }
+  }
+  return claimed.length;
+}
+
+export function startSubscriptionDispatcher(intervalMs = 2000): void {
+  if (dispatcherTimer) return;
+  initSubscriptions();
+  let ticking = false;
+  dispatcherTimer = setInterval(() => {
+    if (ticking) return;
+    ticking = true;
+    processPendingDeliveries()
+      .catch((err) => console.error("[Subscriptions] Dispatcher tick failed:", err))
+      .finally(() => {
+        ticking = false;
+      });
+  }, intervalMs);
+  console.log(`[Subscriptions] Dispatcher started (interval ${intervalMs}ms)`);
+}
+
+export function stopSubscriptionDispatcher(): void {
+  if (dispatcherTimer) {
+    clearInterval(dispatcherTimer);
+    dispatcherTimer = null;
+  }
+  if (tapInstalled) {
+    workflowEventBus.offAny(onBusEvent);
+    tapInstalled = false;
+  }
+}

--- a/src/subscriptions/matcher.ts
+++ b/src/subscriptions/matcher.ts
@@ -1,0 +1,45 @@
+/**
+ * Glob matcher for dot-separated event names.
+ *
+ * Pattern language (kept deliberately tiny):
+ *   - `*`  matches exactly one segment (no dots)
+ *   - `**` matches one or more remaining segments (only meaningful as the
+ *     last segment)
+ *   - anything else is matched literally, per segment
+ *
+ * Examples: "task.*" matches "task.completed" but not "task.a.b";
+ * "github.**" matches "github.pull_request.opened"; "*" matches "ping" only.
+ */
+export function matchesEventPattern(pattern: string, eventName: string): boolean {
+  if (pattern === eventName) return true;
+  const patternSegments = pattern.split(".");
+  const nameSegments = eventName.split(".");
+
+  for (let i = 0; i < patternSegments.length; i++) {
+    const seg = patternSegments[i];
+    if (seg === "**") {
+      // `**` must consume at least one segment.
+      return i === patternSegments.length - 1 && nameSegments.length > i;
+    }
+    if (i >= nameSegments.length) return false;
+    if (seg !== "*" && seg !== nameSegments[i]) return false;
+  }
+  return patternSegments.length === nameSegments.length;
+}
+
+/** Validate a pattern at subscription-creation time. */
+export function validateEventPattern(pattern: string): string | null {
+  if (!pattern) return "eventPattern must be non-empty";
+  const segments = pattern.split(".");
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    if (!seg) return "eventPattern must not contain empty segments";
+    if (seg === "**" && i !== segments.length - 1) {
+      return "'**' is only allowed as the last segment";
+    }
+    if (seg.includes("*") && seg !== "*" && seg !== "**") {
+      return `invalid segment '${seg}' — '*' must stand alone in a segment`;
+    }
+  }
+  return null;
+}

--- a/src/subscriptions/types.ts
+++ b/src/subscriptions/types.ts
@@ -1,63 +1,17 @@
-import * as z from "zod";
+// Subscription schemas live in src/types.ts (table-backed schemas convention);
+// this module re-exports them for subscription-local imports.
 
-// SPIKE NOTE: schemas live module-local for now; production would hoist them
-// into src/types.ts alongside the other table-backed schemas.
-
-export const SubscriptionTargetTypeSchema = z.enum(["script", "workflow"]);
-export type SubscriptionTargetType = z.infer<typeof SubscriptionTargetTypeSchema>;
-
-export const SubscriptionSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  description: z.string().optional(),
-  /**
-   * Glob over dot-separated event names: `*` matches one segment,
-   * `**` matches the rest. e.g. "task.*", "github.**", "task.completed".
-   */
-  eventPattern: z.string(),
-  /**
-   * Optional payload filter using the wait-node filter language: either an
-   * object of dot-path → expected value, or a string expression compiled by
-   * src/workflows/wait-filter.ts.
-   */
-  filter: z.unknown().optional(),
-  targetType: SubscriptionTargetTypeSchema,
-  scriptName: z.string().optional(),
-  scriptArgs: z.record(z.string(), z.unknown()).optional(),
-  workflowId: z.string().optional(),
-  enabled: z.boolean(),
-  createdByAgentId: z.string().optional(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-});
-export type Subscription = z.infer<typeof SubscriptionSchema>;
-
-export const SwarmEventSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  data: z.unknown().optional(),
-  emittedAt: z.string(),
-});
-export type SwarmEvent = z.infer<typeof SwarmEventSchema>;
-
-export const SubscriptionDeliveryStatusSchema = z.enum([
-  "pending",
-  "running",
-  "succeeded",
-  "failed",
-]);
-export type SubscriptionDeliveryStatus = z.infer<typeof SubscriptionDeliveryStatusSchema>;
-
-export const SubscriptionDeliverySchema = z.object({
-  id: z.string(),
-  subscriptionId: z.string(),
-  eventId: z.string(),
-  status: SubscriptionDeliveryStatusSchema,
-  attempts: z.number().int(),
-  claimedAt: z.string().optional(),
-  finishedAt: z.string().optional(),
-  error: z.string().optional(),
-  result: z.unknown().optional(),
-  createdAt: z.string(),
-});
-export type SubscriptionDelivery = z.infer<typeof SubscriptionDeliverySchema>;
+export type {
+  Subscription,
+  SubscriptionDelivery,
+  SubscriptionDeliveryStatus,
+  SubscriptionTargetType,
+  SwarmBusEvent,
+} from "../types";
+export {
+  SubscriptionDeliverySchema,
+  SubscriptionDeliveryStatusSchema,
+  SubscriptionSchema,
+  SubscriptionTargetTypeSchema,
+  SwarmBusEventSchema,
+} from "../types";

--- a/src/subscriptions/types.ts
+++ b/src/subscriptions/types.ts
@@ -1,0 +1,63 @@
+import * as z from "zod";
+
+// SPIKE NOTE: schemas live module-local for now; production would hoist them
+// into src/types.ts alongside the other table-backed schemas.
+
+export const SubscriptionTargetTypeSchema = z.enum(["script", "workflow"]);
+export type SubscriptionTargetType = z.infer<typeof SubscriptionTargetTypeSchema>;
+
+export const SubscriptionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  /**
+   * Glob over dot-separated event names: `*` matches one segment,
+   * `**` matches the rest. e.g. "task.*", "github.**", "task.completed".
+   */
+  eventPattern: z.string(),
+  /**
+   * Optional payload filter using the wait-node filter language: either an
+   * object of dot-path → expected value, or a string expression compiled by
+   * src/workflows/wait-filter.ts.
+   */
+  filter: z.unknown().optional(),
+  targetType: SubscriptionTargetTypeSchema,
+  scriptName: z.string().optional(),
+  scriptArgs: z.record(z.string(), z.unknown()).optional(),
+  workflowId: z.string().optional(),
+  enabled: z.boolean(),
+  createdByAgentId: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type Subscription = z.infer<typeof SubscriptionSchema>;
+
+export const SwarmEventSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  data: z.unknown().optional(),
+  emittedAt: z.string(),
+});
+export type SwarmEvent = z.infer<typeof SwarmEventSchema>;
+
+export const SubscriptionDeliveryStatusSchema = z.enum([
+  "pending",
+  "running",
+  "succeeded",
+  "failed",
+]);
+export type SubscriptionDeliveryStatus = z.infer<typeof SubscriptionDeliveryStatusSchema>;
+
+export const SubscriptionDeliverySchema = z.object({
+  id: z.string(),
+  subscriptionId: z.string(),
+  eventId: z.string(),
+  status: SubscriptionDeliveryStatusSchema,
+  attempts: z.number().int(),
+  claimedAt: z.string().optional(),
+  finishedAt: z.string().optional(),
+  error: z.string().optional(),
+  result: z.unknown().optional(),
+  createdAt: z.string(),
+});
+export type SubscriptionDelivery = z.infer<typeof SubscriptionDeliverySchema>;

--- a/src/tests/rbac-engine.test.ts
+++ b/src/tests/rbac-engine.test.ts
@@ -84,6 +84,7 @@ const LEAD_OR_RESOURCE_OWNER_VERBS: PermissionVerb[] = [
   "mcp-server.delete.any",
   "mcp-server.update.any",
   "page.delete.any",
+  "subscription.mutate.any",
 ];
 
 const LEAD_OR_TASK_CREATOR_VERBS: PermissionVerb[] = ["task.cancel.any"];

--- a/src/tests/rbac-engine.test.ts
+++ b/src/tests/rbac-engine.test.ts
@@ -95,6 +95,7 @@ const ANY_AUTHENTICATED_VERBS: PermissionVerb[] = [
   "task.create.own",
   "favorite.write.own",
   "script.search",
+  "subscription.write",
 ];
 
 const REQUESTER_OWNS_TASK_VERBS: PermissionVerb[] = [

--- a/src/tests/rbac-engine.test.ts
+++ b/src/tests/rbac-engine.test.ts
@@ -42,6 +42,7 @@ type Expected = Record<PrincipalName, boolean>;
 
 const LEAD_ONLY_VERBS: PermissionVerb[] = [
   "user.manage",
+  "tool.publish",
   "agent.profile.update.any",
   "agent.context.read.any",
   "memory.learning.inject",

--- a/src/tests/script-tools.test.ts
+++ b/src/tests/script-tools.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Extension system, Layer 3: script-backed tools.
+ *
+ * Covers:
+ * - script_tools DB layer: create/get/list/enable/delete + unique toolName.
+ * - registerDynamicScriptTools(): enabled rows become registered MCP tools on
+ *   a real createServer() instance; disabled rows and rows whose backing
+ *   script is missing are skipped.
+ * - runGlobalScriptByName(): executes a real catalog script and surfaces its
+ *   return value; throws on script failure.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { unlink } from "node:fs/promises";
+import { closeDb, createAgent, initDb } from "../be/db";
+import {
+  createScriptTool,
+  deleteScriptTool,
+  getScriptToolByName,
+  listScriptTools,
+  setScriptToolEnabled,
+} from "../be/script-tools-db";
+import { upsertScriptByName } from "../be/scripts/db";
+import { setScriptEmbeddingProviderForTests } from "../be/scripts/embeddings";
+import { runGlobalScriptByName } from "../be/scripts/run-global";
+import { createServer } from "../server";
+
+const TEST_DB_PATH = "./test-script-tools.sqlite";
+const API_KEY = "test-script-tools-key-1234567890";
+
+const noOpEmbeddingProvider = {
+  name: "test/noop-script-tools-embedding",
+  dimensions: 1,
+  async embed() {
+    return null;
+  },
+  async embedBatch(texts: string[]) {
+    return texts.map(() => null);
+  },
+};
+
+let savedEnv: NodeJS.ProcessEnv;
+let agentId: string;
+
+async function removeDbFiles(): Promise<void> {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      await unlink(TEST_DB_PATH + suffix);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+}
+
+function getRegisteredToolNames(server: ReturnType<typeof createServer>): Set<string> {
+  const tools = (server as unknown as { _registeredTools: Record<string, unknown> })
+    ._registeredTools;
+  return new Set(Object.keys(tools));
+}
+
+beforeAll(async () => {
+  savedEnv = { ...process.env };
+  await removeDbFiles();
+  initDb(TEST_DB_PATH);
+  process.env.AGENT_SWARM_API_KEY = API_KEY;
+  delete process.env.API_KEY;
+  setScriptEmbeddingProviderForTests(noOpEmbeddingProvider);
+  const agent = createAgent({ name: "script-tools-test-agent", isLead: true, status: "idle" });
+  agentId = agent.id;
+
+  await upsertScriptByName({
+    name: "tool-echo",
+    scope: "global",
+    source: `export default async function run(args: Record<string, unknown>) { return { echoed: args }; }`,
+    description: "echo test script",
+    intent: "script-tools test fixture",
+    signatureJson: JSON.stringify({ args: { type: "object" }, result: { type: "object" } }),
+    agentId,
+    typeChecked: true,
+  });
+  await upsertScriptByName({
+    name: "tool-throws",
+    scope: "global",
+    source: `export default async function run() { throw new Error("nope"); }`,
+    description: "always-fails test script",
+    intent: "script-tools test fixture",
+    signatureJson: JSON.stringify({ args: { type: "object" }, result: { type: "object" } }),
+    agentId,
+    typeChecked: true,
+  });
+});
+
+afterAll(async () => {
+  setScriptEmbeddingProviderForTests(null);
+  closeDb();
+  await removeDbFiles();
+  for (const key of Object.keys(process.env)) {
+    if (!(key in savedEnv)) delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("script_tools DB layer", () => {
+  test("create, get, list, toggle, delete", () => {
+    const tool = createScriptTool({
+      toolName: "db-layer-tool",
+      scriptName: "tool-echo",
+      description: "d",
+      createdByAgentId: agentId,
+    });
+    expect(tool.enabled).toBe(true);
+    expect(getScriptToolByName("db-layer-tool")?.scriptName).toBe("tool-echo");
+    expect(listScriptTools().some((t) => t.toolName === "db-layer-tool")).toBe(true);
+
+    expect(setScriptToolEnabled("db-layer-tool", false)).toBe(true);
+    expect(getScriptToolByName("db-layer-tool")?.enabled).toBe(false);
+    expect(listScriptTools({ enabledOnly: true }).some((t) => t.toolName === "db-layer-tool")).toBe(
+      false,
+    );
+
+    expect(deleteScriptTool("db-layer-tool")).toBe(true);
+    expect(getScriptToolByName("db-layer-tool")).toBeNull();
+  });
+
+  test("toolName is unique", () => {
+    createScriptTool({ toolName: "unique-tool", scriptName: "tool-echo", description: "d" });
+    expect(() =>
+      createScriptTool({ toolName: "unique-tool", scriptName: "tool-echo", description: "d" }),
+    ).toThrow();
+    deleteScriptTool("unique-tool");
+  });
+});
+
+describe("registerDynamicScriptTools via createServer", () => {
+  test("enabled tools register; disabled and script-missing rows are skipped", () => {
+    createScriptTool({ toolName: "dyn-enabled", scriptName: "tool-echo", description: "d" });
+    createScriptTool({
+      toolName: "dyn-disabled",
+      scriptName: "tool-echo",
+      description: "d",
+      enabled: false,
+    });
+    createScriptTool({ toolName: "dyn-orphan", scriptName: "no-such-script", description: "d" });
+
+    const server = createServer();
+    const names = getRegisteredToolNames(server);
+    expect(names.has("dyn-enabled")).toBe(true);
+    expect(names.has("dyn-disabled")).toBe(false);
+    expect(names.has("dyn-orphan")).toBe(false);
+    expect(names.has("script-tools")).toBe(true);
+
+    deleteScriptTool("dyn-enabled");
+    deleteScriptTool("dyn-disabled");
+    deleteScriptTool("dyn-orphan");
+  });
+});
+
+describe("runGlobalScriptByName", () => {
+  test("returns the script result", async () => {
+    const { result } = await runGlobalScriptByName({
+      scriptName: "tool-echo",
+      args: { x: 1 },
+      agentId,
+    });
+    expect(result).toMatchObject({ echoed: { x: 1 } });
+  }, 30_000);
+
+  test("throws on failing script and missing script", async () => {
+    await expect(
+      runGlobalScriptByName({ scriptName: "tool-throws", args: {}, agentId }),
+    ).rejects.toThrow("nope");
+    await expect(
+      runGlobalScriptByName({ scriptName: "does-not-exist", args: {}, agentId }),
+    ).rejects.toThrow("not found");
+  }, 30_000);
+});

--- a/src/tests/subscriptions.test.ts
+++ b/src/tests/subscriptions.test.ts
@@ -18,7 +18,9 @@ import { setScriptEmbeddingProviderForTests } from "../be/scripts/embeddings";
 import {
   createSubscription,
   getDeliveryById,
+  getSubscriptionById,
   listDeliveriesForSubscription,
+  updateSubscription,
 } from "../be/subscriptions-db";
 import {
   initSubscriptions,
@@ -161,6 +163,38 @@ describe("event pattern matcher", () => {
     expect(validateEventPattern("a..b")).not.toBeNull();
     expect(validateEventPattern("a.**.b")).not.toBeNull();
     expect(validateEventPattern("task.foo*")).not.toBeNull();
+  });
+});
+
+describe("updateSubscription", () => {
+  test("patches fields, clears filter with null, pauses via enabled", async () => {
+    await saveGlobalScript(
+      "sub-patch-fixture",
+      `export default async function run() { return { ok: true }; }`,
+    );
+    const sub = createSubscription({
+      name: `patch-${crypto.randomUUID()}`,
+      eventPattern: "patchtest.*",
+      filter: { a: 1 },
+      targetType: "script",
+      scriptName: "sub-patch-fixture",
+      createdByAgentId: agentId,
+    });
+
+    const updated = updateSubscription(sub.id, {
+      eventPattern: "patchtest.**",
+      filter: null,
+      enabled: false,
+      description: "paused",
+    });
+    expect(updated?.eventPattern).toBe("patchtest.**");
+    expect(updated?.filter).toBeUndefined();
+    expect(updated?.enabled).toBe(false);
+    expect(updated?.description).toBe("paused");
+
+    // no-op patch returns current row unchanged
+    expect(updateSubscription(sub.id, {})?.eventPattern).toBe("patchtest.**");
+    expect(getSubscriptionById(sub.id)?.enabled).toBe(false);
   });
 });
 

--- a/src/tests/subscriptions.test.ts
+++ b/src/tests/subscriptions.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Extension-system spike (Layer 1): event subscriptions.
+ *
+ * Covers:
+ * - matcher: glob semantics for dot-separated event names + pattern validation.
+ * - capture: bus emit → swarm_events row + subscription_deliveries rows for
+ *   matching enabled subscriptions only (pattern + wait-filter language).
+ * - dispatch: processPendingDeliveries() runs a real catalog script via the
+ *   scripts-runtime and a workflow via a stub executor registry; failures
+ *   retry up to MAX_ATTEMPTS then land on status='failed'.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { unlink } from "node:fs/promises";
+import { z } from "zod";
+import { closeDb, createAgent, createWorkflow, getWorkflowRun, initDb } from "../be/db";
+import { upsertScriptByName } from "../be/scripts/db";
+import { setScriptEmbeddingProviderForTests } from "../be/scripts/embeddings";
+import {
+  createSubscription,
+  getDeliveryById,
+  listDeliveriesForSubscription,
+} from "../be/subscriptions-db";
+import {
+  initSubscriptions,
+  processPendingDeliveries,
+  setSubscriptionExecutorRegistry,
+  stopSubscriptionDispatcher,
+} from "../subscriptions/dispatcher";
+import { matchesEventPattern, validateEventPattern } from "../subscriptions/matcher";
+import { InProcessEventBus, workflowEventBus } from "../workflows/event-bus";
+import { BaseExecutor, type ExecutorResult } from "../workflows/executors/base";
+import { ExecutorRegistry } from "../workflows/executors/registry";
+import { interpolate } from "../workflows/template";
+
+const TEST_DB_PATH = "./test-subscriptions.sqlite";
+const API_KEY = "test-subscriptions-key-1234567890";
+
+const noOpEmbeddingProvider = {
+  name: "test/noop-subscriptions-embedding",
+  dimensions: 1,
+  async embed() {
+    return null;
+  },
+  async embedBatch(texts: string[]) {
+    return texts.map(() => null);
+  },
+};
+
+class EchoExecutor extends BaseExecutor<typeof EchoExecutor.schema, typeof EchoExecutor.outSchema> {
+  static readonly schema = z.object({ value: z.string().default("ok") });
+  static readonly outSchema = z.object({ value: z.string() });
+
+  readonly type = "echo";
+  readonly mode = "instant" as const;
+  readonly configSchema = EchoExecutor.schema;
+  readonly outputSchema = EchoExecutor.outSchema;
+
+  protected async execute(
+    config: z.infer<typeof EchoExecutor.schema>,
+  ): Promise<ExecutorResult<z.infer<typeof EchoExecutor.outSchema>>> {
+    return { status: "success", output: { value: config.value } };
+  }
+}
+
+let savedEnv: NodeJS.ProcessEnv;
+let agentId: string;
+
+async function removeDbFiles(): Promise<void> {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      await unlink(TEST_DB_PATH + suffix);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+}
+
+async function saveGlobalScript(name: string, source: string) {
+  return upsertScriptByName({
+    name,
+    scope: "global",
+    source,
+    description: `${name} test script`,
+    intent: "subscriptions test fixture",
+    signatureJson: JSON.stringify({ args: { type: "object" }, result: { type: "object" } }),
+    agentId,
+    typeChecked: true,
+  });
+}
+
+/** Emit on the bus and give the async capture tap a beat to persist. */
+async function emitAndSettle(name: string, data: unknown): Promise<void> {
+  workflowEventBus.emit(name, data);
+  await Bun.sleep(100);
+}
+
+/** Drain the pending queue so cross-test claims can't interleave. */
+async function drain(): Promise<void> {
+  while ((await processPendingDeliveries(10)) > 0) {
+    // keep claiming until empty
+  }
+}
+
+beforeAll(async () => {
+  savedEnv = { ...process.env };
+  await removeDbFiles();
+  initDb(TEST_DB_PATH);
+  process.env.AGENT_SWARM_API_KEY = API_KEY;
+  delete process.env.API_KEY;
+  setScriptEmbeddingProviderForTests(noOpEmbeddingProvider);
+
+  const agent = createAgent({ name: "subscriptions-test-agent", isLead: true, status: "idle" });
+  agentId = agent.id;
+
+  const eventBus = new InProcessEventBus();
+  const db = await import("../be/db");
+  const registry = new ExecutorRegistry();
+  registry.register(
+    new EchoExecutor({
+      db,
+      eventBus,
+      interpolate: (template, ctx) => interpolate(template, ctx).result,
+    }),
+  );
+  setSubscriptionExecutorRegistry(registry);
+  initSubscriptions();
+});
+
+afterAll(async () => {
+  stopSubscriptionDispatcher();
+  setSubscriptionExecutorRegistry(null);
+  setScriptEmbeddingProviderForTests(null);
+  closeDb();
+  await removeDbFiles();
+  for (const key of Object.keys(process.env)) {
+    if (!(key in savedEnv)) delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("event pattern matcher", () => {
+  test("exact, single-segment, and multi-segment globs", () => {
+    expect(matchesEventPattern("task.completed", "task.completed")).toBe(true);
+    expect(matchesEventPattern("task.completed", "task.failed")).toBe(false);
+    expect(matchesEventPattern("task.*", "task.completed")).toBe(true);
+    expect(matchesEventPattern("task.*", "task.a.b")).toBe(false);
+    expect(matchesEventPattern("github.**", "github.pull_request.opened")).toBe(true);
+    expect(matchesEventPattern("github.**", "github")).toBe(false);
+    expect(matchesEventPattern("*", "ping")).toBe(true);
+    expect(matchesEventPattern("*", "task.completed")).toBe(false);
+    expect(matchesEventPattern("**", "task.completed")).toBe(true);
+  });
+
+  test("pattern validation", () => {
+    expect(validateEventPattern("task.*")).toBeNull();
+    expect(validateEventPattern("github.**")).toBeNull();
+    expect(validateEventPattern("")).not.toBeNull();
+    expect(validateEventPattern("a..b")).not.toBeNull();
+    expect(validateEventPattern("a.**.b")).not.toBeNull();
+    expect(validateEventPattern("task.foo*")).not.toBeNull();
+  });
+});
+
+describe("capture: bus emit → deliveries", () => {
+  test("matching enabled subscription enqueues a delivery; filter mismatch does not", async () => {
+    await saveGlobalScript(
+      "sub-noop",
+      `export default async function run(args: Record<string, unknown>) { return { ok: true }; }`,
+    );
+    const matching = createSubscription({
+      name: `capture-match-${crypto.randomUUID()}`,
+      eventPattern: "spiketest.*",
+      targetType: "script",
+      scriptName: "sub-noop",
+      createdByAgentId: agentId,
+    });
+    const filtered = createSubscription({
+      name: `capture-filtered-${crypto.randomUUID()}`,
+      eventPattern: "spiketest.*",
+      filter: { kind: "never-matches" },
+      targetType: "script",
+      scriptName: "sub-noop",
+      createdByAgentId: agentId,
+    });
+    const disabled = createSubscription({
+      name: `capture-disabled-${crypto.randomUUID()}`,
+      eventPattern: "spiketest.*",
+      targetType: "script",
+      scriptName: "sub-noop",
+      enabled: false,
+      createdByAgentId: agentId,
+    });
+
+    await emitAndSettle("spiketest.created", { kind: "demo", taskId: "t-1" });
+
+    expect(listDeliveriesForSubscription(matching.id)).toHaveLength(1);
+    expect(listDeliveriesForSubscription(matching.id)[0]?.status).toBe("pending");
+    expect(listDeliveriesForSubscription(filtered.id)).toHaveLength(0);
+    expect(listDeliveriesForSubscription(disabled.id)).toHaveLength(0);
+
+    await drain();
+  });
+});
+
+describe("dispatch: script target", () => {
+  test("runs the catalog script with the event as args.event", async () => {
+    await saveGlobalScript(
+      "sub-echo-event",
+      `export default async function run(args: Record<string, unknown>) {
+         const event = args.event as { name: string };
+         if (!event || event.name !== "spikescript.fired") {
+           throw new Error("event not injected: " + JSON.stringify(args));
+         }
+         return { seen: event.name };
+       }`,
+    );
+    const sub = createSubscription({
+      name: `dispatch-script-${crypto.randomUUID()}`,
+      eventPattern: "spikescript.fired",
+      targetType: "script",
+      scriptName: "sub-echo-event",
+      createdByAgentId: agentId,
+    });
+
+    await emitAndSettle("spikescript.fired", { payload: 42 });
+    await drain();
+
+    const deliveries = listDeliveriesForSubscription(sub.id);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]?.status).toBe("succeeded");
+    expect(deliveries[0]?.result).toMatchObject({ scriptName: "sub-echo-event", exitCode: 0 });
+  }, 30_000);
+
+  test("failing script retries then lands on failed", async () => {
+    await saveGlobalScript(
+      "sub-always-throws",
+      `export default async function run() { throw new Error("boom"); }`,
+    );
+    const sub = createSubscription({
+      name: `dispatch-retry-${crypto.randomUUID()}`,
+      eventPattern: "spikeretry.fired",
+      targetType: "script",
+      scriptName: "sub-always-throws",
+      createdByAgentId: agentId,
+    });
+
+    await emitAndSettle("spikeretry.fired", {});
+    const first = listDeliveriesForSubscription(sub.id)[0];
+    expect(first?.status).toBe("pending");
+
+    // MAX_ATTEMPTS = 3: attempts 1..2 fail → pending again; attempt 3 → failed.
+    await drain();
+    const done = getDeliveryById(first!.id);
+    expect(done?.status).toBe("failed");
+    expect(done?.attempts).toBe(3);
+    expect(done?.error).toContain("boom");
+  }, 60_000);
+});
+
+describe("dispatch: workflow target", () => {
+  test("triggers the workflow with { event, subscriptionId } trigger data", async () => {
+    const wf = createWorkflow({
+      name: `sub-test-wf-${crypto.randomUUID()}`,
+      definition: { nodes: [{ id: "n1", type: "echo", config: { value: "hi" } }] },
+      createdByAgentId: agentId,
+    });
+    const sub = createSubscription({
+      name: `dispatch-workflow-${crypto.randomUUID()}`,
+      eventPattern: "spikewf.**",
+      targetType: "workflow",
+      workflowId: wf.id,
+      createdByAgentId: agentId,
+    });
+
+    await emitAndSettle("spikewf.thing.happened", { detail: "x" });
+    await drain();
+
+    const deliveries = listDeliveriesForSubscription(sub.id);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]?.status).toBe("succeeded");
+    const runId = (deliveries[0]?.result as { workflowRunId?: string })?.workflowRunId;
+    expect(runId).toBeTruthy();
+    const run = getWorkflowRun(runId!);
+    expect(run).toBeTruthy();
+    expect(run?.triggerData).toMatchObject({
+      subscriptionId: sub.id,
+      event: { name: "spikewf.thing.happened", data: { detail: "x" } },
+    });
+  }, 30_000);
+});

--- a/src/tests/tool-annotations.test.ts
+++ b/src/tests/tool-annotations.test.ts
@@ -331,7 +331,7 @@ describe("Tool Annotations & Classification", () => {
     // Includes 11 skill tools, 7 MCP server tools, reusable script tools, and the
     // native Kapso/WhatsApp tools (register/unregister number + send/reply message).
     expect(count).toBeGreaterThanOrEqual(45);
-    expect(count).toBeLessThanOrEqual(125);
+    expect(count).toBeLessThanOrEqual(130);
   });
 
   test("core tools are fewer than deferred tools", () => {

--- a/src/tests/tool-annotations.test.ts
+++ b/src/tests/tool-annotations.test.ts
@@ -331,7 +331,7 @@ describe("Tool Annotations & Classification", () => {
     // Includes 11 skill tools, 7 MCP server tools, reusable script tools, and the
     // native Kapso/WhatsApp tools (register/unregister number + send/reply message).
     expect(count).toBeGreaterThanOrEqual(45);
-    expect(count).toBeLessThanOrEqual(120);
+    expect(count).toBeLessThanOrEqual(125);
   });
 
   test("core tools are fewer than deferred tools", () => {

--- a/src/tools/dynamic-script-tools.ts
+++ b/src/tools/dynamic-script-tools.ts
@@ -1,0 +1,87 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod";
+import { listScriptTools } from "@/be/script-tools-db";
+import { getScript } from "@/be/scripts/db";
+import { runGlobalScriptByName } from "@/be/scripts/run-global";
+import { createToolRegistrar } from "@/tools/utils";
+
+/**
+ * Extension system, Layer 3: register every enabled script-backed tool
+ * (script_tools table) on the given MCP server. Called from createServer(),
+ * which runs per MCP session — newly published tools appear on the next
+ * session, same freshness contract as prompt/config changes.
+ *
+ * Input args are passed through to the script unvalidated at the MCP layer
+ * (permissive schema); the script's own `argsSchema` (Zod, enforced by the
+ * eval harness) is the validation boundary. The script's stored
+ * `argsJsonSchema` is appended to the tool description so agents see the
+ * expected shape.
+ */
+export function registerDynamicScriptTools(server: McpServer): number {
+  let tools: ReturnType<typeof listScriptTools>;
+  try {
+    tools = listScriptTools({ enabledOnly: true });
+  } catch (err) {
+    // DB not migrated/initialized in this context — a server without dynamic
+    // tools is better than no server.
+    console.error("[ScriptTools] Failed to list script tools:", err);
+    return 0;
+  }
+
+  const registrar = createToolRegistrar(server);
+  let registered = 0;
+  for (const tool of tools) {
+    const script = getScript({ name: tool.scriptName, scope: "global" });
+    if (!script) {
+      console.warn(
+        `[ScriptTools] Skipping '${tool.toolName}' — script '${tool.scriptName}' missing`,
+      );
+      continue;
+    }
+    let description = tool.description;
+    if (script.argsJsonSchema) {
+      description += `\n\nArgs JSON Schema:\n${script.argsJsonSchema}`;
+    }
+    registrar(
+      tool.toolName,
+      {
+        title: tool.toolName,
+        description,
+        annotations: { destructiveHint: false },
+        inputSchema: z.record(z.string(), z.unknown()),
+        outputSchema: z.object({
+          success: z.boolean(),
+          result: z.unknown().optional(),
+          error: z.string().optional(),
+        }),
+      },
+      async (args, requestInfo) => {
+        try {
+          const { result } = await runGlobalScriptByName({
+            scriptName: tool.scriptName,
+            args,
+            agentId: requestInfo.agentId ?? tool.createdByAgentId ?? "script-tool",
+          });
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  result === undefined ? "Script completed (no result)." : JSON.stringify(result),
+              },
+            ],
+            structuredContent: { success: true, result },
+          };
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return {
+            content: [{ type: "text", text: `Script tool failed: ${message}` }],
+            structuredContent: { success: false, error: message },
+          };
+        }
+      },
+    );
+    registered++;
+  }
+  return registered;
+}

--- a/src/tools/script-tools.ts
+++ b/src/tools/script-tools.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod";
+import { resolveTaskAuditUserId } from "@/be/audit-user";
 import { getAgentById } from "@/be/db";
 import {
   createScriptTool,
@@ -111,6 +112,8 @@ export const registerScriptToolsTool = (server: McpServer) => {
             scriptName: args.scriptName,
             description: args.description,
             createdByAgentId: requestInfo.agentId,
+            createdBy:
+              resolveTaskAuditUserId(requestInfo.sourceTaskId, requestInfo.agentId) ?? undefined,
           });
           return respond(
             true,
@@ -127,7 +130,9 @@ export const registerScriptToolsTool = (server: McpServer) => {
         }
         case "enable":
         case "disable": {
-          if (!setScriptToolEnabled(args.toolName, args.action === "enable")) {
+          const updatedBy =
+            resolveTaskAuditUserId(requestInfo.sourceTaskId, requestInfo.agentId) ?? undefined;
+          if (!setScriptToolEnabled(args.toolName, args.action === "enable", updatedBy)) {
             return respond(false, `Tool '${args.toolName}' not found`);
           }
           return respond(true, `Tool '${args.toolName}' ${args.action}d.`);

--- a/src/tools/script-tools.ts
+++ b/src/tools/script-tools.ts
@@ -1,0 +1,138 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod";
+import { getAgentById } from "@/be/db";
+import {
+  createScriptTool,
+  deleteScriptTool,
+  getScriptToolByName,
+  listScriptTools,
+  setScriptToolEnabled,
+} from "@/be/script-tools-db";
+import { getScript } from "@/be/scripts/db";
+import { can } from "@/rbac";
+import { ALL_TOOLS } from "@/tools/tool-config";
+import { createToolRegistrar } from "@/tools/utils";
+import { ScriptToolSchema } from "@/types";
+
+const TOOL_NAME_PATTERN = /^[a-z][a-z0-9_-]{2,63}$/;
+
+export const registerScriptToolsTool = (server: McpServer) => {
+  createToolRegistrar(server)(
+    "script-tools",
+    {
+      title: "Manage Script-Backed Tools",
+      annotations: { destructiveHint: true },
+      description:
+        "Publish a global catalog script as an agent-visible MCP tool (lead only), unpublish, " +
+        "enable/disable, or list. Published tools become callable on the next MCP session; the " +
+        "script receives the tool call arguments as its args.",
+      inputSchema: z.object({
+        action: z.enum(["publish", "unpublish", "enable", "disable", "list"]),
+        toolName: z
+          .string()
+          .optional()
+          .describe(
+            "Tool name (^[a-z][a-z0-9_-]{2,63}$). Required for all actions except 'list'. " +
+              "Must not collide with a built-in tool.",
+          ),
+        scriptName: z
+          .string()
+          .optional()
+          .describe("Global catalog script to back the tool. Required for 'publish'."),
+        description: z
+          .string()
+          .min(1)
+          .max(1024)
+          .optional()
+          .describe("Tool description shown to agents. Required for 'publish'."),
+      }),
+      outputSchema: z.object({
+        yourAgentId: z.string().uuid().optional(),
+        success: z.boolean(),
+        message: z.string(),
+        tools: z.array(ScriptToolSchema).optional(),
+      }),
+    },
+    async (args, requestInfo) => {
+      const respond = (success: boolean, message: string, tools?: unknown[]) => ({
+        content: [{ type: "text" as const, text: message }],
+        structuredContent: {
+          yourAgentId: requestInfo.agentId,
+          success,
+          message,
+          ...(tools ? { tools } : {}),
+        },
+      });
+
+      if (args.action === "list") {
+        const tools = listScriptTools();
+        return respond(
+          true,
+          tools.length === 0
+            ? "No script-backed tools published."
+            : tools
+                .map((t) => `${t.enabled ? "●" : "○"} ${t.toolName} → script:${t.scriptName}`)
+                .join("\n"),
+          tools,
+        );
+      }
+
+      const callerAgent = requestInfo.agentId ? getAgentById(requestInfo.agentId) : null;
+      if (!callerAgent) return respond(false, 'Agent not found. Set the "X-Agent-ID" header.');
+      const decision = can({
+        principal: { kind: "agent", agentId: callerAgent.id, isLead: callerAgent.isLead },
+        verb: "tool.publish",
+        source: "mcp",
+      });
+      if (!decision.allow) {
+        return respond(false, `Not allowed: ${decision.reason ?? "tool.publish"}`);
+      }
+
+      if (!args.toolName) return respond(false, "toolName is required");
+
+      switch (args.action) {
+        case "publish": {
+          if (!TOOL_NAME_PATTERN.test(args.toolName)) {
+            return respond(false, "toolName must match ^[a-z][a-z0-9_-]{2,63}$");
+          }
+          if (ALL_TOOLS.has(args.toolName)) {
+            return respond(false, `'${args.toolName}' collides with a built-in tool`);
+          }
+          if (getScriptToolByName(args.toolName)) {
+            return respond(false, `Tool '${args.toolName}' is already published`);
+          }
+          if (!args.scriptName) return respond(false, "scriptName is required for publish");
+          if (!args.description) return respond(false, "description is required for publish");
+          if (!getScript({ name: args.scriptName, scope: "global" })) {
+            return respond(false, `Script '${args.scriptName}' not found in global scope`);
+          }
+          const tool = createScriptTool({
+            toolName: args.toolName,
+            scriptName: args.scriptName,
+            description: args.description,
+            createdByAgentId: requestInfo.agentId,
+          });
+          return respond(
+            true,
+            `Published tool '${tool.toolName}' → script '${tool.scriptName}'. ` +
+              "Available to agents on their next MCP session.",
+            [tool],
+          );
+        }
+        case "unpublish": {
+          if (!deleteScriptTool(args.toolName)) {
+            return respond(false, `Tool '${args.toolName}' not found`);
+          }
+          return respond(true, `Unpublished tool '${args.toolName}'.`);
+        }
+        case "enable":
+        case "disable": {
+          if (!setScriptToolEnabled(args.toolName, args.action === "enable")) {
+            return respond(false, `Tool '${args.toolName}' not found`);
+          }
+          return respond(true, `Tool '${args.toolName}' ${args.action}d.`);
+        }
+      }
+    },
+  );
+};

--- a/src/tools/subscriptions/create-subscription.ts
+++ b/src/tools/subscriptions/create-subscription.ts
@@ -1,8 +1,9 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod";
-import { getWorkflow } from "@/be/db";
+import { getAgentById, getWorkflow } from "@/be/db";
 import { getScript } from "@/be/scripts/db";
 import { createSubscription, getSubscriptionByName } from "@/be/subscriptions-db";
+import { can } from "@/rbac";
 import { validateEventPattern } from "@/subscriptions/matcher";
 import { SubscriptionSchema, SubscriptionTargetTypeSchema } from "@/subscriptions/types";
 import { createToolRegistrar } from "@/tools/utils";
@@ -68,6 +69,17 @@ export const registerCreateSubscriptionTool = (server: McpServer) => {
     },
     async (args, requestInfo) => {
       try {
+        const callerAgent = requestInfo.agentId ? getAgentById(requestInfo.agentId) : null;
+        if (!callerAgent) throw new Error('Agent not found. Set the "X-Agent-ID" header.');
+        const decision = can({
+          principal: { kind: "agent", agentId: callerAgent.id, isLead: callerAgent.isLead },
+          verb: "subscription.write",
+          source: "mcp",
+        });
+        if (!decision.allow) {
+          throw new Error(`Not allowed: ${decision.reason ?? "subscription.write"}`);
+        }
+
         const patternError = validateEventPattern(args.eventPattern);
         if (patternError) throw new Error(patternError);
         if (args.targetType === "script") {

--- a/src/tools/subscriptions/create-subscription.ts
+++ b/src/tools/subscriptions/create-subscription.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod";
+import { resolveTaskAuditUserId } from "@/be/audit-user";
 import { getAgentById, getWorkflow } from "@/be/db";
 import { getScript } from "@/be/scripts/db";
 import { createSubscription, getSubscriptionByName } from "@/be/subscriptions-db";
@@ -109,6 +110,8 @@ export const registerCreateSubscriptionTool = (server: McpServer) => {
           workflowId: args.workflowId,
           enabled: args.enabled,
           createdByAgentId: requestInfo.agentId,
+          createdBy:
+            resolveTaskAuditUserId(requestInfo.sourceTaskId, requestInfo.agentId) ?? undefined,
         });
 
         return {

--- a/src/tools/subscriptions/create-subscription.ts
+++ b/src/tools/subscriptions/create-subscription.ts
@@ -1,0 +1,129 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod";
+import { getWorkflow } from "@/be/db";
+import { getScript } from "@/be/scripts/db";
+import { createSubscription, getSubscriptionByName } from "@/be/subscriptions-db";
+import { validateEventPattern } from "@/subscriptions/matcher";
+import { SubscriptionSchema, SubscriptionTargetTypeSchema } from "@/subscriptions/types";
+import { createToolRegistrar } from "@/tools/utils";
+
+export const createSubscriptionInputSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(100)
+    .describe("Unique name for the subscription (e.g., 'triage-failed-tasks')"),
+  description: z.string().optional().describe("Human-readable description"),
+  eventPattern: z
+    .string()
+    .min(1)
+    .describe(
+      "Glob over dot-separated event names: '*' matches one segment, '**' (last segment only) " +
+        "matches the rest. Examples: 'task.completed', 'task.*', 'github.**'.",
+    ),
+  filter: z
+    .union([z.record(z.string(), z.unknown()), z.string()])
+    .optional()
+    .describe(
+      "Optional payload filter (wait-node filter language): object of dot-path → expected value " +
+        "for deep-equal matching, or a string expression over the event payload.",
+    ),
+  targetType: SubscriptionTargetTypeSchema.describe(
+    "What to run when the event fires: 'script' (global catalog script, receives the event as " +
+      "args.event) or 'workflow' (triggered with { event, subscriptionId } as trigger data).",
+  ),
+  scriptName: z
+    .string()
+    .optional()
+    .describe("Catalog script name (global scope). Required when targetType is 'script'."),
+  scriptArgs: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe("Extra JSON args merged into the script invocation (event wins on key 'event')."),
+  workflowId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Workflow ID to trigger. Required when targetType is 'workflow'."),
+  enabled: z.boolean().default(true).optional(),
+});
+
+export const registerCreateSubscriptionTool = (server: McpServer) => {
+  createToolRegistrar(server)(
+    "create-subscription",
+    {
+      title: "Create Event Subscription",
+      annotations: { destructiveHint: false },
+      description:
+        "Subscribe a catalog script or workflow to swarm events (task lifecycle, GitHub/GitLab " +
+        "webhooks, approvals, …). When a matching event fires, the target runs with the event " +
+        "payload. Delivery is at-least-once with retries.",
+      inputSchema: createSubscriptionInputSchema,
+      outputSchema: z.object({
+        yourAgentId: z.string().uuid().optional(),
+        success: z.boolean(),
+        message: z.string(),
+        subscription: SubscriptionSchema.optional(),
+      }),
+    },
+    async (args, requestInfo) => {
+      try {
+        const patternError = validateEventPattern(args.eventPattern);
+        if (patternError) throw new Error(patternError);
+        if (args.targetType === "script") {
+          if (!args.scriptName) throw new Error("scriptName is required when targetType=script");
+          if (!getScript({ name: args.scriptName, scope: "global" })) {
+            throw new Error(`Script '${args.scriptName}' not found in global scope`);
+          }
+        }
+        if (args.targetType === "workflow") {
+          if (!args.workflowId) throw new Error("workflowId is required when targetType=workflow");
+          if (!getWorkflow(args.workflowId)) {
+            throw new Error(`Workflow ${args.workflowId} not found`);
+          }
+        }
+        if (getSubscriptionByName(args.name)) {
+          throw new Error(`Subscription '${args.name}' already exists`);
+        }
+
+        const subscription = createSubscription({
+          name: args.name,
+          description: args.description,
+          eventPattern: args.eventPattern,
+          filter: args.filter,
+          targetType: args.targetType,
+          scriptName: args.scriptName,
+          scriptArgs: args.scriptArgs,
+          workflowId: args.workflowId,
+          enabled: args.enabled,
+          createdByAgentId: requestInfo.agentId,
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Created subscription "${args.name}" (${args.eventPattern} → ${args.targetType}).`,
+            },
+          ],
+          structuredContent: {
+            yourAgentId: requestInfo.agentId,
+            success: true,
+            message: `Created subscription "${args.name}".`,
+            subscription,
+          },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown error";
+        return {
+          content: [{ type: "text", text: `Failed to create subscription: ${message}` }],
+          structuredContent: {
+            yourAgentId: requestInfo.agentId,
+            success: false,
+            message: `Failed to create subscription: ${message}`,
+          },
+        };
+      }
+    },
+  );
+};

--- a/src/tools/subscriptions/delete-subscription.ts
+++ b/src/tools/subscriptions/delete-subscription.ts
@@ -1,6 +1,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod";
+import { getAgentById } from "@/be/db";
 import { deleteSubscription, getSubscriptionByName } from "@/be/subscriptions-db";
+import { can } from "@/rbac";
 import { createToolRegistrar } from "@/tools/utils";
 
 export const registerDeleteSubscriptionTool = (server: McpServer) => {
@@ -20,6 +22,22 @@ export const registerDeleteSubscriptionTool = (server: McpServer) => {
       }),
     },
     async (args, requestInfo) => {
+      const callerAgent = requestInfo.agentId ? getAgentById(requestInfo.agentId) : null;
+      const decision = callerAgent
+        ? can({
+            principal: { kind: "agent", agentId: callerAgent.id, isLead: callerAgent.isLead },
+            verb: "subscription.write",
+            source: "mcp",
+          })
+        : { allow: false as const, reason: "agent not found" };
+      if (!decision.allow) {
+        const message = `Not allowed: ${"reason" in decision ? decision.reason : "subscription.write"}`;
+        return {
+          content: [{ type: "text", text: message }],
+          structuredContent: { yourAgentId: requestInfo.agentId, success: false, message },
+        };
+      }
+
       const sub = getSubscriptionByName(args.name);
       if (!sub) {
         return {

--- a/src/tools/subscriptions/delete-subscription.ts
+++ b/src/tools/subscriptions/delete-subscription.ts
@@ -1,0 +1,45 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod";
+import { deleteSubscription, getSubscriptionByName } from "@/be/subscriptions-db";
+import { createToolRegistrar } from "@/tools/utils";
+
+export const registerDeleteSubscriptionTool = (server: McpServer) => {
+  createToolRegistrar(server)(
+    "delete-subscription",
+    {
+      title: "Delete Event Subscription",
+      annotations: { destructiveHint: true },
+      description: "Delete an event subscription by name. Pending deliveries are not executed.",
+      inputSchema: z.object({
+        name: z.string().min(1).describe("Subscription name to delete"),
+      }),
+      outputSchema: z.object({
+        yourAgentId: z.string().uuid().optional(),
+        success: z.boolean(),
+        message: z.string(),
+      }),
+    },
+    async (args, requestInfo) => {
+      const sub = getSubscriptionByName(args.name);
+      if (!sub) {
+        return {
+          content: [{ type: "text", text: `Subscription '${args.name}' not found` }],
+          structuredContent: {
+            yourAgentId: requestInfo.agentId,
+            success: false,
+            message: `Subscription '${args.name}' not found`,
+          },
+        };
+      }
+      deleteSubscription(sub.id);
+      return {
+        content: [{ type: "text", text: `Deleted subscription '${args.name}'` }],
+        structuredContent: {
+          yourAgentId: requestInfo.agentId,
+          success: true,
+          message: `Deleted subscription '${args.name}'`,
+        },
+      };
+    },
+  );
+};

--- a/src/tools/subscriptions/delete-subscription.ts
+++ b/src/tools/subscriptions/delete-subscription.ts
@@ -22,32 +22,26 @@ export const registerDeleteSubscriptionTool = (server: McpServer) => {
       }),
     },
     async (args, requestInfo) => {
+      const fail = (message: string) => ({
+        content: [{ type: "text" as const, text: message }],
+        structuredContent: { yourAgentId: requestInfo.agentId, success: false, message },
+      });
+
       const callerAgent = requestInfo.agentId ? getAgentById(requestInfo.agentId) : null;
-      const decision = callerAgent
-        ? can({
-            principal: { kind: "agent", agentId: callerAgent.id, isLead: callerAgent.isLead },
-            verb: "subscription.write",
-            source: "mcp",
-          })
-        : { allow: false as const, reason: "agent not found" };
-      if (!decision.allow) {
-        const message = `Not allowed: ${"reason" in decision ? decision.reason : "subscription.write"}`;
-        return {
-          content: [{ type: "text", text: message }],
-          structuredContent: { yourAgentId: requestInfo.agentId, success: false, message },
-        };
-      }
+      if (!callerAgent) return fail('Agent not found. Set the "X-Agent-ID" header.');
 
       const sub = getSubscriptionByName(args.name);
-      if (!sub) {
-        return {
-          content: [{ type: "text", text: `Subscription '${args.name}' not found` }],
-          structuredContent: {
-            yourAgentId: requestInfo.agentId,
-            success: false,
-            message: `Subscription '${args.name}' not found`,
-          },
-        };
+      if (!sub) return fail(`Subscription '${args.name}' not found`);
+
+      // Lead or the creating agent may delete (mirrors task.cancel.any's shape).
+      const decision = can({
+        principal: { kind: "agent", agentId: callerAgent.id, isLead: callerAgent.isLead },
+        verb: "subscription.mutate.any",
+        resource: { kind: "owned", ownerAgentId: sub.createdByAgentId ?? null },
+        source: "mcp",
+      });
+      if (!decision.allow) {
+        return fail(`Not allowed: ${decision.reason ?? "subscription.mutate.any"}`);
       }
       deleteSubscription(sub.id);
       return {

--- a/src/tools/subscriptions/index.ts
+++ b/src/tools/subscriptions/index.ts
@@ -1,3 +1,4 @@
 export { registerCreateSubscriptionTool } from "./create-subscription";
 export { registerDeleteSubscriptionTool } from "./delete-subscription";
 export { registerListSubscriptionsTool } from "./list-subscriptions";
+export { registerPatchSubscriptionTool } from "./patch-subscription";

--- a/src/tools/subscriptions/index.ts
+++ b/src/tools/subscriptions/index.ts
@@ -1,0 +1,3 @@
+export { registerCreateSubscriptionTool } from "./create-subscription";
+export { registerDeleteSubscriptionTool } from "./delete-subscription";
+export { registerListSubscriptionsTool } from "./list-subscriptions";

--- a/src/tools/subscriptions/list-subscriptions.ts
+++ b/src/tools/subscriptions/list-subscriptions.ts
@@ -1,0 +1,59 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod";
+import { listDeliveriesForSubscription, listSubscriptions } from "@/be/subscriptions-db";
+import { SubscriptionDeliverySchema, SubscriptionSchema } from "@/subscriptions/types";
+import { createToolRegistrar } from "@/tools/utils";
+
+export const registerListSubscriptionsTool = (server: McpServer) => {
+  createToolRegistrar(server)(
+    "list-subscriptions",
+    {
+      title: "List Event Subscriptions",
+      annotations: { readOnlyHint: true },
+      description:
+        "List event subscriptions (event pattern → script/workflow bindings), optionally with " +
+        "recent delivery attempts per subscription.",
+      inputSchema: z.object({
+        enabledOnly: z.boolean().default(false).optional(),
+        includeDeliveries: z
+          .boolean()
+          .default(false)
+          .optional()
+          .describe("Include the 5 most recent deliveries per subscription"),
+      }),
+      outputSchema: z.object({
+        yourAgentId: z.string().uuid().optional(),
+        subscriptions: z.array(
+          SubscriptionSchema.extend({
+            recentDeliveries: z.array(SubscriptionDeliverySchema).optional(),
+          }),
+        ),
+      }),
+    },
+    async (args, requestInfo) => {
+      const subscriptions = listSubscriptions({ enabledOnly: args.enabledOnly }).map((sub) =>
+        args.includeDeliveries
+          ? { ...sub, recentDeliveries: listDeliveriesForSubscription(sub.id, 5) }
+          : sub,
+      );
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              subscriptions.length === 0
+                ? "No subscriptions."
+                : subscriptions
+                    .map(
+                      (s) =>
+                        `${s.enabled ? "●" : "○"} ${s.name}: ${s.eventPattern} → ` +
+                        `${s.targetType === "script" ? `script:${s.scriptName}` : `workflow:${s.workflowId}`}`,
+                    )
+                    .join("\n"),
+          },
+        ],
+        structuredContent: { yourAgentId: requestInfo.agentId, subscriptions },
+      };
+    },
+  );
+};

--- a/src/tools/subscriptions/patch-subscription.ts
+++ b/src/tools/subscriptions/patch-subscription.ts
@@ -47,15 +47,20 @@ export const registerPatchSubscriptionTool = (server: McpServer) => {
 
       const callerAgent = requestInfo.agentId ? getAgentById(requestInfo.agentId) : null;
       if (!callerAgent) return fail('Agent not found. Set the "X-Agent-ID" header.');
-      const decision = can({
-        principal: { kind: "agent", agentId: callerAgent.id, isLead: callerAgent.isLead },
-        verb: "subscription.write",
-        source: "mcp",
-      });
-      if (!decision.allow) return fail(`Not allowed: ${decision.reason ?? "subscription.write"}`);
 
       const sub = getSubscriptionByName(args.name);
       if (!sub) return fail(`Subscription '${args.name}' not found`);
+
+      // Lead or the creating agent may mutate (mirrors task.cancel.any's shape).
+      const decision = can({
+        principal: { kind: "agent", agentId: callerAgent.id, isLead: callerAgent.isLead },
+        verb: "subscription.mutate.any",
+        resource: { kind: "owned", ownerAgentId: sub.createdByAgentId ?? null },
+        source: "mcp",
+      });
+      if (!decision.allow) {
+        return fail(`Not allowed: ${decision.reason ?? "subscription.mutate.any"}`);
+      }
       if (args.eventPattern !== undefined) {
         const patternError = validateEventPattern(args.eventPattern);
         if (patternError) return fail(patternError);

--- a/src/tools/subscriptions/patch-subscription.ts
+++ b/src/tools/subscriptions/patch-subscription.ts
@@ -1,0 +1,81 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod";
+import { getAgentById } from "@/be/db";
+import { getSubscriptionByName, updateSubscription } from "@/be/subscriptions-db";
+import { can } from "@/rbac";
+import { validateEventPattern } from "@/subscriptions/matcher";
+import { SubscriptionSchema } from "@/subscriptions/types";
+import { createToolRegistrar } from "@/tools/utils";
+
+export const registerPatchSubscriptionTool = (server: McpServer) => {
+  createToolRegistrar(server)(
+    "patch-subscription",
+    {
+      title: "Patch Event Subscription",
+      annotations: { destructiveHint: false },
+      description:
+        "Update fields of an event subscription: pause/resume (enabled), description, " +
+        "eventPattern, filter, or scriptArgs. Target (script/workflow) is immutable — " +
+        "delete and recreate to retarget.",
+      inputSchema: z.object({
+        name: z.string().min(1).describe("Subscription name to patch"),
+        description: z.string().optional(),
+        eventPattern: z.string().min(1).optional(),
+        filter: z
+          .union([z.record(z.string(), z.unknown()), z.string(), z.null()])
+          .optional()
+          .describe("New payload filter; pass null to clear"),
+        scriptArgs: z
+          .union([z.record(z.string(), z.unknown()), z.null()])
+          .optional()
+          .describe("New extra script args; pass null to clear"),
+        enabled: z.boolean().optional().describe("false pauses the subscription"),
+      }),
+      outputSchema: z.object({
+        yourAgentId: z.string().uuid().optional(),
+        success: z.boolean(),
+        message: z.string(),
+        subscription: SubscriptionSchema.optional(),
+      }),
+    },
+    async (args, requestInfo) => {
+      const fail = (message: string) => ({
+        content: [{ type: "text" as const, text: message }],
+        structuredContent: { yourAgentId: requestInfo.agentId, success: false, message },
+      });
+
+      const callerAgent = requestInfo.agentId ? getAgentById(requestInfo.agentId) : null;
+      if (!callerAgent) return fail('Agent not found. Set the "X-Agent-ID" header.');
+      const decision = can({
+        principal: { kind: "agent", agentId: callerAgent.id, isLead: callerAgent.isLead },
+        verb: "subscription.write",
+        source: "mcp",
+      });
+      if (!decision.allow) return fail(`Not allowed: ${decision.reason ?? "subscription.write"}`);
+
+      const sub = getSubscriptionByName(args.name);
+      if (!sub) return fail(`Subscription '${args.name}' not found`);
+      if (args.eventPattern !== undefined) {
+        const patternError = validateEventPattern(args.eventPattern);
+        if (patternError) return fail(patternError);
+      }
+
+      const updated = updateSubscription(sub.id, {
+        description: args.description,
+        eventPattern: args.eventPattern,
+        filter: args.filter,
+        scriptArgs: args.scriptArgs,
+        enabled: args.enabled,
+      });
+      return {
+        content: [{ type: "text", text: `Updated subscription '${args.name}'.` }],
+        structuredContent: {
+          yourAgentId: requestInfo.agentId,
+          success: true,
+          message: `Updated subscription '${args.name}'.`,
+          subscription: updated ?? undefined,
+        },
+      };
+    },
+  );
+};

--- a/src/tools/subscriptions/patch-subscription.ts
+++ b/src/tools/subscriptions/patch-subscription.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod";
+import { resolveTaskAuditUserId } from "@/be/audit-user";
 import { getAgentById } from "@/be/db";
 import { getSubscriptionByName, updateSubscription } from "@/be/subscriptions-db";
 import { can } from "@/rbac";
@@ -66,6 +67,8 @@ export const registerPatchSubscriptionTool = (server: McpServer) => {
         filter: args.filter,
         scriptArgs: args.scriptArgs,
         enabled: args.enabled,
+        updatedBy:
+          resolveTaskAuditUserId(requestInfo.sourceTaskId, requestInfo.agentId) ?? undefined,
       });
       return {
         content: [{ type: "text", text: `Updated subscription '${args.name}'.` }],

--- a/src/tools/tool-config.ts
+++ b/src/tools/tool-config.ts
@@ -53,6 +53,10 @@ export const DEFERRED_TOOLS = new Set([
   "patch-subscription",
   "delete-subscription",
 
+  // Script-backed tools management (1) — the published tools themselves are
+  // dynamic (script_tools table) and intentionally not in this static set
+  "script-tools",
+
   // Workflows (11)
   "create-workflow",
   "list-workflows",

--- a/src/tools/tool-config.ts
+++ b/src/tools/tool-config.ts
@@ -47,9 +47,10 @@ export const DEFERRED_TOOLS = new Set([
   "delete-schedule",
   "run-schedule-now",
 
-  // Event subscriptions (3) — extension-system spike
+  // Event subscriptions (4)
   "create-subscription",
   "list-subscriptions",
+  "patch-subscription",
   "delete-subscription",
 
   // Workflows (11)

--- a/src/tools/tool-config.ts
+++ b/src/tools/tool-config.ts
@@ -47,6 +47,11 @@ export const DEFERRED_TOOLS = new Set([
   "delete-schedule",
   "run-schedule-now",
 
+  // Event subscriptions (3) — extension-system spike
+  "create-subscription",
+  "list-subscriptions",
+  "delete-subscription",
+
   // Workflows (11)
   "create-workflow",
   "list-workflows",

--- a/src/types.ts
+++ b/src/types.ts
@@ -2557,6 +2557,8 @@ export const SubscriptionSchema = z.object({
   workflowId: z.string().optional(),
   enabled: z.boolean(),
   createdByAgentId: z.string().optional(),
+  createdBy: z.string().optional(),
+  updatedBy: z.string().optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
@@ -2602,6 +2604,8 @@ export const ScriptToolSchema = z.object({
   description: z.string(),
   enabled: z.boolean(),
   createdByAgentId: z.string().optional(),
+  createdBy: z.string().optional(),
+  updatedBy: z.string().optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -2591,3 +2591,18 @@ export const SubscriptionDeliverySchema = z.object({
   createdAt: z.string(),
 });
 export type SubscriptionDelivery = z.infer<typeof SubscriptionDeliverySchema>;
+
+// ── Script-backed tools (extension system, Layer 3) ─────────────────────────
+// Keep in sync with src/be/migrations/118_script_tools.sql.
+
+export const ScriptToolSchema = z.object({
+  id: z.string(),
+  toolName: z.string(),
+  scriptName: z.string(),
+  description: z.string(),
+  enabled: z.boolean(),
+  createdByAgentId: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type ScriptTool = z.infer<typeof ScriptToolSchema>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2527,3 +2527,67 @@ export const KvEntrySchema = z.object({
   updatedAt: z.number().int(),
 });
 export type KvEntry = z.infer<typeof KvEntrySchema>;
+
+// ── Event subscriptions (extension system, Layer 1) ─────────────────────────
+// Keep in sync with src/be/migrations/117_swarm_events_subscriptions.sql
+// CHECK constraints (targetType ∈ {script, workflow}; delivery status ∈
+// {pending, running, succeeded, failed}).
+
+export const SubscriptionTargetTypeSchema = z.enum(["script", "workflow"]);
+export type SubscriptionTargetType = z.infer<typeof SubscriptionTargetTypeSchema>;
+
+export const SubscriptionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  /**
+   * Glob over dot-separated event names: `*` matches one segment,
+   * `**` (last segment only) matches the rest. e.g. "task.*", "github.**".
+   */
+  eventPattern: z.string(),
+  /**
+   * Optional payload filter using the wait-node filter language: either an
+   * object of dot-path → expected value, or a string expression compiled by
+   * src/workflows/wait-filter.ts.
+   */
+  filter: z.unknown().optional(),
+  targetType: SubscriptionTargetTypeSchema,
+  scriptName: z.string().optional(),
+  scriptArgs: z.record(z.string(), z.unknown()).optional(),
+  workflowId: z.string().optional(),
+  enabled: z.boolean(),
+  createdByAgentId: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type Subscription = z.infer<typeof SubscriptionSchema>;
+
+export const SwarmBusEventSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  data: z.unknown().optional(),
+  emittedAt: z.string(),
+});
+export type SwarmBusEvent = z.infer<typeof SwarmBusEventSchema>;
+
+export const SubscriptionDeliveryStatusSchema = z.enum([
+  "pending",
+  "running",
+  "succeeded",
+  "failed",
+]);
+export type SubscriptionDeliveryStatus = z.infer<typeof SubscriptionDeliveryStatusSchema>;
+
+export const SubscriptionDeliverySchema = z.object({
+  id: z.string(),
+  subscriptionId: z.string(),
+  eventId: z.string(),
+  status: SubscriptionDeliveryStatusSchema,
+  attempts: z.number().int(),
+  claimedAt: z.string().optional(),
+  finishedAt: z.string().optional(),
+  error: z.string().optional(),
+  result: z.unknown().optional(),
+  createdAt: z.string(),
+});
+export type SubscriptionDelivery = z.infer<typeof SubscriptionDeliverySchema>;

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -28,7 +28,7 @@ const MAX_STEPS_PER_RUN = Number(process.env.WORKFLOW_MAX_STEPS_PER_RUN) || 500;
 
 export interface WorkflowExecutionOptions {
   requestedByUserId?: string;
-  triggerType?: "schedule" | "manual" | "event" | "api";
+  triggerType?: "schedule" | "manual" | "event" | "api" | "subscription";
 }
 
 /**

--- a/src/workflows/event-bus.ts
+++ b/src/workflows/event-bus.ts
@@ -4,16 +4,31 @@ export interface WorkflowEventBus {
   emit(event: string, data: unknown): void;
   on(event: string, handler: (data: unknown) => void): void;
   off(event: string, handler: (data: unknown) => void): void;
+  /**
+   * Tap invoked for every emit, regardless of event name. Used by the
+   * subscriptions layer to persist events durably (src/subscriptions).
+   */
+  onAny(handler: (event: string, data: unknown) => void): void;
+  offAny(handler: (event: string, data: unknown) => void): void;
 }
 
 export class InProcessEventBus implements WorkflowEventBus {
   private emitter = new EventEmitter();
+  private anyHandlers: Array<(event: string, data: unknown) => void> = [];
 
   constructor() {
     this.emitter.setMaxListeners(100);
   }
 
   emit(event: string, data: unknown): void {
+    for (const handler of this.anyHandlers) {
+      try {
+        handler(event, data);
+      } catch (err) {
+        // A failing tap must never break the emitting call site.
+        console.error(`[EventBus] onAny handler failed for '${event}':`, err);
+      }
+    }
     this.emitter.emit(event, data);
   }
 
@@ -23,6 +38,14 @@ export class InProcessEventBus implements WorkflowEventBus {
 
   off(event: string, handler: (data: unknown) => void): void {
     this.emitter.off(event, handler);
+  }
+
+  onAny(handler: (event: string, data: unknown) => void): void {
+    this.anyHandlers.push(handler);
+  }
+
+  offAny(handler: (event: string, data: unknown) => void): void {
+    this.anyHandlers = this.anyHandlers.filter((h) => h !== handler);
   }
 }
 

--- a/thoughts/taras/research/2026-07-18-extension-system-spike.md
+++ b/thoughts/taras/research/2026-07-18-extension-system-spike.md
@@ -114,3 +114,36 @@ evaluator for operator-installed hooks only. Recommendation: (b) for v1,
 3. SDK exposure (`subscription_create` et al.) so agents/scripts self-serve.
 4. Journal retention policy + events HTTP listing for the UI.
 5. Then Layer 3 (script-backed tools) — independent of all of the above.
+
+## Update 2026-07-18 (later): promotion + Layer 3 DONE on this branch
+
+Steps 1–4 above shipped in `d9da8556`, Layer 3 in `340e80b2`:
+
+- **Promotion (`d9da8556`)**: `subscription.write` verb (anyAuthenticated) gating
+  create/patch/delete; new `patch-subscription` tool (pause/resume, pattern,
+  filter, args); schemas hoisted to `src/types.ts` (renamed `SwarmBusEvent` —
+  `SwarmEventSchema` was taken by the telemetry `events` table from the
+  2026-03-25 plan, which SHIPPED — worth evaluating as the long-term journal
+  substrate); `subscription_create/list/patch/delete` in the scripts SDK
+  (+ regenerated d.ts, healing pre-existing `schedule_patch` drift where the
+  generated file had been hand-edited); Linear (`linear.<type>.<action>`) and
+  Jira (`jira.<event>`) now emit on the bus (Slack already emitted
+  `slack.message` — runbook list was stale); hourly journal prune
+  (succeeded 14d / failed 30d / orphan events 30d).
+- **Layer 3 (`340e80b2`)**: `script_tools` table (migration 118); lead-gated
+  `script-tools` management tool (`tool.publish` verb, leadOnly); dynamic
+  registration in `createServer()` — per-session, so published tools appear on
+  next MCP session; input passthrough with the script's `argsJsonSchema` in
+  the description, script-side Zod as the validation boundary; shared
+  `runGlobalScriptByName()` helper (dispatcher refactored onto it; scheduler
+  still has its older copy — small follow-up).
+
+All gates green after both commits: full `bun test` (6285 ran, 0 fail),
+rbac-coverage (53 verbs), db-boundary, sdk-tool-registration, dep-graph,
+lint, tsc, MCP.md + swarm-sdk.d.ts regenerated, migrations 117+118 verified
+fresh + existing.
+
+**Remaining before merge to main**: manual E2E against a live server; decide
+whether `swarm_events` should fold into the existing telemetry `events` table;
+UI surface for subscriptions/deliveries/script-tools; docs-site page. Layers
+2 (hook points) and 4 (pack manifest) are unbuilt — next design checkpoints.

--- a/thoughts/taras/research/2026-07-18-extension-system-spike.md
+++ b/thoughts/taras/research/2026-07-18-extension-system-spike.md
@@ -1,0 +1,116 @@
+---
+date: 2026-07-18T16:00:00+02:00
+researcher: Claude
+git_commit: d33d280c
+branch: spike/extension-system
+repository: agent-swarm
+topic: "Extension-system spike: Layer 1 (event subscriptions) implementation + findings"
+tags: [spike, extensions, subscriptions, event-bus, scripts-runtime, latency]
+status: complete
+autonomy: autopilot
+last_updated: 2026-07-18
+last_updated_by: Claude
+---
+
+# Spike: Extension System — Layer 1 (Event Subscriptions)
+
+Companion to `2026-07-18-swarm-extension-system.md` (the research + proposal).
+This spike implements the proposal's MVP slice on branch `spike/extension-system`
+and records what it validated, what it changed vs. the proposal, and the
+measured answer to the `tool.before_call` latency question.
+
+## What was built
+
+**"On event X, run script/workflow Y"** — the react-to-things primitive, end to end:
+
+| Piece | File | Notes |
+|---|---|---|
+| Migration | `src/be/migrations/117_swarm_events_subscriptions.sql` | `swarm_events` (journal), `subscriptions`, `subscription_deliveries` (outbox, `UNIQUE(subscriptionId, eventId)` dedupe) |
+| Bus tap | `src/workflows/event-bus.ts` | `onAny`/`offAny` added to `WorkflowEventBus` — every emit reaches the capture layer without touching any emit site |
+| Types | `src/subscriptions/types.ts` | module-local Zod schemas (production: hoist to `src/types.ts`) |
+| Matcher | `src/subscriptions/matcher.ts` | dot-segment glob: `*` = one segment, `**` = rest (last segment only) |
+| DB layer | `src/be/subscriptions-db.ts` | CRUD + atomic claim (`UPDATE … WHERE id IN (SELECT … LIMIT n) RETURNING *`) |
+| Dispatcher | `src/subscriptions/dispatcher.ts` | capture (pattern + reused `wait-filter` language) → deliveries; scheduler-style poller executes script targets (same invocation pattern as `executeScheduleScript`) and workflow targets (`triggerType: "subscription"` added to the engine union); MAX_ATTEMPTS=3 retry |
+| MCP tools | `src/tools/subscriptions/` | `create-subscription` (validates pattern + target existence), `list-subscriptions` (with recent deliveries), `delete-subscription`; registered in `server.ts`, DEFERRED_TOOLS, EXCLUDED from scripts SDK for now |
+| Boot | `src/http/index.ts` | `startSubscriptionDispatcher()` unless `SUBSCRIPTIONS_DISABLE=true`; `SUBSCRIPTIONS_INTERVAL_MS` (default 2000) |
+| Tests | `src/tests/subscriptions.test.ts` | 6 tests: matcher semantics, capture w/ filter + disabled exclusion, real sandboxed script execution with `args.event` injection, retry→failed (attempts=3), workflow trigger with `{event, subscriptionId}` trigger data |
+| Latency probe | `scripts/spike-script-spawn-latency.ts` | see below |
+
+Verification run: `bun run tsc:check` ✓, `bun run lint` ✓, full `bun test` ✓
+(6268 pass; one pre-existing tool-count band in `tool-annotations.test.ts`
+bumped 120→125 for the 3 new tools), `check-db-boundary.sh` ✓,
+`check:dep-graph` ✓ (0 errors), `check-sdk-tool-registration` ✓ (18 excluded),
+migration verified against fresh DB **and** a copy of the dev DB, `MCP.md`
+regenerated (124 tools).
+
+## Measured: scripts-runtime spawn latency
+
+`AGENT_SWARM_API_KEY=123123 bun scripts/spike-script-spawn-latency.ts`
+(trivial script through the full sandbox: ulimit preamble + `env -i` +
+stdin config + eval harness), 10 runs after 2 warmups, on the M-series dev box:
+
+```
+min=61ms  p50=179ms  p95=215ms  max=215ms
+```
+
+**Verdict for the proposal's open question:** ~180ms typical is
+**unacceptable for a synchronous per-tool-call hook** (`tool.before_call`) —
+agents make many tool calls per minute and this would dominate dispatch time.
+It is **perfectly fine** for the cold paths (`task.before_create`,
+`event.before_task`, subscription dispatch). `tool.before_call` therefore
+needs one of: (a) a resident warm hook-runner process (pool of pre-spawned
+harnesses fed over stdin), (b) matcher-gating so the sandbox only spawns for
+explicitly named tools (Claude Code-style), or (c) an in-process trusted-tier
+evaluator for operator-installed hooks only. Recommendation: (b) for v1,
+(a) if usage grows.
+
+## What the spike validated
+
+1. **The `onAny` tap is the right capture point.** Zero emit sites changed;
+   Slack/Linear/Jira remain the only gap (they don't emit at all yet — still
+   the one-line follow-ups listed in `runbooks/workflows.md`).
+2. **The scheduler is a ready-made template.** Poller shape, script invocation
+   (credential bindings, connection descriptors, timeout), and the
+   executor-registry injection/fallback pattern all transplanted cleanly.
+3. **Reusing the wait-node filter language works** — one filter dialect across
+   wait nodes and subscriptions, no new DSL.
+4. **The scripts sandbox is a viable extension runtime**: real scripts received
+   the event payload as `args.event`, ran, failed, and retried exactly as
+   designed, inside the existing resource limits.
+5. **The event journal write is cheap** and only happens when ≥1 subscription
+   matches (spike behavior — see trade-offs).
+
+## Deviations from the proposal / spike shortcuts (production TODOs)
+
+- **Events are journaled only when a subscription matches.** The proposal's
+  "durable journal of everything" would bloat on `task.progress`; decide a
+  retention/filter policy (e.g. journal all except a denylist, TTL cleanup in
+  `cleanupStaleResources`).
+- **Capture is in-process** (tap → async persist). True transactional emit
+  (event row written in the same transaction as the state change) needs the
+  emit-site refactor; deferred with rationale in the dispatcher header comment.
+- **No RBAC verbs yet** (`subscription.write` etc. — research gap #11); tools
+  are currently ungated like most main-surface tools. Add before merge.
+- **Zod schemas are module-local** (`src/subscriptions/types.ts`), not in
+  `src/types.ts`.
+- **Not exposed to the scripts SDK** (EXCLUDED_TOOLS) — flip to
+  `SDK_TOOL_NAME_MAP` + regenerate `swarm-sdk.d.ts` once the design settles,
+  so scripts can self-subscribe.
+- **Multi-replica claim/lease** (gap #12) untouched — single-statement UPDATE
+  claim is single-process-safe only.
+- **No HTTP routes / UI** — MCP-only surface for the spike.
+- **No pause tool** (`setSubscriptionEnabled` exists in the DB layer; only
+  create/list/delete are exposed).
+- **Manual E2E not run** (server + live task lifecycle); unit tests exercise
+  the real sandbox and real workflow engine. Suggested manual check:
+  `bun run start:http`, `create-subscription` on `task.completed` → a noop
+  global script, complete any task, `list-subscriptions includeDeliveries=true`.
+
+## Next steps (if promoted from spike)
+
+1. RBAC verbs + `patch-subscription`/pause tool + schemas → `src/types.ts`.
+2. Wire Slack/Linear/Jira/heartbeat emitters onto the bus (unlocks the
+   integration-pack scenario).
+3. SDK exposure (`subscription_create` et al.) so agents/scripts self-serve.
+4. Journal retention policy + events HTTP listing for the UI.
+5. Then Layer 3 (script-backed tools) — independent of all of the above.

--- a/thoughts/taras/research/2026-07-18-swarm-extension-system.md
+++ b/thoughts/taras/research/2026-07-18-swarm-extension-system.md
@@ -1,0 +1,292 @@
+---
+date: 2026-07-18T12:00:00+02:00
+researcher: Claude
+git_commit: ebba27fa
+branch: main
+repository: agent-swarm
+topic: "Extension system for agent-swarm — extend/script the swarm without contributing to core"
+tags: [research, codebase, extensions, plugins, scripts-runtime, workflows, event-bus, pi-mono, prior-art, proposal]
+status: complete
+autonomy: autopilot
+last_updated: 2026-07-18
+last_updated_by: Claude
+---
+
+# Research: Extension System for Agent-Swarm
+
+**Date**: 2026-07-18
+**Researcher**: Claude
+**Git Commit**: ebba27fa
+**Branch**: main
+
+## Research Question
+
+How could agent-swarm be made extensible/scriptable without contributing to core? Study pi-mono's extension system as the prime example, plus other prior art (Claude Code plugins, OpenCode, VS Code, n8n, etc.). The swarm already has many primitives (scripts-runtime, workflows, MCP tools, hooks, prompt-template registry, integrations). Target: something someone could ship as an npm package, OR the swarm's own agents could build as a runtime-pluggable thing — e.g. new integrations, changing behavior, reacting to events.
+
+Deliverable includes (explicitly requested): proposal ideas + gaps/changes needed in the current architecture.
+
+## Summary
+
+**The swarm already has ~70% of an extension system — what's missing is the connective tissue, not the primitives.** Today an external MCP client or an in-swarm agent can: register versioned, typechecked TS scripts into a catalog (`script_upsert`); compose them into workflow DAGs with 11 node types; schedule workflows/scripts/tasks on cron; publish any script as a public HTTP endpoint (`script_apis`); register typed API connections with host-scoped secret injection (script-connections); override prompt-template bodies per global/agent/repo scope at runtime; and edit per-agent behavior files (soulMd/toolsMd/claudeMd/setupScript) live. That is already "runtime-pluggable things built by agents."
+
+**The four missing pieces are:** (1) **reacting to events** — an in-process `workflowEventBus` exists and task/GitHub/GitLab events land on it, but nothing lets user code *subscribe* (wait-nodes can match events mid-run, but there's no durable "on `task.completed` run script X" primitive, and Slack/Linear/Jira never emit); (2) **changing behavior** — every interception point (worker hooks, tool admission, prompt composition structure, task routing) is compile-time TypeScript with no veto/mutate handler registry; (3) **adding agent-visible tools** — the MCP tool registry is a hardcoded import list in `src/server.ts`; a catalog script cannot be surfaced as a tool; (4) **a packaging unit** — nothing bundles scripts + workflows + subscriptions + prompt overrides + skills + connections into one installable, upgradable artifact, even though the seeder framework (`src/be/seed/`) was explicitly designed to grow into exactly this.
+
+**Prior art points at a clear shape.** pi-mono is the strongest reference: a default-exported TS factory receiving an `ExtensionAPI`, ~27 lifecycle events each returning a *narrow typed result* (block/transform/replace — never a generic mutation blob), tool/command/provider registration, jiti zero-build loading, npm/git "pi packages", and a `project_trust` gate. Its philosophy ("every feature you add to the core is a feature the agent can no longer reason about"; "pi can create extensions — ask it to build one") matches the swarm's agent-authored goal exactly. Meanwhile *no* surveyed system (Claude Code, OpenCode, VS Code, n8n, Obsidian) achieves real sandboxing — they all rely on curation or manual review. Agent-swarm's `Bun.spawn` + ulimit + stdin-config scripts sandbox is therefore a genuine differentiator: the swarm can safely let *untrusted agents* author extensions, which none of the prior art can.
+
+The proposal (§Proposal) is a four-layer design — durable event subscriptions, sandboxed hook points with pi-style typed results, script-backed tools, and a "swarm pack" manifest installed through the existing seeder — with an MVP slice that is mostly wiring, not new machinery.
+
+## Detailed Findings
+
+### 1. Existing extensibility primitives (the asset inventory)
+
+#### 1.1 Scripts-runtime — the sandboxed execution primitive
+
+- **Sandbox**: `src/scripts-runtime/executors/native.ts` spawns `sh -c` with a ulimit preamble (`memoryMb: 512, cpuTimeSec: 60, wallClockMs: 30_000, maxProcs: 32, maxFdCount: 64, maxStdoutBytes: 1MB` — `executors/types.ts:80-88`) and `env -i` environment scrubbing. Config (agentId, bearer, mcpBaseUrl) flows as JSON over **stdin**, with the bearer wrapped in `Redacted<string>` (`swarm-config.ts:4-33`) — user code never sees the raw key.
+- **Import allowlist**: only `swarm-sdk`, `stdlib`, `zod`, relative imports (`import-allowlist.ts:3-4`); `node:*`, `bun:*`, `fs`, `child_process` are banned.
+- **Typed SDK**: `SDK_TOOL_NAME_MAP` (`src/scripts-runtime/sdk-allowlist.ts`) maps SDK methods → registered MCP tools, verified at build time by `scripts/bundle-script-types.ts` (boots a real server, asserts every method resolves) and CI (`scripts/check-sdk-tool-registration.ts`). Notably scripts can already call `workflow_create/patch/trigger` and `script_run`/`script_search` — **scripts can compose workflows and invoke other scripts**.
+- **Catalog + versioning**: `scripts` + `script_versions` tables (`src/be/migrations/064_scripts.sql`), unique `(name, scope, scopeId)`, content-hash version pinning (`pinHash`), embeddings for semantic search (migration 065), `argsSchema` Zod validation, `tsc --noEmit` typecheck on upsert (`src/be/scripts/typecheck.ts`).
+- **Executor registry**: `executors/registry.ts:4-16` is a name→factory map keyed by `SCRIPT_EXECUTOR` — a ready-made seam for E2B/Docker backends, currently `native` only.
+- **script_apis**: any script can be published as `POST /api/x/script/<endpointId>` (`src/http/x.ts`) — public endpoint id, optional encrypted bearer, timeout header up to 300s. This is already "turn a script into a webhook handler," minus signature verification and event semantics.
+- **Credential broker**: `[REDACTED:<configKey>]` placeholders substituted by a patched `fetch` **only for hostnames on the binding's `allowedHosts`** (`credential-broker/fetch-patch.ts:63-91`) — host-scoped, SSRF-safe secret injection. Connections registry (`script_connections`, kinds `raw/openapi/mcp/graphql`, migrations 101/102/112) types the external APIs scripts talk to.
+- **Seeder framework**: `src/be/seed/` + `src/be/seed-scripts/catalog/` (~24 built-ins) with pristine-vs-user-modified content-hash tracking (`seed_state`, migration 069). `runbooks/seed-scripts.md` explicitly says: "the mechanism is generic so future kinds (workflows, schedules, skills, …) plug in the same way."
+- **What's absent**: no event/cron trigger owned by scripts-runtime itself (invocation = explicit tool call, workflow node, or published endpoint), and no hook/extension registry of any kind (`grep` confirms).
+
+#### 1.2 Workflow engine + event bus — the reaction machinery
+
+- **Node types** (11, each self-describing via `z.toJSONSchema`, exposed at `GET /api/executor-types` — `src/http/workflows.ts:259-282`): `property-match`, `code-match`, `notify`, `raw-llm`, `script`, `swarm-script`, `vcs`, `validate` (instant); `agent-task`, `human-in-the-loop`, `wait` (async). Registry: `src/workflows/executors/registry.ts`.
+- **Triggers**: manual (`trigger-workflow` MCP + HTTP), webhook (`POST /api/webhooks/{workflowId}`), schedule (scheduler with `targetType: agent-task|workflow|script`, migration 103, `src/scheduler/scheduler.ts:120,248,379`). `triggerSchema` validates trigger data uniformly (`engine.ts:54-60`).
+- **Event bus**: `src/workflows/event-bus.ts` — `InProcessEventBus` over Node `EventEmitter`, singleton `workflowEventBus`. **In-process only; multi-replica deployments won't propagate** (documented limitation).
+- **Emit sites**: task lifecycle (`task.completed/failed/cancelled/created/progress/budget_refused` from `src/be/db.ts`), `approval.resolved` (`src/http/approval-requests.ts:183`), `agentmail.message.received`, GitHub (`github.pull_request.<action>`, `github.issue.<action>`, `github.issue_comment.created`, `github.pull_request_review.submitted` — `src/http/webhooks.ts:268-302`), GitLab (`:385-418`). **Not wired**: Slack, Linear, Jira, Sentry, Stripe, claude-managed callbacks.
+- **Consumption**: only `wait` nodes (event mode, dot-path or sandboxed-`Function` filters) inside an *already-running* workflow run, plus external signal injection endpoints (`POST /api/workflow-runs/{id}/events`, `POST /api/workflow-events`). There is **no subscription registry** that starts a script/workflow when an event fires.
+
+#### 1.3 Tool registry, prompts, per-agent customization
+
+- **MCP tools**: hardcoded — ~150 `registerXTool(server)` calls in `src/server.ts:9-190`. Registration goes through `createToolRegistrar` (`src/tools/utils.ts:141`; OTel span + secret scrubbing + RequestInfo injection). Two surfaces: full agent-facing (`server.ts`) and curated 5-tool user-facing (`server-user.ts:59-87`, uniformly gated by `decideToolAdmission` — `src/rbac/admission.ts:46`). The main surface self-guards via inline `can()` in 36 tool files instead. `tool-config.ts` splits `CORE_TOOLS`/`DEFERRED_TOOLS` (ToolSearch discovery) — context optimization, not access control. `SCRIPTS_ONLY_MCP=true` collapses the surface to script tools only.
+- **Runtime-CRUD-able registries already exist** for prompt templates (`src/tools/prompt-templates/`), skills (`src/tools/skills/`), MCP servers (`src/tools/mcp-servers/`), script connections (`src/tools/script-connections/`) — i.e., several "contribution kinds" are already data, just not bundled or event-driven.
+- **Prompt registry**: two layers — compile-time `registerTemplate()` map (`src/prompts/registry.ts:33`; ~27 templates in `session-templates.ts`) + runtime DB **body** overrides scoped repo > agent > global (`resolver.ts`, `{{@template[id]}}` recursion, `skip_event` sentinel; workers resolve over HTTP via `POST /api/prompt-templates/render`). **Which sections exist and compose in what order is compile-time** (`base-prompt.ts:96-295` branches in TS).
+- **Per-agent surface**: `claudeMd`, `soulMd`, `identityMd`, `toolsMd`, `setupScript`, `heartbeatMd` (64KB each, `src/types.ts:737-751`), spliced into the system prompt at runtime, editable live via `update-profile` (self-edit or lead coaching, with disk sync into the running container — `update-profile.ts:277-320`). `capabilities` gate task routing, **not** tool access.
+
+#### 1.4 Worker hooks + harness-side plugin bundle
+
+- **Hooks**: `src/hooks/hook.ts` (1318 lines) implements Claude Code lifecycle hooks (SessionStart/PreToolUse/PostToolUse/PreCompact/UserPromptSubmit/Stop), wired via `settings.json` **baked into the worker image** (`Dockerfile.worker:238-255`). Behavior (cancellation check, tool-loop detection, heartbeat, session summary) is fixed; parity re-implementations exist per harness: `src/providers/pi-mono-extension.ts:419` (`createSwarmHooksExtension` — the swarm is *already a pi extension author*) and `plugin/opencode-plugins/agent-swarm.ts` (`@opencode-ai/plugin`).
+- **plugin/ dir**: 13 slash commands (`plugin/commands/*.md` with `<!-- claude-only -->`/`<!-- pi-only -->` markers), 4 subagents, skills, and a generated pi-skills conversion (`plugin/build-pi-skills.ts`) — shipped inside the npm package (`package.json` files array). This is the existing harness-side distribution pipeline: one authoring format → per-harness transforms.
+- **Providers**: `ProviderAdapter` interface (`src/providers/types.ts`) with a hardcoded 6-case switch factory (`providers/index.ts:24-55`), but **selection** is data-driven and live-reconciled every poll cycle from `swarm_config` (`runner.ts:4108-4113`).
+
+#### 1.5 Integrations — the bespoke corner
+
+Each of GitHub/Slack/Linear/Jira/Kapso is a hand-built top-level dir (`app.ts`/`oauth.ts`/`webhook.ts`/`outbound.ts`); the only shared abstraction is the `OAuthProviderConfig` shape (`src/oauth/wrapper.ts:6`). Adding a 5th integration = core PR touching webhook routes, RBAC, event emission, secret storage. The Composio prototype (`docs-site/.../integrations/composio.mdx`, `swarm_x` tool) already outsources *outbound* third-party tool access (Gmail/Notion/HubSpot via Tool Router sessions + Connect Links) — the docs themselves call the long-term shape "API-mediated integration where the swarm server owns auth."
+
+### 2. pi-mono's extension system (the exemplar)
+
+Source studied at `/tmp/pi-mono-research` (shallow clone of `badlogic/pi-mono`; ephemeral — re-clone if needed). Core: `packages/coding-agent/docs/extensions.md` (2944 lines), `src/core/extensions/{types.ts,loader.ts,runner.ts}`, ~90 examples in `examples/extensions/`.
+
+**Shape**: default-exported factory `(pi: ExtensionAPI) => void | Promise<void>`. The API (`types.ts:1167-1402`):
+- `pi.on(event, handler)` — 27 typed overloads; `pi.registerTool/registerCommand/registerShortcut/registerFlag/registerProvider/registerMessageRenderer`; session actions (`sendMessage`, `appendEntry`, `setSessionName`); runtime control (`setModel`, `setActiveTools`); inter-extension `pi.events` bus.
+
+**The five design lessons that matter for the swarm:**
+1. **Narrow typed results per event, never a generic mutation blob.** `tool_call` → `{block: true, reason}`; `input` → `continue | transform | handled`; `context` → filtered message array; `message_end` → replacement message (same role enforced); `before_agent_start` → inject message / rewrite system prompt. Handler chaining is defined (load order, each sees the previous result). This is the single cleanest part of the design.
+2. **Two-tier context to prevent deadlocks**: event handlers get safe `ExtensionContext`; only command handlers get `ExtensionCommandContext` (adds `waitForIdle/newSession/fork/reload`) because those can deadlock the agent loop.
+3. **Zero-build TS loading** (jiti, `tryNative: false`, virtual modules in the compiled binary; npm deps via a sibling `package.json`). Discovery: project `.pi/extensions/` (gated behind a `project_trust` event) + global `~/.pi/agent/extensions/` + settings/CLI paths; packages via `pi install npm:@foo/bar` bundling extensions+skills+prompts+themes under a `pi` manifest key in `package.json`.
+4. **State persistence pattern**: store extension state in tool-result `details`, reconstruct on `session_start` by walking the session branch — survives forking. Two visibility tiers: messages (LLM-visible) vs entries (session-durable, TUI-only).
+5. **Philosophy** (Zechner's blog + docs): "Every feature you add to the agent core is a feature the agent can no longer reason freely about" — even MCP support is an extension, not core. And the first line of the extensions doc: "pi can create extensions. Ask it to build one for your use case." Extensions run with full user permissions; trust = the `project_trust` gate + "only install what you trust."
+
+Representative examples: `permission-gate.ts` (confirm dangerous bash), `protected-paths.ts`, `git-checkpoint.ts`, `todo.ts` (stateful tool + command), `dynamic-tools.ts` (post-startup registration), `subagent/` (1015-line subagent orchestrator), `custom-provider-anthropic/` (full OAuth provider), `ssh.ts` (reroutes all built-in tools to a remote machine via pluggable `*Operations`), `doom-overlay/`.
+
+Note: the swarm's prior deep dive `thoughts/taras/research/2026-03-08-pi-mono-deep-dive.md` §4 already sketched "agent profile could gain customTools / extension paths" and a `HARNESS_EXTENSIONS` env — worker-side loading of pi extensions is essentially solved design.
+
+### 3. Prior art survey (condensed)
+
+| System | Unit / distribution | Hook model | Veto/mutate? | Sandbox | Discovery |
+|---|---|---|---|---|---|
+| **pi** | TS module, jiti-loaded; file drop or npm "pi package" | 27 lifecycle events, typed results | **Yes** (block/transform/replace) | None; `project_trust` gate | None (npm/file) |
+| **Claude Code plugins** | Dir + `.claude-plugin/plugin.json` (name-only manifest, conventional dirs auto-discovered: commands/agents/skills/hooks/.mcp.json) | ~12+ hook events, regex matchers, external process | **Yes** (exit 2 / `permissionDecision: deny`) | None (manual review) | Git-repo marketplaces (`marketplace.json`), official + community |
+| **OpenCode** | JS/TS module or npm pkg (auto `bun install` from config) | 25+ events (`tool.execute.before`, `session.idle`…) | **Yes** | None (host Bun process) | npm itself |
+| **VS Code** | npm-style pkg, declarative `contributes` + activation events | Activation gating only | No | Process isolation (Extension Host) but full app privileges | Central marketplace |
+| **n8n community nodes** | npm pkg `n8n-nodes-*`, `INodeType` + credentials classes | N/A (workflow node unit) | No | None; **2-tier trust** (unverified self-host-only vs Verified: vetted, no runtime deps, provenance) | In-app for Verified |
+| **Zapier CLI** | JS app pushed to Zapier infra | N/A (declarative triggers/actions/auth) | No | Runs on their infra | Curated app store |
+| **Obsidian** | Dir + manifest + main.js, curated registry | Observational events | Limited | None (full Electron) | Curated in-app |
+| **Mastra / LangGraph** | MCP-as-plugin-system / Python middleware | MCP protocol / `before_model`-style hooks | LangGraph: yes | None | MCP ecosystem / none |
+
+**Cross-cutting takeaways:**
+- Veto/mutate hooks are the norm for agent-adjacent systems, absent from static connector platforms. The swarm needs both kinds: n8n-style *connector* contributions (integrations) AND pi-style *interception* hooks (behavior).
+- **Nobody sandboxes.** Trust is curation (n8n Verified: no runtime deps + provenance attestation; Obsidian/Raycast review) or a warning label (pi, Claude Code, OpenCode). VS Code's Extension Host isolates for *stability*, not security. The swarm's scripts sandbox is the only real capability boundary in this whole comparison set.
+- Manifest-optional auto-discovery (Claude Code: only `name` required) is the best authoring ergonomics surveyed; explicit manifests (n8n/VS Code) buy static validation and marketplace metadata.
+- VS Code's activation events (lazy: declare contributions, boot on trigger) is the pattern for keeping a large installed base cheap — analogous to the swarm's existing CORE/DEFERRED tool split.
+- Distribution: git-repo marketplaces (Claude Code) need zero hosting; npm gives versioning/provenance for free. n8n proves npm + naming convention + keyword is a viable discovery layer without building anything.
+
+### 4. Historical context (from thoughts/)
+
+- `thoughts/taras/research/2026-03-08-pi-mono-deep-dive.md` — §4 "Extensions and Custom Tools" already flags "agent-swarm's tool set is static… no mechanism for agents to register custom tools or users to add extensions", and sketches 4 extension layers for the pi adapter.
+- `thoughts/taras/research/2026-03-10-configurable-event-prompts.md` — ~25 hardcoded webhook→task prompt templates in `src/github|gitlab|agentmail/handlers.ts`; evaluated workflows vs DB table vs config for making them configurable (the prompt-template registry has since shipped, but the *event→handler binding* remains hardcoded).
+- `thoughts/taras/plans/2026-03-25-generic-events-table.md` — a designed-but-separate `events` table (category/event/data JSON, batch worker ingestion) for telemetry; relevant as the durable-events substrate the current in-process bus lacks.
+- `thoughts/taras/research/2026-03-18-workflow-redesign.md` — the workflow engine's design history.
+- Project memory: the scripts-only MCP experiment (3v3 matrix) found the **full MCP tool surface beat code-mode on Claude** ($1.83 vs $3.13) with context a wash thanks to ToolSearch — a counterweight to pi's "no baked-in tool schemas" argument; deferred-tool discovery makes a *growing* tool surface tolerable, so extension-registered tools don't have to be rationed aggressively.
+
+## Proposal
+
+> Requested explicitly: proposal ideas + gaps. Everything below is proposal, not documentation of current state.
+
+### Design stance
+
+Two authoring personas, one mechanism:
+- **Community/human**: ships a versioned npm package ("swarm pack") — n8n-style naming + manifest, installed by an operator.
+- **The swarm's own agents**: call the same underlying CRUD primitives (`script_upsert`, `workflow_create`, `subscription_create`, …) directly at runtime — no package needed; a pack is *only* the bundling/versioning/distribution layer over primitives that must each work standalone.
+
+And one hard architectural choice: **server-side extension code runs in the scripts sandbox, not in the API process.** pi/OpenCode load extensions in-process because they're single-user local tools; the swarm is a multi-tenant server where agents author extensions. The sandbox (already built: ulimits, env scrubbing, Redacted bearer, host-gated secrets, SDK allowlist) is the trust story no prior-art system has. An in-process "native extension" tier for operators (OpenCode-style npm module loaded into the API server) can be a later opt-in for people self-hosting who need custom node executors — keep it out of v1.
+
+Worker-side (harness) extensibility stays native per harness — pi extensions, CC plugin, opencode plugin — distributed through the pack as assets, exactly like `plugin/` does today.
+
+### Layer 1 — Event subscriptions ("react to things")
+
+The single highest-leverage addition. A `subscriptions` table:
+
+```
+subscription: { id, eventPattern ("task.completed", "github.*", glob),
+                target: {type: "script", name, args} | {type: "workflow", id},
+                filter (same dot-path/code filter language as wait-nodes, reuse src/workflows/wait-filter.ts),
+                scope (global|agent|repo), enabled, createdByAgentId,
+                delivery: {maxConcurrency, retries, timeoutMs} }
+```
+
+- Delivery is **durable outbox, not EventEmitter**: emit sites write an event row (the 2026-03-25 generic-events-table design is the substrate) inside the same transaction as the state change; a dispatcher (same pattern as `wait-poller.ts` / scheduler loop) claims rows and invokes targets at-least-once. Fixes the documented multi-replica limitation of `workflowEventBus` at the same time.
+- Script targets receive `ctx.event` in the sandbox; a subscription-triggered script that wants an agent involved calls `task_create` or `workflow_trigger` via the SDK — that already works.
+- Prereq wiring: put Slack/Linear/Jira/Sentry/heartbeat-findings emitters on the bus (already one-line follow-ups per `runbooks/workflows.md`).
+- New MCP tools: `subscription-create/list/delete/pause` + SDK methods. RBAC: `subscription.write` verb; global scope requires lead.
+
+This alone gives: auto-triage on `task.failed`, Slack digests on `task.completed`, label-driven routing on `github.issue.opened`, budget alerts on `task.budget_refused` — all agent-authorable today-shaped scripts.
+
+### Layer 2 — Interception hooks ("change behavior")
+
+pi's key lesson applied server-side: a small set of **named hook points, each with a narrow typed result**, handlers being catalog scripts registered against them:
+
+| Hook point | Fires | Typed result |
+|---|---|---|
+| `task.before_create` | in `createTaskExtended` path | `continue \| {transform: patch} \| {block, reason}` |
+| `task.before_assign` | pool claim / routing | `continue \| {assignTo} \| {block, reason}` |
+| `tool.before_call` | server-side MCP tool dispatch (in `createToolRegistrar`) | `allow \| {deny, reason}` |
+| `event.before_task` | webhook handler → task creation (GitHub/Slack/… prompts) | `continue \| {transform: description/config} \| {drop}` |
+| `prompt.compose` | `getBasePrompt` assembly | `{insert: [{anchor, body}]}` |
+
+- Handlers run **synchronously in-request** in the sandbox with a tight budget (e.g. 2–5s wall, distinct from the 30s script default), explicit per-hook-point fail-open/fail-closed config, priority ordering, and pi-style chaining (each handler sees the previous transform).
+- `tool.before_call` dovetails with RBAC increment-5 (MCP tool admission) — the hook is the *user-extensible* layer on top of the declarative `rbac:` posture, mirroring how `server-user.ts` already wraps admission.
+- `prompt.compose` fixes the "sections are compile-time" gap without opening full prompt rewriting: extensions insert bodies at named anchors (registered in `src/prompts/registry.ts`), headers stay non-overridable.
+- Worker-side (PreToolUse-style veto *inside the harness*) stays with the harness's native mechanism; the pack can carry a pi extension / CC hook for that. Don't rebuild pi inside the worker.
+
+Performance note: hot paths (tool dispatch) must skip the subprocess entirely when zero handlers are registered (one indexed lookup, cached), and per-hook results can be memoized where semantics allow. Sandbox spawn overhead (~tens of ms) is acceptable for task/webhook paths, borderline for `tool.before_call` — consider restricting v1 of that hook to matcher-scoped registration (Claude Code-style tool-name matchers) so it only fires for named tools.
+
+### Layer 3 — Script-backed tools ("add capabilities agents can see")
+
+A `script_tools` registration: expose a catalog script as an MCP tool — name, description, JSON schema derived from its `argsSchema` (Zod → JSON Schema is already how executor types self-describe), scope global/agent/repo. `createToolRegistrar` consults this table at tool-list time; all script-backed tools are DEFERRED_TOOLS (ToolSearch handles surface growth — validated by the scripts-only experiment). Combined with script-connections, this makes "new integration" = connection + scripts + tools + subscriptions, **zero core code**. Optionally same treatment for workflow-backed tools (`triggerSchema` → tool schema).
+
+### Layer 4 — Swarm packs (the unit + distribution)
+
+Manifest, n8n/pi hybrid — npm package named `swarm-pack-*` (or `@scope/swarm-pack-*`) with a `swarm` key:
+
+```jsonc
+// package.json
+{ "name": "@acme/swarm-pack-sentry",
+  "swarm": {
+    "packVersion": 1,
+    "scripts": ["./scripts/*.ts"],            // → script catalog (typechecked on install)
+    "workflows": ["./workflows/*.json"],
+    "subscriptions": ["./subscriptions.json"],
+    "hooks": ["./hooks.json"],                 // hook-point registrations
+    "tools": ["./tools.json"],                 // script-backed tool defs
+    "promptOverrides": ["./prompts/*.md"],
+    "connections": ["./connections.json"],     // declares required config keys + allowedHosts
+    "skills": ["./skills/*"],                  // harness-side, fed through plugin/ conversion pipeline
+    "configSchema": { }                        // JSON Schema for pack settings, surfaced at install
+  } }
+```
+
+- **Installer = the seeder.** `agent-swarm pack install npm:@acme/swarm-pack-sentry@1.2.0` fetches the tarball, validates the manifest, typechecks scripts, checks connection `allowedHosts` + required secrets, then ingests every kind through the existing `Seeder` framework — which already gives pristine-hash upgrade semantics (user-modified entities never clobbered on `pack update`). A `packs` table tracks installed packs, versions, and owned-entity ids for clean uninstall.
+- **Agent-authored path**: an agent that has built scripts/subscriptions can run `pack export` to snapshot them into a pack (publishable or just archived to agent-fs) — closing the loop where the swarm builds its own extensions and they become distributable.
+- **Discovery**: v1 is n8n-style — npm search on the naming convention + keyword. No marketplace infra to build. A curated "verified" list (JSON in the repo or docs-site page) is the v2 trust tier.
+- **Trust model**: all pack code runs sandboxed (unique vs all prior art); network egress limited to declared `allowedHosts` per connection; secrets only via `[REDACTED:key]` broker; install requires operator/lead RBAC (`pack.install`); hooks show provenance ("blocked by @acme/swarm-pack-policy") in logs/UI. Later: n8n-style verified tier (review + provenance attestation).
+
+### What this enables (concrete scenarios)
+
+1. **Sentry integration as a pack**: connection (Sentry API + HMAC secret) + a generic-webhook script published via `script_apis` (needs Gap 6's signature verification) emitting `sentry.issue.created` + subscription → triage workflow + a `sentry_search_issues` script-backed tool. No core PR — versus today, where Sentry would be a 6th bespoke `src/sentry/` dir.
+2. **Org policy pack**: `tool.before_call` handler denying `db-query` for non-lead agents outside work hours; `task.before_create` enforcing budget tags.
+3. **Agent-built automation**: an agent notices repeated manual triage, writes a script, creates a subscription on `task.failed` — live in one conversation, no deploy.
+4. **Prompt pack**: a team ships tuned `system.agent.*` overrides + extra sections via `prompt.compose` anchors + matching skills for all three harnesses.
+
+### Suggested sequencing (MVP → full)
+
+1. **MVP (mostly wiring)**: durable events table + outbox dispatcher; missing bus emitters; `subscriptions` (script/workflow targets) + MCP tools; webhook-signature support on `script_apis` endpoints. → "react to things" done.
+2. **Script-backed tools** (Layer 3) — small, high leverage, exercises the Zod→JSON-schema path.
+3. **Hook points** (Layer 2), starting with `event.before_task` + `task.before_create` (cold paths, immediately useful, low perf risk); `tool.before_call` last.
+4. **Pack manifest + installer** over the seeder; `pack export` for agents.
+5. Later: verified tier, native in-process extension tier for self-hosters, workflow-node-executor contributions, provider adapters as packs.
+
+## Gaps / changes needed in current architecture
+
+| # | Gap | Change | Where |
+|---|---|---|---|
+| 1 | Event bus is in-process, single-replica, and consumable only by in-flight wait-nodes | Durable `events` outbox (reuse 2026-03-25 design) + dispatcher loop; keep `workflowEventBus` as a thin shim over it | `src/workflows/event-bus.ts`, new `src/be/events.ts`, emit sites in `src/be/db.ts` + `src/http/webhooks.ts` |
+| 2 | Slack/Linear/Jira/Sentry/heartbeat never emit events | Add emit calls (documented as one-liners in `runbooks/workflows.md`) | `src/slack/`, `src/linear/webhook.ts`, `src/jira/webhook.ts`, `src/heartbeat/heartbeat.ts` |
+| 3 | No subscription primitive | `subscriptions` table + migration + MCP tools + SDK methods + dispatcher; reuse `wait-filter.ts` filter language | new `src/be/subscriptions.ts`, `src/tools/subscriptions/`, scheduler-style poller |
+| 4 | No interception/hook registry; all behavior compile-time | Named hook points with typed results; registration table; sandbox execution with tight budgets + fail-open/closed config | `createTaskExtended` path, `src/tools/utils.ts` (`createToolRegistrar`), webhook handlers, `src/prompts/base-prompt.ts` |
+| 5 | Tool registry hardcoded; scripts can't surface as tools | `script_tools` table consulted by registrar; Zod `argsSchema` → JSON Schema; register as DEFERRED_TOOLS; admission via existing `decideToolAdmission` | `src/server.ts`, `src/tools/utils.ts`, `src/rbac/admission.ts` |
+| 6 | `script_apis` endpoints lack webhook semantics | Optional per-endpoint HMAC signature verification (secret via connections) + "emit event" mode | `src/http/x.ts`, `script_apis` schema |
+| 7 | Prompt sections/composition are compile-time | Named anchor points in `base-prompt.ts`; `prompt.compose` insertions; keep header non-overridable | `src/prompts/registry.ts`, `base-prompt.ts` |
+| 8 | Scripts sandbox lacks hook/event context + hook-grade budgets | `ctx.event`/`ctx.hook` in `SwarmConfigPayload`; per-invocation resource profile (2–5s hook budget); warm-spawn or matcher gating for hot paths | `src/scripts-runtime/loader.ts`, `eval-harness.ts`, `executors/types.ts` |
+| 9 | SDK surface unversioned; external authors need a stable target | Publish `@desplega.ai/swarm-script-sdk` types package (generated `.d.ts` already exists via `bundle-script-types.ts`); semver it; pack manifest declares `sdkVersion` | `scripts/bundle-script-types.ts`, npm publish pipeline |
+| 10 | Seeder only seeds built-ins | Generalize `Seeder` input to user-supplied packs; `packs` table (version, owned entities, pristine hashes); install/uninstall/update CLI + MCP tools | `src/be/seed/`, new `src/be/packs.ts`, CLI command |
+| 11 | RBAC verbs missing for new surfaces | `subscription.write`, `hook.register`, `pack.install`, `tool.publish` etc. in permissions + legacy-policy; extension-registered non-GET routes N/A (no new routes beyond pack/subscription CRUD) | `src/rbac/permissions.ts`, `src/rbac/legacy-policy.ts` |
+| 12 | Multi-replica double-fire risk for dispatchers | Claim/lease semantics on outbox rows (same pattern as task claim path) | dispatcher implementation |
+| 13 | Harness-side pack assets need per-harness conversion | Generalize `plugin/build-pi-skills.ts` pipeline to consume pack `skills/` at install time; deliver via existing skills runtime CRUD | `plugin/build-pi-skills.ts`, `src/tools/skills/` |
+| 14 | Integrations bespoke; no generic inbound path | Covered by Gaps 3+6 (generic webhook → event → subscription); existing four integrations stay native, new ones start as packs; Composio remains the managed-auth outbound complement | — |
+
+### Open design questions
+
+- **`tool.before_call` latency**: is per-call subprocess spawn acceptable even matcher-gated, or does this hook need a resident hook-runner process (warm sandbox pool)? Measure `native.ts` spawn overhead first.
+- **Fail-open vs fail-closed defaults** per hook point (policy hooks want fail-closed; enrichment hooks fail-open) — needs an explicit table before implementation.
+- **Pack-scoped secrets UX**: `configSchema` at install prompts the operator; where do values live — `swarm_config` scoped keys vs connections? (Probably connections for anything with egress, config for the rest.)
+- **Workflow-node executors as contributions** (true custom node types, not just `swarm-script`) require in-process code — defer to the native-extension tier or model them as script nodes with richer output schemas?
+- **The scripts-only-MCP counterpoint**: pi argues against baked-in tool schemas; the swarm's own experiment says the full surface + ToolSearch wins on Claude. Proposal follows the experiment (script-backed tools as deferred tools) — revisit if the deferred surface grows past ToolSearch's discrimination ability.
+
+## Code References
+
+| File | Line | Description |
+|------|------|-------------|
+| `src/scripts-runtime/executors/native.ts` | 123-134 | ulimit + `env -i` sandbox spawn |
+| `src/scripts-runtime/sdk-allowlist.ts` | — | `SDK_TOOL_NAME_MAP` — curated SDK→MCP bridge |
+| `src/scripts-runtime/executors/registry.ts` | 4-16 | pluggable executor backend seam (native-only today) |
+| `src/scripts-runtime/credential-broker/fetch-patch.ts` | 63-91 | host-gated `[REDACTED:key]` secret substitution |
+| `src/http/x.ts` | — | `POST /api/x/script/<endpointId>` public script endpoints |
+| `src/be/seed/` + `runbooks/seed-scripts.md` | — | generic seeder, "future kinds plug in the same way" |
+| `src/workflows/event-bus.ts` | — | in-process `workflowEventBus` (EventEmitter, single-replica) |
+| `src/workflows/executors/registry.ts` | — | 11 node types, self-describing schemas |
+| `src/http/webhooks.ts` | 268-302, 385-418 | GitHub/GitLab event emission |
+| `src/scheduler/scheduler.ts` | 120, 248, 379 | schedule dispatch (`agent-task`/`workflow`/`script` targets) |
+| `src/server.ts` | 9-190 | hardcoded tool registration (~150 calls) |
+| `src/tools/utils.ts` | 121, 141 | `createToolRegistrar` — the tool-dispatch chokepoint for hooks/admission |
+| `src/rbac/admission.ts` | 46 | `decideToolAdmission` (used only by `server-user.ts` today) |
+| `src/tools/tool-config.ts` | — | CORE/DEFERRED tool split (ToolSearch) |
+| `src/prompts/registry.ts` | 33 | compile-time template registration |
+| `src/prompts/resolver.ts` | 30, 73, 149 | DB overrides (repo>agent>global), HTTP resolver for workers, `{{@template}}` recursion |
+| `src/prompts/base-prompt.ts` | 96-295 | compile-time prompt composition (anchor-point candidate) |
+| `src/hooks/hook.ts` | 422, 943 | worker hook dispatch (fixed behavior, image-baked) |
+| `src/providers/pi-mono-extension.ts` | 419 | `createSwarmHooksExtension` — swarm as pi-extension author |
+| `plugin/build-pi-skills.ts` | 22-36 | per-harness skill conversion pipeline |
+| `src/tools/update-profile.ts` | 277-320 | live per-agent behavior editing (soulMd/toolsMd/setupScript) |
+| `src/oauth/wrapper.ts` | 6 | `OAuthProviderConfig` — only shared integration abstraction |
+| `/tmp/pi-mono-research/packages/coding-agent/src/core/extensions/types.ts` | 1167-1402 | pi `ExtensionAPI` (ephemeral clone) |
+| `/tmp/pi-mono-research/packages/coding-agent/docs/extensions.md` | — | pi extension spec (2944 lines) |
+
+## Open Questions
+
+Carried in §Open design questions above; additionally:
+- Whether `src/tools/mcp-servers/` runtime CRUD already covers "attach external MCP server per agent" well enough to serve as the outbound-integration path for packs (not deep-dived here).
+- Exact spawn latency of the native executor (drives the `tool.before_call` design).
+
+## Appendix
+
+- **Architecture notes**: API server is sole DB owner; workers HTTP-only (`scripts/check-db-boundary.sh`) — any extension mechanism must respect this split, which is why sandboxed server-side scripts + HTTP-consuming worker assets is the natural shape. RBAC (grantsAll no-op in prod today) is the admission substrate for pack/hook/subscription verbs.
+- **Historical context (from thoughts/)**: see §4.
+- **Related research**:
+  - `thoughts/taras/research/2026-03-08-pi-mono-deep-dive.md` — pi integration + first extension-gap observation
+  - `thoughts/taras/research/2026-03-10-configurable-event-prompts.md` — hardcoded event→task prompts (solved by `event.before_task` hook + prompt registry)
+  - `thoughts/taras/plans/2026-03-25-generic-events-table.md` — durable events substrate for Layer 1
+  - `thoughts/taras/research/2026-03-18-workflow-redesign.md` — workflow engine design history


### PR DESCRIPTION
## Summary

First two runnable layers of the extension-system proposal ([research doc](https://github.com/desplega-ai/agent-swarm/blob/spike/extension-system/thoughts/taras/research/2026-07-18-swarm-extension-system.md), [spike findings](https://github.com/desplega-ai/agent-swarm/blob/spike/extension-system/thoughts/taras/research/2026-07-18-extension-system-spike.md)) — making the swarm scriptable without core PRs: **react to events** and **add agent-visible tools**, both agent-authorable at runtime.

### Layer 1 — Event subscriptions (`117_swarm_events_subscriptions.sql`)

- **"On event X, run script/workflow Y"**: `subscriptions` table binds an event-name glob (`task.*`, `github.**`) + optional wait-filter-language payload filter to a target — a global catalog script (event injected as `args.event`) or a workflow (`triggerType: "subscription"`).
- **Capture**: `onAny` tap on `workflowEventBus` — zero emit-site changes. **Delivery**: durable at-least-once outbox (`subscription_deliveries`, 3 attempts, dedupe per subscription×event), scheduler-style poller, hourly journal prune (14/30d).
- **New emitters**: Linear (`linear.<type>.<action>`) and Jira (`jira.<event>`) webhooks now emit on the bus; runbook's stale "not wired" list corrected (Slack already emitted `slack.message`).
- **Surface**: `create/list/patch/delete-subscription` MCP tools (pause/resume via patch), gated by new `subscription.write` RBAC verb; exposed to the scripts SDK as `subscription_*` so scripts can self-subscribe.

### Layer 3 — Script-backed tools (`118_script_tools.sql`)

- Leads publish a global catalog script as a named MCP tool via `script-tools` (new lead-only `tool.publish` verb, built-in name collision guard).
- `createServer()` registers enabled `script_tools` rows per session — published tools appear on agents' next MCP connect. Args pass through to the sandbox; the script's own Zod `argsSchema` is the validation boundary (stored `argsJsonSchema` shown in the tool description).
- Shared `runGlobalScriptByName()` helper (subscription dispatcher refactored onto it; scheduler still has its older copy — follow-up).

### Measured

Sandbox spawn latency for a trivial script: **p50 179ms / min 61ms / p95 215ms** (`scripts/spike-script-spawn-latency.ts`) — fine for these cold paths; rules out naive per-tool-call sync hooks for the future Layer 2 (needs matcher-gating or a warm pool).

### Drive-bys

- Healed pre-existing drift: `schedule_patch` was hand-added to the generated `swarm-sdk.d.ts` but missing from its source template in `typecheck.ts`.
- Subscription schemas in `src/types.ts` are named `SwarmBusEvent*` — `SwarmEventSchema` was already taken by the telemetry `events` table. Open question for review: fold `swarm_events` into it long-term?

## Testing

- 13 new tests (`subscriptions.test.ts`, `script-tools.test.ts`): glob matcher semantics, capture w/ filter + disabled exclusion, real sandboxed script execution with event injection, retry→failed path, workflow trigger data, dynamic tool registration on a real `createServer()`, script result surfacing.
- Full `bun test`: 6285 ran, 0 fail. Gates: lint, tsc, db-boundary, rbac-coverage (53 verbs), sdk-tool-registration, dep-graph. Migrations 117+118 verified on fresh **and** existing DBs. `MCP.md` + `swarm-sdk.d.ts` regenerated.
- Not yet done (called out in findings doc): manual E2E against a live server; UI + docs-site surfaces.

## Not in scope

Layers 2 (interception hook points) and 4 (swarm-pack manifest/installer) — design checkpoints pending review of the research doc.

https://claude.ai/code/session_01KKnXmn9FHACLVTigxqfFbz