### PR TITLE
feat(providers): OPENROUTER_BASE_URL gateway routing for all OpenRouter consumers

### DIFF
--- a/plugin/opencode-plugins/lib/summarize.ts
+++ b/plugin/opencode-plugins/lib/summarize.ts
@@ -328,7 +328,14 @@ async function callOpenAICompat(
   let baseUrl: string;
   let modelId: string;
   if (cred.kind === "openrouter") {
-    baseUrl = "https://openrouter.ai/api/v1";
+    // Vendored from `src/utils/openrouter-base-url.ts` (plugin sandbox can't
+    // import from src/): OPENROUTER_BASE_URL routes traffic through an
+    // OpenAI-compatible gateway; unset/blank means openrouter.ai directly.
+    const envBase = process.env.OPENROUTER_BASE_URL;
+    baseUrl =
+      typeof envBase === "string" && envBase.trim().length > 0
+        ? envBase.trim().replace(/\/+$/, "")
+        : "https://openrouter.ai/api/v1";
     // OpenRouter model strings retain the inner provider segment, e.g.
     // "openrouter/google/gemini-3-flash-preview" → "google/gemini-3-flash-preview".
     modelId = cred.modelDefault.replace(/^openrouter\//, "");

--- a/src/be/memory/raters/llm-summarizer.ts
+++ b/src/be/memory/raters/llm-summarizer.ts
@@ -11,6 +11,7 @@
  * No `bun:sqlite` / `src/be/db` imports. Boundary script enforces this.
  */
 import { z } from "zod";
+import { getOpenRouterBaseUrl } from "../../../utils/openrouter-base-url";
 import { type SummaryWithRatings, SummaryWithRatingsSchema } from "./llm";
 
 /**
@@ -27,7 +28,14 @@ export const DEFAULT_MEMORY_RATER_MODEL = "google/gemini-3-flash-preview";
  */
 export const MEMORY_RATER_SCHEMA_NAME = "memory_rater_output";
 
-const OPENROUTER_CHAT_COMPLETIONS_URL = "https://openrouter.ai/api/v1/chat/completions";
+/**
+ * Chat-completions URL, resolved per call so `OPENROUTER_BASE_URL` (gateway
+ * routing — see `src/utils/openrouter-base-url.ts`) is honored even when it
+ * is set after module load (worker subprocess env resolution).
+ */
+function openRouterChatCompletionsUrl(): string {
+  return `${getOpenRouterBaseUrl()}/chat/completions`;
+}
 
 /**
  * JSON Schema derived from {@link SummaryWithRatingsSchema}, the source of
@@ -138,7 +146,7 @@ export async function runMemoryRater(opts: RunMemoryRaterOpts): Promise<RunMemor
 
   let res: Response;
   try {
-    res = await fetchFn(OPENROUTER_CHAT_COMPLETIONS_URL, {
+    res = await fetchFn(openRouterChatCompletionsUrl(), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/commands/provider-credentials.ts
+++ b/src/commands/provider-credentials.ts
@@ -25,6 +25,7 @@ import { checkDevinCredentials } from "../providers/devin-adapter";
 import { checkOpencodeCredentials } from "../providers/opencode-adapter";
 import type { CredCheckOptions, CredStatus } from "../providers/types";
 import type { AgentCredStatus, AgentLatestModel, ProviderName, ReasoningEffort } from "../types";
+import { getOpenRouterBaseUrl } from "../utils/openrouter-base-url";
 import { scrubSecrets } from "../utils/secret-scrubber";
 
 export type SupportedProvider = "claude" | "claude-managed" | "codex" | "devin" | "opencode" | "pi";
@@ -202,7 +203,7 @@ async function checkOpenAiApiKey(apiKey: string): Promise<LiveValidationResult> 
 }
 
 async function checkOpenRouter(apiKey: string): Promise<LiveValidationResult> {
-  const r = await timedFetch("https://openrouter.ai/api/v1/models", {
+  const r = await timedFetch(`${getOpenRouterBaseUrl()}/models`, {
     method: "GET",
     headers: { Authorization: `Bearer ${apiKey}` },
   });

--- a/src/providers/codex-adapter.ts
+++ b/src/providers/codex-adapter.ts
@@ -1301,6 +1301,9 @@ export class CodexSession implements ProviderSession {
       },
       apiUrl,
       apiKey,
+      // Per-task resolved env — swarm_config overlays (e.g.
+      // OPENROUTER_BASE_URL) never reach process.env.
+      env: this.config.env,
     });
     // null = no auth resolved or wrapper exhausted retries (already logged inside)
     if (!result) return;

--- a/src/providers/opencode-adapter.ts
+++ b/src/providers/opencode-adapter.ts
@@ -19,6 +19,7 @@ import {
 } from "../utils/context-window";
 import { validateOpencodeCredentials } from "../utils/credentials";
 import { fetchInstalledMcpServers } from "../utils/mcp-server-fetcher";
+import { DEFAULT_OPENROUTER_BASE_URL, getOpenRouterBaseUrl } from "../utils/openrouter-base-url";
 import { scrubSecrets } from "../utils/secret-scrubber";
 import { resolveSlashSkillPrompt } from "./codex-skill-resolver";
 import { CTX_MODE_NUDGE_EVERY } from "./ctx-mode-env";
@@ -133,6 +134,31 @@ async function readSpawnOutput(stream: ReadableStream<Uint8Array> | null): Promi
 
 function formatUnknownError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Route OpenRouter traffic through the configured gateway (see
+ * src/utils/openrouter-base-url.ts). opencode's bundled openrouter provider
+ * honors `provider.openrouter.options.baseURL`. Mutates `opencodeConfig` in
+ * place; no-op when `OPENROUTER_BASE_URL` is unset/blank/default, so default
+ * openrouter.ai behavior is preserved. Exported for tests.
+ */
+export function applyOpenRouterBaseUrlOverride(
+  opencodeConfig: Config,
+  env: Record<string, string | undefined> = process.env,
+): void {
+  const openRouterBaseUrl = getOpenRouterBaseUrl(env as NodeJS.ProcessEnv);
+  if (openRouterBaseUrl === DEFAULT_OPENROUTER_BASE_URL) return;
+  opencodeConfig.provider = {
+    ...opencodeConfig.provider,
+    openrouter: {
+      ...opencodeConfig.provider?.openrouter,
+      options: {
+        ...opencodeConfig.provider?.openrouter?.options,
+        baseURL: openRouterBaseUrl,
+      },
+    },
+  };
 }
 
 async function refreshOpenRouterModelCache(
@@ -725,6 +751,8 @@ export class OpencodeAdapter implements ProviderAdapter {
         },
       };
     }
+
+    applyOpenRouterBaseUrlOverride(opencodeConfig, config.env ?? process.env);
 
     // Write per-task config file
     try {

--- a/src/providers/opencode-adapter.ts
+++ b/src/providers/opencode-adapter.ts
@@ -771,12 +771,24 @@ export class OpencodeAdapter implements ProviderAdapter {
       SWARM_AGENT_ID: process.env.SWARM_AGENT_ID,
       SWARM_TASK_ID: process.env.SWARM_TASK_ID,
       SWARM_IS_LEAD: process.env.SWARM_IS_LEAD,
+      OPENROUTER_BASE_URL: process.env.OPENROUTER_BASE_URL,
     };
     process.env.SWARM_API_URL = config.apiUrl;
     process.env.SWARM_API_KEY = config.apiKey;
     process.env.SWARM_AGENT_ID = config.agentId;
     process.env.SWARM_TASK_ID = config.taskId;
     process.env.SWARM_IS_LEAD = config.role === "lead" ? "true" : "false";
+    // Mirror the resolved OpenRouter gateway into the spawn env: the
+    // summarize plugin (and any other plugin OpenRouter fetch) reads its own
+    // process.env inside the opencode subprocess, which inherits OURS — a
+    // per-task swarm_config value in `config.env` would otherwise be
+    // invisible there and the plugin would bypass the gateway.
+    const spawnOpenRouterBaseUrl = getOpenRouterBaseUrl(
+      (config.env ?? process.env) as NodeJS.ProcessEnv,
+    );
+    if (spawnOpenRouterBaseUrl !== DEFAULT_OPENROUTER_BASE_URL) {
+      process.env.OPENROUTER_BASE_URL = spawnOpenRouterBaseUrl;
+    }
     process.env.CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY = CTX_MODE_NUDGE_EVERY;
 
     // Set OPENCODE_CONFIG scoped to the spawn call (save + restore)

--- a/src/providers/pi-mono-adapter.ts
+++ b/src/providers/pi-mono-adapter.ts
@@ -28,6 +28,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { type TSchema, Type } from "typebox";
 import { classifyAwsSdkError } from "../utils/aws-error-classifier";
+import { DEFAULT_OPENROUTER_BASE_URL, getOpenRouterBaseUrl } from "../utils/openrouter-base-url";
 import { scrubSecrets } from "../utils/secret-scrubber";
 import { readPkgVersion } from "./harness-version";
 import { createSwarmHooksExtension } from "./pi-mono-extension";
@@ -354,6 +355,58 @@ export async function createPiRuntimeAuth(
   }
 
   return modelRuntime;
+}
+
+/**
+ * Materialize the OpenRouter gateway override into `<agentDir>/models.json`
+ * so pi-coding-agent's `ModelRuntime` (which loads that file at create time)
+ * composes every built-in OpenRouter model with the gateway `baseUrl` — see
+ * `src/utils/openrouter-base-url.ts` for the env contract.
+ *
+ * Merge-preserving: existing provider entries (and any other openrouter
+ * config keys) are kept; only `providers.openrouter.baseUrl` is set. A
+ * corrupt existing file is overwritten with just the override — for gateway
+ * deployments, guaranteed rerouting wins over preserving unparseable config.
+ * No-op when `OPENROUTER_BASE_URL` is unset/blank/default, so local pi usage
+ * is untouched.
+ */
+export async function ensureOpenRouterModelsOverride(
+  agentDir: string,
+  env: Record<string, string | undefined> = process.env,
+): Promise<void> {
+  const baseUrl = getOpenRouterBaseUrl(env as NodeJS.ProcessEnv);
+  if (baseUrl === DEFAULT_OPENROUTER_BASE_URL) return;
+
+  const modelsPath = join(agentDir, "models.json");
+  let existing: Record<string, unknown> = {};
+  try {
+    const file = Bun.file(modelsPath);
+    if (await file.exists()) {
+      existing = JSON.parse(await file.text()) as Record<string, unknown>;
+    }
+  } catch (err) {
+    console.warn(
+      `[pi-mono] ${modelsPath} is unreadable/invalid (${err instanceof Error ? err.message : err}); rewriting with the OpenRouter gateway override`,
+    );
+    existing = {};
+  }
+
+  const providers =
+    typeof existing.providers === "object" && existing.providers !== null
+      ? (existing.providers as Record<string, unknown>)
+      : {};
+  const openrouter =
+    typeof providers.openrouter === "object" && providers.openrouter !== null
+      ? (providers.openrouter as Record<string, unknown>)
+      : {};
+  const next = {
+    ...existing,
+    providers: {
+      ...providers,
+      openrouter: { ...openrouter, baseUrl },
+    },
+  };
+  await Bun.write(modelsPath, `${JSON.stringify(next, null, 2)}\n`);
 }
 
 /**
@@ -960,8 +1013,18 @@ export class PiMonoAdapter implements ProviderAdapter {
     const sessionEnv = config.env ?? process.env;
 
     // 3. Resolve model
-    const model = resolveModel(config.model, sessionEnv);
+    // Write the gateway override BEFORE ModelRuntime.create — the runtime
+    // loads `<agentDir>/models.json` exactly once at creation.
+    await ensureOpenRouterModelsOverride(getAgentDir(), sessionEnv);
+    const builtinModel = resolveModel(config.model, sessionEnv);
     const modelRuntime = await createPiRuntimeAuth(sessionEnv);
+    // models.json overrides (e.g. the OpenRouter gateway baseUrl) only apply
+    // to models resolved through the runtime's composed store; the builtin
+    // catalog object from `resolveModel` carries the hardcoded upstream URL
+    // and would be used verbatim by the session.
+    const model = builtinModel
+      ? (modelRuntime.getModel(builtinModel.provider, builtinModel.id) ?? builtinModel)
+      : builtinModel;
 
     // 4. Create swarm hooks extension
     const swarmExtension = createSwarmHooksExtension({

--- a/src/providers/pi-mono-adapter.ts
+++ b/src/providers/pi-mono-adapter.ts
@@ -358,26 +358,69 @@ export async function createPiRuntimeAuth(
 }
 
 /**
- * Materialize the OpenRouter gateway override into `<agentDir>/models.json`
- * so pi-coding-agent's `ModelRuntime` (which loads that file at create time)
- * composes every built-in OpenRouter model with the gateway `baseUrl` — see
- * `src/utils/openrouter-base-url.ts` for the env contract.
+ * Sidecar marker recording the gateway `baseUrl` WE wrote into models.json
+ * (and any user value we displaced). Lets `ensureOpenRouterModelsOverride`
+ * revert precisely when the env returns to default, without ever touching a
+ * hand-authored override it didn't create. Lives next to models.json; NOT
+ * part of pi's config surface.
+ */
+const OPENROUTER_OVERRIDE_MARKER = ".agent-swarm-openrouter-override.json";
+
+interface OpenRouterOverrideMarker {
+  baseUrl: string;
+  /** User-authored baseUrl we displaced, restored on revert. */
+  previous?: string;
+}
+
+async function readJsonFile(path: string): Promise<Record<string, unknown> | undefined> {
+  try {
+    const file = Bun.file(path);
+    if (!(await file.exists())) return undefined;
+    const parsed: unknown = JSON.parse(await file.text());
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Materialize (or revert) the OpenRouter gateway override in
+ * `<agentDir>/models.json` so pi-coding-agent's `ModelRuntime` (which loads
+ * that file at create time) composes every built-in OpenRouter model with
+ * the gateway `baseUrl` — see `src/utils/openrouter-base-url.ts` for the
+ * env contract.
  *
- * Merge-preserving: existing provider entries (and any other openrouter
- * config keys) are kept; only `providers.openrouter.baseUrl` is set. A
- * corrupt existing file is overwritten with just the override — for gateway
- * deployments, guaranteed rerouting wins over preserving unparseable config.
- * No-op when `OPENROUTER_BASE_URL` is unset/blank/default, so local pi usage
- * is untouched.
+ * Gateway set (non-default): merge-preserving write — existing provider
+ * entries and other openrouter keys are kept, only
+ * `providers.openrouter.baseUrl` is set; a displaced user value is recorded
+ * in a sidecar marker. A corrupt existing file is overwritten with just the
+ * override — for gateway deployments, guaranteed rerouting wins over
+ * preserving unparseable config.
+ *
+ * Gateway unset/default: reverts a PREVIOUSLY WRITTEN override (marker
+ * present and models.json still carries the marker's value) — restoring the
+ * displaced user baseUrl or deleting the key, dropping now-empty objects,
+ * and removing models.json entirely if the override was all it contained.
+ * The env value in a shared worker isn't per-task in practice, but reverts
+ * make rollback = "unset the env" and keep repo-scoped/self-hosted setups
+ * from inheriting a stale gateway (PR #1010 review). Without a marker the
+ * function never touches models.json, so hand-authored overrides survive.
  */
 export async function ensureOpenRouterModelsOverride(
   agentDir: string,
   env: Record<string, string | undefined> = process.env,
 ): Promise<void> {
   const baseUrl = getOpenRouterBaseUrl(env as NodeJS.ProcessEnv);
-  if (baseUrl === DEFAULT_OPENROUTER_BASE_URL) return;
-
   const modelsPath = join(agentDir, "models.json");
+  const markerPath = join(agentDir, OPENROUTER_OVERRIDE_MARKER);
+
+  if (baseUrl === DEFAULT_OPENROUTER_BASE_URL) {
+    await revertOpenRouterModelsOverride(modelsPath, markerPath);
+    return;
+  }
+
   let existing: Record<string, unknown> = {};
   try {
     const file = Bun.file(modelsPath);
@@ -399,6 +442,17 @@ export async function ensureOpenRouterModelsOverride(
     typeof providers.openrouter === "object" && providers.openrouter !== null
       ? (providers.openrouter as Record<string, unknown>)
       : {};
+
+  // Record what we displace, once — re-runs with the marker already present
+  // keep the ORIGINAL displaced value (the current baseUrl is then ours).
+  const priorMarker = (await readJsonFile(markerPath)) as OpenRouterOverrideMarker | undefined;
+  const currentBaseUrl = typeof openrouter.baseUrl === "string" ? openrouter.baseUrl : undefined;
+  const previous = priorMarker
+    ? priorMarker.previous
+    : currentBaseUrl !== baseUrl
+      ? currentBaseUrl
+      : undefined;
+
   const next = {
     ...existing,
     providers: {
@@ -407,6 +461,66 @@ export async function ensureOpenRouterModelsOverride(
     },
   };
   await Bun.write(modelsPath, `${JSON.stringify(next, null, 2)}\n`);
+  const marker: OpenRouterOverrideMarker = {
+    baseUrl,
+    ...(previous !== undefined ? { previous } : {}),
+  };
+  await Bun.write(markerPath, `${JSON.stringify(marker, null, 2)}\n`);
+}
+
+/**
+ * Undo a marker-recorded gateway override. Only acts when the marker exists
+ * AND models.json's `providers.openrouter.baseUrl` still equals the value
+ * the marker says we wrote — anything else means the user edited the file
+ * since, and we leave it alone (the stale marker is dropped either way).
+ */
+async function revertOpenRouterModelsOverride(
+  modelsPath: string,
+  markerPath: string,
+): Promise<void> {
+  const marker = (await readJsonFile(markerPath)) as OpenRouterOverrideMarker | undefined;
+  if (!marker) return;
+  const removeMarker = () => Bun.file(markerPath).delete();
+
+  const existing = await readJsonFile(modelsPath);
+  if (!existing) {
+    await removeMarker();
+    return;
+  }
+  const providers =
+    typeof existing.providers === "object" && existing.providers !== null
+      ? { ...(existing.providers as Record<string, unknown>) }
+      : undefined;
+  const openrouter =
+    providers && typeof providers.openrouter === "object" && providers.openrouter !== null
+      ? { ...(providers.openrouter as Record<string, unknown>) }
+      : undefined;
+  if (!providers || !openrouter || openrouter.baseUrl !== marker.baseUrl) {
+    await removeMarker();
+    return;
+  }
+
+  if (marker.previous !== undefined) {
+    openrouter.baseUrl = marker.previous;
+  } else {
+    delete openrouter.baseUrl;
+  }
+  if (Object.keys(openrouter).length === 0) {
+    delete providers.openrouter;
+  } else {
+    providers.openrouter = openrouter;
+  }
+  const next: Record<string, unknown> = { ...existing, providers };
+  if (Object.keys(providers).length === 0) {
+    delete next.providers;
+  }
+
+  if (Object.keys(next).length === 0) {
+    await Bun.file(modelsPath).delete();
+  } else {
+    await Bun.write(modelsPath, `${JSON.stringify(next, null, 2)}\n`);
+  }
+  await removeMarker();
 }
 
 /**
@@ -1033,6 +1147,7 @@ export class PiMonoAdapter implements ProviderAdapter {
       agentId: config.agentId,
       taskId: config.taskId,
       isLead: config.role === "lead",
+      env: sessionEnv,
     });
 
     // 5. Create resource loader with system prompt + extension

--- a/src/providers/pi-mono-extension.ts
+++ b/src/providers/pi-mono-extension.ts
@@ -17,6 +17,12 @@ export interface SwarmHooksConfig {
   agentId: string;
   taskId: string;
   isLead: boolean;
+  /**
+   * Per-task resolved env (`ProviderSessionConfig.env`). Forwarded to the
+   * session-summary path so swarm_config overlays (rotated credentials,
+   * `OPENROUTER_BASE_URL`) apply — they never reach `process.env`.
+   */
+  env?: Record<string, string | undefined>;
 }
 
 /** Standard headers for swarm API requests */
@@ -368,6 +374,9 @@ export async function summarizeSessionForPi(
       },
       apiUrl: config.apiUrl,
       apiKey: config.apiKey,
+      // Per-task resolved env — swarm_config overlays (e.g.
+      // OPENROUTER_BASE_URL) never reach process.env.
+      env: config.env,
     });
     // null = no auth resolved or wrapper exhausted retries (already logged inside)
     if (!result) return;

--- a/src/tests/memory-rater-llm-summarizer.test.ts
+++ b/src/tests/memory-rater-llm-summarizer.test.ts
@@ -139,6 +139,30 @@ describe("runMemoryRater — request shape", () => {
     expect(body.response_format.json_schema.schema).toEqual(MEMORY_RATER_JSON_SCHEMA);
   });
 
+  test("OPENROUTER_BASE_URL reroutes the chat-completions call through the gateway", async () => {
+    const origBaseUrl = process.env.OPENROUTER_BASE_URL;
+    process.env.OPENROUTER_BASE_URL = "https://control-plane.example/proxy/v1/";
+    try {
+      let capturedUrl: string | URL | Request | undefined;
+      const fakeFetch: typeof fetch = async (url) => {
+        capturedUrl = url;
+        return makeOpenRouterResponse(JSON.stringify({ summary: "ok", ratings: [] }));
+      };
+
+      const result = await runMemoryRater({
+        prompt: "test prompt",
+        apiKey: "test-api-key-123",
+        fetchImpl: fakeFetch,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(String(capturedUrl)).toBe("https://control-plane.example/proxy/v1/chat/completions");
+    } finally {
+      if (origBaseUrl === undefined) delete process.env.OPENROUTER_BASE_URL;
+      else process.env.OPENROUTER_BASE_URL = origBaseUrl;
+    }
+  });
+
   test("MEMORY_RATER_JSON_SCHEMA reflects SummaryWithRatingsSchema (key shape only)", () => {
     // Don't assert exact JSON Schema bytes — Zod's emitter can change with
     // version bumps. Lock down the contract that matters for the OpenRouter

--- a/src/tests/opencode-plugin.test.ts
+++ b/src/tests/opencode-plugin.test.ts
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { Message, Part } from "@opencode-ai/sdk";
 import {
   flattenOpencodeTranscript,
+  runSummaryLlm,
   type SummarizeSessionForOpencodeDeps,
   type SwarmConfig,
   summarizeSessionForOpencode,
@@ -492,5 +493,47 @@ describe("summarizeSessionForOpencode", () => {
     expect(postRatingsArgs!.events.length).toBe(2);
     // Task ID is passed for cross-referencing.
     expect(postRatingsArgs!.taskId).toBe("task-oc-1");
+  });
+});
+
+// ── OPENROUTER_BASE_URL gateway routing (vendored resolver in summarize.ts) ──
+
+describe("runSummaryLlm — OPENROUTER_BASE_URL gateway", () => {
+  const summaryBody = {
+    choices: [{ message: { content: JSON.stringify({ summary: "ok", ratings: [] }) } }],
+  };
+  const openrouterCred = {
+    kind: "openrouter" as const,
+    apiKey: "sk-or-test",
+    modelDefault: "openrouter/google/gemini-3-flash-preview",
+  };
+
+  afterEach(() => {
+    delete process.env.OPENROUTER_BASE_URL;
+  });
+
+  test("defaults to openrouter.ai when the env is unset", async () => {
+    fetchHandler = async () => ({
+      ok: true,
+      status: 200,
+      text: async () => "",
+      json: async () => summaryBody,
+    });
+    const result = await runSummaryLlm(openrouterCred, "sys", "user");
+    expect(result).not.toBeNull();
+    expect(fetchCalls[0]?.url).toBe("https://openrouter.ai/api/v1/chat/completions");
+  });
+
+  test("reroutes through the gateway when OPENROUTER_BASE_URL is set", async () => {
+    process.env.OPENROUTER_BASE_URL = "https://control-plane.example/proxy/v1/";
+    fetchHandler = async () => ({
+      ok: true,
+      status: 200,
+      text: async () => "",
+      json: async () => summaryBody,
+    });
+    const result = await runSummaryLlm(openrouterCred, "sys", "user");
+    expect(result).not.toBeNull();
+    expect(fetchCalls[0]?.url).toBe("https://control-plane.example/proxy/v1/chat/completions");
   });
 });

--- a/src/tests/openrouter-base-url.test.ts
+++ b/src/tests/openrouter-base-url.test.ts
@@ -1,0 +1,176 @@
+/**
+ * OPENROUTER_BASE_URL gateway routing — unit tests.
+ *
+ * Covers the shared resolver (`src/utils/openrouter-base-url.ts`), the pi
+ * models.json override writer (`ensureOpenRouterModelsOverride`) including
+ * its composition through pi-coding-agent's ModelRuntime, and the opencode
+ * per-task config injection (`applyOpenRouterBaseUrlOverride`).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ModelRuntime } from "@earendil-works/pi-coding-agent";
+import type { Config } from "@opencode-ai/sdk";
+import { applyOpenRouterBaseUrlOverride } from "../providers/opencode-adapter";
+import { ensureOpenRouterModelsOverride } from "../providers/pi-mono-adapter";
+import { DEFAULT_OPENROUTER_BASE_URL, getOpenRouterBaseUrl } from "../utils/openrouter-base-url";
+
+const GATEWAY = "https://control-plane.example/proxy/v1";
+
+describe("getOpenRouterBaseUrl", () => {
+  test("defaults to openrouter.ai when unset", () => {
+    expect(getOpenRouterBaseUrl({} as NodeJS.ProcessEnv)).toBe(DEFAULT_OPENROUTER_BASE_URL);
+  });
+
+  test("blank / whitespace-only values fall back to the default", () => {
+    expect(getOpenRouterBaseUrl({ OPENROUTER_BASE_URL: "" } as NodeJS.ProcessEnv)).toBe(
+      DEFAULT_OPENROUTER_BASE_URL,
+    );
+    expect(getOpenRouterBaseUrl({ OPENROUTER_BASE_URL: "   " } as NodeJS.ProcessEnv)).toBe(
+      DEFAULT_OPENROUTER_BASE_URL,
+    );
+  });
+
+  test("returns the override verbatim (trimmed)", () => {
+    expect(getOpenRouterBaseUrl({ OPENROUTER_BASE_URL: ` ${GATEWAY} ` } as NodeJS.ProcessEnv)).toBe(
+      GATEWAY,
+    );
+  });
+
+  test("strips trailing slashes so call sites can append paths", () => {
+    expect(getOpenRouterBaseUrl({ OPENROUTER_BASE_URL: `${GATEWAY}//` } as NodeJS.ProcessEnv)).toBe(
+      GATEWAY,
+    );
+  });
+});
+
+describe("ensureOpenRouterModelsOverride (pi)", () => {
+  let agentDir: string;
+
+  beforeAll(() => {
+    agentDir = mkdtempSync(join(tmpdir(), "pi-or-override-"));
+  });
+
+  afterAll(() => {
+    rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  test("no-op when OPENROUTER_BASE_URL is unset", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-or-noop-"));
+    try {
+      await ensureOpenRouterModelsOverride(dir, {});
+      expect(await Bun.file(join(dir, "models.json")).exists()).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("writes providers.openrouter.baseUrl when the env is set", async () => {
+    await ensureOpenRouterModelsOverride(agentDir, { OPENROUTER_BASE_URL: GATEWAY });
+    const written = JSON.parse(await Bun.file(join(agentDir, "models.json")).text());
+    expect(written).toEqual({ providers: { openrouter: { baseUrl: GATEWAY } } });
+  });
+
+  test("merge-preserves existing providers and openrouter keys", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-or-merge-"));
+    try {
+      await Bun.write(
+        join(dir, "models.json"),
+        JSON.stringify({
+          providers: {
+            openrouter: { baseUrl: "https://old.example/v1", compat: { supportsTools: true } },
+            custom: { baseUrl: "https://custom.example/v1", api: "openai-completions" },
+          },
+        }),
+      );
+      await ensureOpenRouterModelsOverride(dir, { OPENROUTER_BASE_URL: GATEWAY });
+      const written = JSON.parse(await Bun.file(join(dir, "models.json")).text());
+      expect(written.providers.openrouter.baseUrl).toBe(GATEWAY);
+      expect(written.providers.openrouter.compat).toEqual({ supportsTools: true });
+      expect(written.providers.custom).toEqual({
+        baseUrl: "https://custom.example/v1",
+        api: "openai-completions",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("overwrites a corrupt models.json with just the override", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-or-corrupt-"));
+    try {
+      await Bun.write(join(dir, "models.json"), "{not json");
+      await ensureOpenRouterModelsOverride(dir, { OPENROUTER_BASE_URL: GATEWAY });
+      const written = JSON.parse(await Bun.file(join(dir, "models.json")).text());
+      expect(written).toEqual({ providers: { openrouter: { baseUrl: GATEWAY } } });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("ModelRuntime composes the override onto built-in OpenRouter models", async () => {
+    // The whole point of the lever: built-in model IDs resolved through the
+    // runtime's composed store carry the gateway baseUrl.
+    const runtime = await ModelRuntime.create({
+      authPath: join(agentDir, "auth.json"),
+      modelsPath: join(agentDir, "models.json"),
+    });
+    expect(runtime.getError()).toBeUndefined();
+    const model = runtime.getModel("openrouter", "anthropic/claude-sonnet-5");
+    expect(model?.baseUrl).toBe(GATEWAY);
+  });
+
+  test("ModelRuntime keeps the default baseUrl when no models.json exists", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-or-default-"));
+    try {
+      const runtime = await ModelRuntime.create({
+        authPath: join(dir, "auth.json"),
+        modelsPath: join(dir, "models.json"),
+      });
+      const model = runtime.getModel("openrouter", "anthropic/claude-sonnet-5");
+      expect(model?.baseUrl).toBe(DEFAULT_OPENROUTER_BASE_URL);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("applyOpenRouterBaseUrlOverride (opencode)", () => {
+  test("no-op when OPENROUTER_BASE_URL is unset", () => {
+    const config: Config = { model: "openrouter/google/gemini-3-flash-preview" };
+    applyOpenRouterBaseUrlOverride(config, {});
+    expect(config.provider).toBeUndefined();
+  });
+
+  test("sets provider.openrouter.options.baseURL when the env is set", () => {
+    const config: Config = { model: "openrouter/google/gemini-3-flash-preview" };
+    applyOpenRouterBaseUrlOverride(config, { OPENROUTER_BASE_URL: GATEWAY });
+    expect(config.provider?.openrouter?.options?.baseURL).toBe(GATEWAY);
+  });
+
+  test("preserves existing provider config (e.g. reasoning model options)", () => {
+    const config: Config = {
+      model: "openrouter/google/gemini-3-flash-preview",
+      provider: {
+        openrouter: {
+          models: {
+            "google/gemini-3-flash-preview": { options: { reasoning: { effort: "low" } } },
+          },
+          options: { apiKey: "sk-keep" },
+        },
+        anthropic: { options: { apiKey: "sk-ant" } },
+      },
+    };
+    applyOpenRouterBaseUrlOverride(config, { OPENROUTER_BASE_URL: GATEWAY });
+    expect(config.provider?.openrouter?.options).toEqual({
+      apiKey: "sk-keep",
+      baseURL: GATEWAY,
+    });
+    expect(config.provider?.openrouter?.models).toEqual({
+      "google/gemini-3-flash-preview": { options: { reasoning: { effort: "low" } } },
+    });
+    expect(config.provider?.anthropic).toEqual({ options: { apiKey: "sk-ant" } });
+  });
+});

--- a/src/tests/openrouter-base-url.test.ts
+++ b/src/tests/openrouter-base-url.test.ts
@@ -73,6 +73,86 @@ describe("ensureOpenRouterModelsOverride (pi)", () => {
     expect(written).toEqual({ providers: { openrouter: { baseUrl: GATEWAY } } });
   });
 
+  test("reverts a written override when the env returns to default (file we created is removed)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-or-revert-"));
+    try {
+      await ensureOpenRouterModelsOverride(dir, { OPENROUTER_BASE_URL: GATEWAY });
+      expect(await Bun.file(join(dir, "models.json")).exists()).toBe(true);
+      await ensureOpenRouterModelsOverride(dir, {});
+      // The override was ALL the file contained — both it and the marker go.
+      expect(await Bun.file(join(dir, "models.json")).exists()).toBe(false);
+      expect(await Bun.file(join(dir, ".agent-swarm-openrouter-override.json")).exists()).toBe(
+        false,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("revert restores a displaced user baseUrl and keeps sibling keys", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-or-restore-"));
+    try {
+      await Bun.write(
+        join(dir, "models.json"),
+        JSON.stringify({
+          providers: {
+            openrouter: { baseUrl: "https://user.example/v1", compat: { supportsTools: true } },
+            custom: { baseUrl: "https://custom.example/v1", api: "openai-completions" },
+          },
+        }),
+      );
+      await ensureOpenRouterModelsOverride(dir, { OPENROUTER_BASE_URL: GATEWAY });
+      // Re-run with the gateway still set — displaced value must survive.
+      await ensureOpenRouterModelsOverride(dir, { OPENROUTER_BASE_URL: GATEWAY });
+      await ensureOpenRouterModelsOverride(dir, {});
+      const restored = JSON.parse(await Bun.file(join(dir, "models.json")).text());
+      expect(restored.providers.openrouter).toEqual({
+        baseUrl: "https://user.example/v1",
+        compat: { supportsTools: true },
+      });
+      expect(restored.providers.custom).toEqual({
+        baseUrl: "https://custom.example/v1",
+        api: "openai-completions",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("revert leaves a user-edited baseUrl alone (marker mismatch) and drops the marker", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-or-user-edit-"));
+    try {
+      await ensureOpenRouterModelsOverride(dir, { OPENROUTER_BASE_URL: GATEWAY });
+      // User hand-edits the file after we wrote it.
+      await Bun.write(
+        join(dir, "models.json"),
+        JSON.stringify({ providers: { openrouter: { baseUrl: "https://mine.example/v1" } } }),
+      );
+      await ensureOpenRouterModelsOverride(dir, {});
+      const kept = JSON.parse(await Bun.file(join(dir, "models.json")).text());
+      expect(kept.providers.openrouter.baseUrl).toBe("https://mine.example/v1");
+      expect(await Bun.file(join(dir, ".agent-swarm-openrouter-override.json")).exists()).toBe(
+        false,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("default env never touches a hand-authored models.json (no marker)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-or-hands-off-"));
+    try {
+      const userConfig = {
+        providers: { openrouter: { baseUrl: "https://mine.example/v1" } },
+      };
+      await Bun.write(join(dir, "models.json"), JSON.stringify(userConfig));
+      await ensureOpenRouterModelsOverride(dir, {});
+      expect(JSON.parse(await Bun.file(join(dir, "models.json")).text())).toEqual(userConfig);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("merge-preserves existing providers and openrouter keys", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-or-merge-"));
     try {

--- a/src/tests/pi-mono-adapter.test.ts
+++ b/src/tests/pi-mono-adapter.test.ts
@@ -81,6 +81,96 @@ describe("PiMonoAdapter.createSession — reasoning_effort", () => {
   });
 });
 
+// ─── OPENROUTER_BASE_URL gateway routing (session model composition) ─────────
+
+describe("PiMonoAdapter.createSession — OPENROUTER_BASE_URL gateway", () => {
+  const GATEWAY = "https://control-plane.example/proxy/v1";
+  const agentDir = `/tmp/pi-or-gateway-test-${Date.now()}`;
+  const origAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+
+  let createAgentSessionSpy: ReturnType<typeof spyOn>;
+  let capturedOptions: Record<string, unknown> | undefined;
+
+  beforeAll(() => {
+    mkdirSync(agentDir, { recursive: true });
+    // getAgentDir() reads process.env directly (config.env doesn't reach it).
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+  });
+
+  afterAll(() => {
+    if (origAgentDirEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = origAgentDirEnv;
+    rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    createAgentSessionSpy?.mockRestore();
+    capturedOptions = undefined;
+  });
+
+  function makeConfig(env: Record<string, string>): ProviderSessionConfig {
+    return {
+      prompt: "hello",
+      systemPrompt: "",
+      model: "openrouter/google/gemini-3-flash-preview",
+      role: "worker",
+      agentId: "test-agent",
+      taskId: "test-task",
+      apiUrl: "",
+      apiKey: "",
+      cwd: "/tmp",
+      logFile: `/tmp/pi-or-gateway-test-${Date.now()}-${Math.random().toString(36).slice(2)}.log`,
+      env: { OPENROUTER_API_KEY: "sk-or-test", ...env },
+    };
+  }
+
+  function spyOnCreateAgentSession() {
+    createAgentSessionSpy = spyOn(piCodingAgent, "createAgentSession").mockImplementation((async (
+      opts: Record<string, unknown>,
+    ) => {
+      capturedOptions = opts;
+      return {
+        session: {
+          sessionId: "fake-session",
+          isStreaming: false,
+          model: undefined,
+          subscribe: () => () => {},
+          dispose: () => {},
+        },
+      };
+    }) as typeof piCodingAgent.createAgentSession);
+  }
+
+  test("session model carries the gateway baseUrl when OPENROUTER_BASE_URL is set", async () => {
+    spyOnCreateAgentSession();
+    const adapter = new PiMonoAdapter();
+    await adapter.createSession(makeConfig({ OPENROUTER_BASE_URL: GATEWAY }));
+    const model = capturedOptions?.model as { baseUrl?: string; id?: string } | undefined;
+    expect(model?.id).toBe("google/gemini-3-flash-preview");
+    expect(model?.baseUrl).toBe(GATEWAY);
+    // The override was materialized for the runtime to load.
+    expect(existsSync(join(agentDir, "models.json"))).toBe(true);
+  });
+
+  test("session model keeps the default openrouter.ai baseUrl when env is unset", async () => {
+    // Fresh agent dir so the previous test's models.json doesn't leak in.
+    const cleanDir = `${agentDir}-clean`;
+    mkdirSync(cleanDir, { recursive: true });
+    process.env.PI_CODING_AGENT_DIR = cleanDir;
+    try {
+      spyOnCreateAgentSession();
+      const adapter = new PiMonoAdapter();
+      await adapter.createSession(makeConfig({}));
+      const model = capturedOptions?.model as { baseUrl?: string } | undefined;
+      expect(model?.baseUrl).toBe("https://openrouter.ai/api/v1");
+      expect(existsSync(join(cleanDir, "models.json"))).toBe(false);
+    } finally {
+      process.env.PI_CODING_AGENT_DIR = agentDir;
+      rmSync(cleanDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("AGENTS.md symlink management", () => {
   const tmpDir = `/tmp/pi-mono-test-${Date.now()}`;
 

--- a/src/utils/internal-ai/complete-structured.ts
+++ b/src/utils/internal-ai/complete-structured.ts
@@ -41,6 +41,14 @@ export interface CompleteStructuredOptions<TZod extends z.ZodTypeAny> {
    */
   apiUrl?: string;
   apiKey?: string;
+  /**
+   * Per-task resolved environment (`ProviderSessionConfig.env` /
+   * `fetchResolvedEnv` output). Used for credential lookup AND the
+   * `OPENROUTER_BASE_URL` gateway override — swarm_config-sourced values
+   * never reach `process.env`, so callers with a session env must pass it.
+   * Defaults to `process.env`.
+   */
+  env?: Record<string, string | undefined>;
   /** Default: 3. */
   retries?: number;
   signal?: AbortSignal;
@@ -187,7 +195,7 @@ export async function completeStructured<TZod extends z.ZodTypeAny>(
   } else {
     const resolver = opts._resolveCredential ?? resolveCredential;
     cred = await resolver({
-      env: process.env,
+      env: (opts.env ?? process.env) as NodeJS.ProcessEnv,
       apiUrl: opts.apiUrl,
       apiKey: opts.apiKey,
       callerTag: opts.callerTag,
@@ -262,7 +270,9 @@ export async function completeStructured<TZod extends z.ZodTypeAny>(
 
   // The builtin catalog hardcodes openrouter.ai; OPENROUTER_BASE_URL reroutes
   // through a gateway (pi-ai's stream path uses `model.baseUrl` verbatim).
-  const openRouterBaseUrl = getOpenRouterBaseUrl();
+  // Resolved from the caller's session env when provided — swarm_config
+  // overlays don't reach `process.env`.
+  const openRouterBaseUrl = getOpenRouterBaseUrl((opts.env ?? process.env) as NodeJS.ProcessEnv);
   if (provider === "openrouter" && openRouterBaseUrl !== DEFAULT_OPENROUTER_BASE_URL) {
     model = { ...model, baseUrl: openRouterBaseUrl };
   }

--- a/src/utils/internal-ai/complete-structured.ts
+++ b/src/utils/internal-ai/complete-structured.ts
@@ -20,6 +20,7 @@ import { complete } from "@earendil-works/pi-ai/compat";
 import { getBuiltinModel as getModel } from "@earendil-works/pi-ai/providers/all";
 import type { TSchema } from "typebox";
 import { z } from "zod";
+import { DEFAULT_OPENROUTER_BASE_URL, getOpenRouterBaseUrl } from "../openrouter-base-url.js";
 import { type ResolvedCredential, resolveCredential } from "./credentials.js";
 import { parseModelStr } from "./models.js";
 
@@ -257,6 +258,13 @@ export async function completeStructured<TZod extends z.ZodTypeAny>(
       err,
     );
     return null;
+  }
+
+  // The builtin catalog hardcodes openrouter.ai; OPENROUTER_BASE_URL reroutes
+  // through a gateway (pi-ai's stream path uses `model.baseUrl` verbatim).
+  const openRouterBaseUrl = getOpenRouterBaseUrl();
+  if (provider === "openrouter" && openRouterBaseUrl !== DEFAULT_OPENROUTER_BASE_URL) {
+    model = { ...model, baseUrl: openRouterBaseUrl };
   }
 
   const completeFn = opts._complete ?? complete;

--- a/src/utils/internal-ai/summarize-session.ts
+++ b/src/utils/internal-ai/summarize-session.ts
@@ -35,6 +35,12 @@ export interface SummarizeSessionOptions {
   /** Passed through to `completeStructured` for codex-OAuth probing. */
   apiUrl: string;
   apiKey: string;
+  /**
+   * Per-task resolved env — forwarded to `completeStructured` so credential
+   * lookup and the `OPENROUTER_BASE_URL` gateway override see swarm_config
+   * overlays that never reach `process.env`.
+   */
+  env?: Record<string, string | undefined>;
   signal?: AbortSignal;
   /**
    * Bypass `resolveCredential` entirely — opencode auth path (and tests) pass
@@ -94,6 +100,7 @@ export async function summarizeSession(
     callerTag: `session-summary:${opts.harness}`,
     apiUrl: opts.apiUrl,
     apiKey: opts.apiKey,
+    env: opts.env,
     signal: opts.signal,
     retries: 3,
     ...(opts._credentialOverride ? { _credentialOverride: opts._credentialOverride } : {}),

--- a/src/utils/openrouter-base-url.ts
+++ b/src/utils/openrouter-base-url.ts
@@ -1,0 +1,28 @@
+/**
+ * OpenRouter base-URL resolution.
+ *
+ * `OPENROUTER_BASE_URL` lets a deployment route all OpenRouter traffic
+ * through an OpenAI-compatible gateway (e.g. the cloud control plane's
+ * `/proxy/v1` endpoint) instead of `openrouter.ai` directly, so the raw
+ * OpenRouter key never has to live on the box. When the env var is unset
+ * the default OpenRouter URL is used and behavior is unchanged.
+ *
+ * Worker-safe: pure env read, no `src/be/db` / `bun:sqlite` imports.
+ * The opencode summarize plugin (`plugin/opencode-plugins/lib/summarize.ts`)
+ * vendors this logic — keep the two in sync.
+ */
+
+export const DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
+/**
+ * Resolve the OpenRouter base URL (no trailing slash). Reads
+ * `OPENROUTER_BASE_URL` from `env`; blank values fall back to the default.
+ * Call sites append paths like `/chat/completions` or `/models`.
+ */
+export function getOpenRouterBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const raw = env.OPENROUTER_BASE_URL;
+  if (typeof raw === "string" && raw.trim().length > 0) {
+    return raw.trim().replace(/\/+$/, "");
+  }
+  return DEFAULT_OPENROUTER_BASE_URL;
+}

--- a/src/workflows/executors/raw-llm.ts
+++ b/src/workflows/executors/raw-llm.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { ExecutorMeta } from "../../types";
+import { getOpenRouterBaseUrl } from "../../utils/openrouter-base-url";
 import { BaseExecutor, type ExecutorResult } from "./base";
 
 // ─── Schemas ────────────────────────────────────────────────
@@ -27,7 +28,7 @@ export async function executeRawLlm(
   try {
     const { createOpenAI } = await import("@ai-sdk/openai");
     const openrouter = createOpenAI({
-      baseURL: "https://openrouter.ai/api/v1",
+      baseURL: getOpenRouterBaseUrl(),
       apiKey: process.env.OPENROUTER_API_KEY,
     });
     const model = openrouter(modelName);

--- a/src/workflows/executors/validate.ts
+++ b/src/workflows/executors/validate.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { ExecutorMeta } from "../../types";
+import { getOpenRouterBaseUrl } from "../../utils/openrouter-base-url";
 import { BaseExecutor, type ExecutorResult } from "./base";
 
 // ─── Schemas ────────────────────────────────────────────────
@@ -115,7 +116,7 @@ export class ValidateExecutor extends BaseExecutor<
       const { generateObject, jsonSchema } = await import("ai");
 
       const openrouter = createOpenAI({
-        baseURL: "https://openrouter.ai/api/v1",
+        baseURL: getOpenRouterBaseUrl(),
         apiKey: process.env.OPENROUTER_API_KEY,
       });
 


### PR DESCRIPTION
## Why

OpenRouter keys cannot be IP-restricted, and the 2026-07 abuse incident showed extracted keys stay spendable from anywhere. The cloud control plane is growing an LLM proxy gateway (`/proxy/v1/chat/completions`) so the raw per-org OpenRouter key never has to live on a swarm box — swarms will call the gateway with their existing `sk_swarm_live_` proxy token instead.

This PR is the swarm-side half: a single `OPENROUTER_BASE_URL` env (default `https://openrouter.ai/api/v1`) threaded through **every** OpenRouter consumer in the image. **Unset env = zero behavior change.**

## What

- **`src/utils/openrouter-base-url.ts`** — shared resolver (trim, trailing-slash strip, default fallback).
- **Direct call sites** now honor it:
  - `raw-llm.ts` / `validate.ts` workflow executors (`@ai-sdk/openai` `baseURL`)
  - memory-rater `llm-summarizer.ts` (raw fetch, Stop-hook path)
  - `provider-credentials.ts` OpenRouter key validation `GET /models`
  - `internal-ai/complete-structured.ts` (overrides the pi-ai builtin model's hardcoded `baseUrl`)
  - vendored opencode summarize plugin (resolver logic vendored — plugin sandbox can't import `src/`)
- **opencode adapter** — `applyOpenRouterBaseUrlOverride` injects `provider.openrouter.options.baseURL` into the generated per-task config (also picked up by the `models --refresh openrouter` cache refresh).
- **pi adapter** — two-part fix (investigated against `@earendil-works/pi-coding-agent` internals):
  1. `ensureOpenRouterModelsOverride` writes a merge-preserving `<agentDir>/models.json` (`{providers:{openrouter:{baseUrl}}}`) **before** `ModelRuntime` creation (the runtime loads that file exactly once at create).
  2. The session model is re-resolved through `modelRuntime.getModel(...)` — models.json provider overrides only compose onto the runtime's store; the raw builtin catalog object the adapter previously passed to `createAgentSession` is used verbatim and would keep the hardcoded openrouter.ai URL. (The alternative credential `auth.baseUrl` lever is a dead end: the builtin provider's `envApiKeyAuth` resolver never returns a `baseUrl`.)

## Tests

- New `src/tests/openrouter-base-url.test.ts`: resolver matrix, pi models.json writer (no-op / write / merge / corrupt-file), real `ModelRuntime` composition assertions (override applied + default untouched), opencode config injection matrix.
- `pi-mono-adapter.test.ts`: createSession integration — captured `sessionOptions.model.baseUrl` swaps to the gateway with env set, stays `openrouter.ai` without.
- Gateway URL assertions added to the memory-rater and opencode-plugin suites.
- Full suite green locally (pre-push hook runs `bun test`, tsc, biome, boundary checks — all passed).

## Rollout

⚠️ **Needs the normal image-release flow (channelTargets) after merge — deliberately NOT triggered here.** The control-plane cutover (env swap to `OPENROUTER_BASE_URL=<gateway>` + `OPENROUTER_API_KEY=<sk_swarm_live_ token>`) is gated on images carrying this change and is tracked in the internal repo.

https://claude.ai/code/session_01DvHFGuKp2TVHTwdcmXwGXV