### PR TITLE
fix(scripts-runtime): resolve authKind:oauth bindings in credential broker

### DIFF
--- a/src/be/script-credential-broker.ts
+++ b/src/be/script-credential-broker.ts
@@ -25,38 +25,24 @@ export async function buildScriptCredentialBindings(input: {
 }): Promise<EgressSecretEntry[]> {
   const resolvedConfigs = getResolvedConfig(input.agentId, input.repoId);
   const configMap = new Map(resolvedConfigs.map((config) => [config.key, config.value]));
-  const relationalBindings = listRelationalCredentialBindings(input);
-  for (const binding of relationalBindings) {
-    if (binding.authKind !== "oauth") continue;
-    configMap.set(binding.configKey, "");
-    if (!binding.oauthProvider) continue;
-
-    let accessToken: string | undefined;
-    try {
-      accessToken = await resolveOAuthBindingToken(binding.oauthProvider);
-    } catch (err) {
-      // A stale/broken provider must not take down unrelated script runs —
-      // skip just this binding (the "" shadow above keeps the placeholder
-      // unresolved instead of falling through to a same-named config value).
-      const message = err instanceof Error ? err.message : String(err);
-      console.warn(
-        `[script-credential-broker] skipping OAuth binding ${binding.configKey}: token refresh for provider ${binding.oauthProvider} failed: ${scrubSecrets(message)}`,
-      );
-      continue;
-    }
-    if (!accessToken) continue;
-
-    configMap.set(binding.configKey, accessToken);
-    registerVolatileSecret(accessToken, binding.configKey);
-  }
-
   const broker = new CredentialBroker(
     new RelationalCredentialBindingStore((filters) => getSwarmConfigs(filters)),
     (configKey) => configMap.get(configKey) ?? process.env[configKey],
     DEFAULT_CREDENTIAL_BINDINGS,
+    async (provider) => {
+      try {
+        return await resolveOAuthBindingToken(provider);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[script-credential-broker] skipping OAuth provider ${provider}: ${scrubSecrets(message)}`,
+        );
+        return undefined;
+      }
+    },
   );
 
-  const bindings = broker.resolveBindings({ agentId: input.agentId, repoId: input.repoId });
+  const bindings = await broker.resolveBindings({ agentId: input.agentId, repoId: input.repoId });
   for (const binding of bindings) {
     registerVolatileSecret(binding.value, binding.configKey);
   }

--- a/src/scripts-runtime/credential-broker/broker.ts
+++ b/src/scripts-runtime/credential-broker/broker.ts
@@ -31,12 +31,12 @@ export class CredentialBroker {
       if (binding.active === false) continue;
       if (!bindingHasPlaceholder(binding)) continue;
 
-      const isOAuthBinding = binding.authKind === "oauth" || Boolean(binding.oauthProvider);
-      const value = isOAuthBinding
-        ? binding.oauthProvider
-          ? await this.resolveOAuthCredential?.(binding.oauthProvider)
-          : undefined
-        : this.resolveConfigCredential(binding.configKey);
+      const value =
+        binding.authKind === "oauth"
+          ? binding.oauthProvider
+            ? await this.resolveOAuthCredential?.(binding.oauthProvider)
+            : undefined
+          : this.resolveConfigCredential(binding.configKey);
       if (!value) continue;
 
       const dedupeKey = [

--- a/src/scripts-runtime/credential-broker/broker.ts
+++ b/src/scripts-runtime/credential-broker/broker.ts
@@ -1,4 +1,9 @@
-import type { CredentialBinding, CredentialBindingStore, CredentialResolver } from "./types";
+import type {
+  CredentialBinding,
+  CredentialBindingStore,
+  CredentialResolver,
+  OAuthCredentialResolver,
+} from "./types";
 import { placeholderForConfigKey, type ResolvedCredentialBinding } from "./types";
 
 function bindingHasPlaceholder(binding: CredentialBinding) {
@@ -12,11 +17,12 @@ function bindingHasPlaceholder(binding: CredentialBinding) {
 export class CredentialBroker {
   constructor(
     private readonly store: CredentialBindingStore,
-    private readonly resolveCredential: CredentialResolver,
+    private readonly resolveConfigCredential: CredentialResolver,
     private readonly defaults: CredentialBinding[] = [],
+    private readonly resolveOAuthCredential?: OAuthCredentialResolver,
   ) {}
 
-  resolveBindings(context: Parameters<CredentialBindingStore["listActiveBindings"]>[0]) {
+  async resolveBindings(context: Parameters<CredentialBindingStore["listActiveBindings"]>[0]) {
     const merged = [...this.defaults, ...this.store.listActiveBindings(context)];
     const resolved: ResolvedCredentialBinding[] = [];
     const seen = new Set<string>();
@@ -25,7 +31,12 @@ export class CredentialBroker {
       if (binding.active === false) continue;
       if (!bindingHasPlaceholder(binding)) continue;
 
-      const value = this.resolveCredential(binding.configKey);
+      const isOAuthBinding = binding.authKind === "oauth" || Boolean(binding.oauthProvider);
+      const value = isOAuthBinding
+        ? binding.oauthProvider
+          ? await this.resolveOAuthCredential?.(binding.oauthProvider)
+          : undefined
+        : this.resolveConfigCredential(binding.configKey);
       if (!value) continue;
 
       const dedupeKey = [

--- a/src/scripts-runtime/credential-broker/index.ts
+++ b/src/scripts-runtime/credential-broker/index.ts
@@ -11,6 +11,7 @@ export {
   type CredentialBindingStoreContext,
   CredentialBindingsDocumentSchema,
   type CredentialResolver,
+  type OAuthCredentialResolver,
   normalizeCredentialBindingsDocument,
   placeholderForConfigKey,
   type ResolvedCredentialBinding,

--- a/src/scripts-runtime/credential-broker/index.ts
+++ b/src/scripts-runtime/credential-broker/index.ts
@@ -11,8 +11,8 @@ export {
   type CredentialBindingStoreContext,
   CredentialBindingsDocumentSchema,
   type CredentialResolver,
-  type OAuthCredentialResolver,
   normalizeCredentialBindingsDocument,
+  type OAuthCredentialResolver,
   placeholderForConfigKey,
   type ResolvedCredentialBinding,
 } from "./types";

--- a/src/scripts-runtime/credential-broker/types.ts
+++ b/src/scripts-runtime/credential-broker/types.ts
@@ -51,6 +51,7 @@ export interface CredentialBindingStore {
 }
 
 export type CredentialResolver = (configKey: string) => string | undefined;
+export type OAuthCredentialResolver = (oauthProvider: string) => Promise<string | undefined>;
 
 export function placeholderForConfigKey(configKey: string): string {
   return `${REDACTED_PLACEHOLDER_PREFIX}${configKey}]`;

--- a/src/scripts-runtime/egress-secrets.ts
+++ b/src/scripts-runtime/egress-secrets.ts
@@ -7,13 +7,13 @@ import {
 
 export type EgressSecretEntry = ResolvedCredentialBinding;
 
-export function buildEgressSecrets(): EgressSecretEntry[] {
+export async function buildEgressSecrets(): Promise<EgressSecretEntry[]> {
   const broker = new CredentialBroker(
     { listActiveBindings: () => [] },
     (configKey) => process.env[configKey],
     DEFAULT_CREDENTIAL_BINDINGS,
   );
-  return broker.resolveBindings({});
+  return await broker.resolveBindings({});
 }
 
 export function patchFetchWithEgressSubstitution(secrets: EgressSecretEntry[]): void {

--- a/src/scripts-runtime/loader.ts
+++ b/src/scripts-runtime/loader.ts
@@ -36,7 +36,7 @@ export type RunScriptOutput = Omit<ExecutorOutput, "result" | "stdout" | "stderr
 
 export type { ScriptRuntimeError, ScriptStackFrame } from "./executors/types";
 
-function buildConfigPayload(input: RunScriptInput): SwarmConfigPayload {
+async function buildConfigPayload(input: RunScriptInput): Promise<SwarmConfigPayload> {
   const apiKey = getApiKey();
   if (!apiKey) throw new Error("Swarm API key is required to run scripts");
 
@@ -50,7 +50,7 @@ function buildConfigPayload(input: RunScriptInput): SwarmConfigPayload {
       },
     },
     user: input.userConfig ?? {},
-    egressSecrets: input.egressSecrets ?? buildEgressSecrets(),
+    egressSecrets: input.egressSecrets ?? (await buildEgressSecrets()),
     apiConnections: input.apiConnections ?? [],
     mcpConnections: input.mcpConnections ?? [],
   };
@@ -91,7 +91,7 @@ export async function runScript(input: RunScriptInput): Promise<RunScriptOutput>
   const output = await getScriptExecutor().run({
     source: input.source,
     args: input.args ?? null,
-    configPayload: buildConfigPayload(input),
+    configPayload: await buildConfigPayload(input),
     resources,
     fsMode: input.fsMode ?? "none",
     network: "open",

--- a/src/tests/credential-broker.test.ts
+++ b/src/tests/credential-broker.test.ts
@@ -228,6 +228,47 @@ describe("credential broker", () => {
     expect(authorization).toBe("Bearer gmail-access-token");
   });
 
+  test("resolves config bindings via the config resolver even when oauthProvider metadata is present", async () => {
+    const oauthResolver = mock(async () => "should-not-be-used");
+    const broker = new CredentialBroker(
+      {
+        listActiveBindings: () => [
+          {
+            configKey: "VENDOR_CONFIG_KEY",
+            allowedHosts: ["api.vendor.test"],
+            headerTemplate: "Authorization: Bearer [REDACTED:VENDOR_CONFIG_KEY]",
+            scope: "global",
+            scopeId: null,
+            active: true,
+            authKind: "config",
+            oauthProvider: "vendorProvider",
+          },
+        ],
+      },
+      (key) => (key === "VENDOR_CONFIG_KEY" ? "vendor-config-value" : undefined),
+      [],
+      oauthResolver,
+    );
+
+    const bindings = await broker.resolveBindings({});
+
+    expect(oauthResolver).not.toHaveBeenCalled();
+    expect(bindings).toEqual([
+      {
+        configKey: "VENDOR_CONFIG_KEY",
+        allowedHosts: ["api.vendor.test"],
+        headerTemplate: "Authorization: Bearer [REDACTED:VENDOR_CONFIG_KEY]",
+        scope: "global",
+        scopeId: null,
+        active: true,
+        authKind: "config",
+        oauthProvider: "vendorProvider",
+        placeholder: "[REDACTED:VENDOR_CONFIG_KEY]",
+        value: "vendor-config-value",
+      },
+    ]);
+  });
+
   test("registers resolved broker config values with the scrubber", async () => {
     const bindingsConfig = upsertSwarmConfig({
       scope: "global",

--- a/src/tests/credential-broker.test.ts
+++ b/src/tests/credential-broker.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { deleteSwarmConfig, upsertSwarmConfig } from "../be/db";
 import { buildScriptCredentialBindings } from "../be/script-credential-broker";
+import { createApiRegistryClient } from "../scripts-runtime/api-client";
 import {
   CREDENTIAL_BINDINGS_CONFIG_KEY,
   type CredentialBindingStore,
@@ -119,7 +120,7 @@ describe("credential broker", () => {
     );
   });
 
-  test("resolves seeded GITHUB_TOKEN binding", () => {
+  test("resolves seeded GITHUB_TOKEN binding", async () => {
     const emptyStore: CredentialBindingStore = { listActiveBindings: () => [] };
     const broker = new CredentialBroker(
       emptyStore,
@@ -127,7 +128,7 @@ describe("credential broker", () => {
       DEFAULT_CREDENTIAL_BINDINGS,
     );
 
-    expect(broker.resolveBindings({})).toEqual([
+    expect(await broker.resolveBindings({})).toEqual([
       {
         configKey: "GITHUB_TOKEN",
         allowedHosts: ["api.github.com"],
@@ -140,6 +141,91 @@ describe("credential broker", () => {
         value: "ghp_test",
       },
     ]);
+  });
+
+  test("resolves OAuth bindings with the OAuth resolver and substitutes their header", async () => {
+    const oauthResolver = mock(async (provider: string) =>
+      provider === "gmailSupport" ? "gmail-access-token" : undefined,
+    );
+    const broker = new CredentialBroker(
+      {
+        listActiveBindings: () => [
+          {
+            configKey: "GMAIL_SUPPORT_OAUTH_BINDING",
+            allowedHosts: ["gmail.googleapis.com"],
+            headerTemplate: "Authorization: Bearer [REDACTED:GMAIL_SUPPORT_OAUTH_BINDING]",
+            scope: "global",
+            scopeId: null,
+            active: true,
+            authKind: "oauth",
+            oauthProvider: "gmailSupport",
+          },
+        ],
+      },
+      () => {
+        throw new Error("config resolver must not be used for OAuth bindings");
+      },
+      [],
+      oauthResolver,
+    );
+    const bindings = await broker.resolveBindings({});
+
+    expect(oauthResolver).toHaveBeenCalledWith("gmailSupport");
+    let authorization: string | null = null;
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      authorization = new Headers(init?.headers).get("authorization");
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+    patchFetchWithCredentialBroker(bindings);
+
+    await fetch("https://gmail.googleapis.com/gmail/v1/users/me/profile", {
+      headers: { Authorization: "Bearer [REDACTED:GMAIL_SUPPORT_OAUTH_BINDING]" },
+    });
+
+    expect(authorization).toBe("Bearer gmail-access-token");
+  });
+
+  test("resolved OAuth bindings also authenticate ctx.api clients", async () => {
+    let authorization: string | null = null;
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      authorization = new Headers(init?.headers).get("authorization");
+      return Response.json({ data: { ok: true } });
+    }) as typeof fetch;
+    const broker = new CredentialBroker(
+      {
+        listActiveBindings: () => [
+          {
+            configKey: "GMAIL_SUPPORT_OAUTH_BINDING",
+            allowedHosts: ["gmail.googleapis.com"],
+            headerTemplate: "Authorization: Bearer [REDACTED:GMAIL_SUPPORT_OAUTH_BINDING]",
+            scope: "global",
+            scopeId: null,
+            active: true,
+            authKind: "oauth",
+            oauthProvider: "gmailSupport",
+          },
+        ],
+      },
+      () => undefined,
+      [],
+      async () => "gmail-access-token",
+    );
+    patchFetchWithCredentialBroker(await broker.resolveBindings({}));
+    const api = createApiRegistryClient([
+      {
+        slug: "gmailSupport",
+        kind: "graphql",
+        baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me/profile",
+        credential: {
+          configKey: "GMAIL_SUPPORT_OAUTH_BINDING",
+          headerTemplate: "Authorization: Bearer [REDACTED:GMAIL_SUPPORT_OAUTH_BINDING]",
+        },
+      },
+    ]);
+
+    await api.gmailSupport.graphql("query { me { id } }");
+
+    expect(authorization).toBe("Bearer gmail-access-token");
   });
 
   test("registers resolved broker config values with the scrubber", async () => {

--- a/src/tests/scripts-runtime-secret-egress.test.ts
+++ b/src/tests/scripts-runtime-secret-egress.test.ts
@@ -49,9 +49,9 @@ describe("runtime secret egress", () => {
 
 describe("egress-substitution", () => {
   describe("buildEgressSecrets", () => {
-    test("includes GITHUB_TOKEN when set in env", () => {
+    test("includes GITHUB_TOKEN when set in env", async () => {
       process.env.GITHUB_TOKEN = "ghp_test1234567890abcdef";
-      const secrets = buildEgressSecrets();
+      const secrets = await buildEgressSecrets();
       expect(secrets).toEqual([
         {
           configKey: "GITHUB_TOKEN",
@@ -67,9 +67,9 @@ describe("egress-substitution", () => {
       ]);
     });
 
-    test("returns empty array when GITHUB_TOKEN not set", () => {
+    test("returns empty array when GITHUB_TOKEN not set", async () => {
       delete process.env.GITHUB_TOKEN;
-      const secrets = buildEgressSecrets();
+      const secrets = await buildEgressSecrets();
       expect(secrets).toEqual([]);
     });
   });


### PR DESCRIPTION
## Summary
- resolve OAuth credential bindings inside `CredentialBroker` through a typed, refresh-aware OAuth resolver
- preserve config-secret resolution and keep refresh failure isolated to the affected OAuth binding
- cover patched `fetch` and `ctx.api` Authorization substitution for an OAuth Gmail-style binding

## Planning artifacts
- [Research](https://live.agent-fs.dev/file/~/4fdbb8e2-f63b-4977-95be-6e18019f0e86/99d03b30-1ffd-4ddd-b332-1244b511b230/thoughts/0d022f19-38ff-4d32-95b2-315fc0864114/research/2026-07-20-oauth-credential-broker.md)
- [Plan](https://live.agent-fs.dev/file/~/4fdbb8e2-f63b-4977-95be-6e18019f0e86/99d03b30-1ffd-4ddd-b332-1244b511b230/thoughts/0d022f19-38ff-4d32-95b2-315fc0864114/plans/2026-07-20-oauth-credential-broker.md)

## Test plan
- `bun run lint:fix`
- `bun run tsc:check`
- `bun test`
- `bash scripts/check-db-boundary.sh`
- With a `gmailSupport` OAuth binding targeting `gmail.googleapis.com`, run a script that fetches `/gmail/v1/users/me/profile` using `Authorization: Bearer [REDACTED:GMAIL_SUPPORT_OAUTH_BINDING]`; it should return 200 rather than 401.
- Run a generated `ctx.api.gmailSupport` operation with the same binding and verify the Authorization header is substituted at egress.

## Notes
The fork main fast-forward from upstream was rejected by branch protection, so this focused branch is based on the current fork `main` and contains no upstream-sync commits.