### PR TITLE
Bake product-video render tooling (ffmpeg + mode40 Remotion starter) into the worker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,6 +54,8 @@ coverage/
 *.md
 !cc-plugin/**/*.md
 !templates/skills/**/*.md
+# The baked mode40 video starter ships its README (COPY'd into the worker image).
+!assets/mode40-video-starter/**/*.md
 
 # Other dockerfiles and compose files
 Dockerfile

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -55,6 +55,7 @@ RUN apt-get update && apt-get install -y curl ca-certificates gnupg \
     build-essential make cmake gcc g++ \
     python3 python3-pip python3-venv \
     jq tree htop unzip zip tar gzip sqlite3 fuse3 libfuse2 gosu tini \
+    ffmpeg \
     openssh-client \
     postgresql-client \
     postgresql-16 \
@@ -348,6 +349,15 @@ RUN HOME=/root NPM_CONFIG_CACHE=/tmp/npm-cache \
     && node -e 'const { chromium } = require("playwright"); (async () => { const browser = await chromium.launch({ headless: true, args: ["--no-sandbox"] }); const page = await browser.newPage(); await page.setContent("<main>chromium smoke ok</main>"); await browser.close(); })().catch((error) => { console.error(error); process.exit(1); });' \
     && rm -rf /tmp/npm-cache /root/.npm /root/.cache \
     && chmod -R a+rX /opt/playwright
+
+# Bake the mode40 Remotion video starter into the image so video tasks start
+# from an on-brand template instead of hand-installing tooling every session.
+# Read-only at /opt; workers copy it into their workspace, then `npm install`
+# the per-project Remotion deps (intentionally NOT vendored here — they're large
+# and version-specific). ffmpeg + Chromium (Playwright, at
+# $PLAYWRIGHT_BROWSERS_PATH) are already in the image; see the starter README.
+COPY assets/mode40-video-starter /opt/mode40/remotion-starter
+RUN chmod -R a+rX /opt/mode40
 
 # Install archil CLI for FUSE/R2-backed disk mounts
 RUN curl https://s3.amazonaws.com/archil-client/install | sh

--- a/assets/mode40-video-starter/.gitignore
+++ b/assets/mode40-video-starter/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+out/
+package-lock.json
+bun.lock
+.remotion/

--- a/assets/mode40-video-starter/README.md
+++ b/assets/mode40-video-starter/README.md
@@ -1,0 +1,63 @@
+# mode40 Video Starter (Remotion)
+
+A minimal, **mode40-branded** Remotion scaffold. Copy it, add a composition,
+render an `.mp4`. Brand tokens — IBM Plex Sans/Mono, navy/cyan, and the motion
+system (easing, stagger, rise, shadow, tint) — live in [`src/theme.ts`](./src/theme.ts)
+and are copied verbatim from mode40 Canon (`canon-brand-color`,
+`canon-typography-rules`). Start from this template, not from scratch.
+
+This scaffold is **baked into the agent-swarm worker image** at
+`/opt/mode40/remotion-starter` so video tasks don't hand-install tooling each
+session. `ffmpeg` and Chromium (via Playwright, at `$PLAYWRIGHT_BROWSERS_PATH`)
+are already in the image.
+
+## Quick start (inside a worker)
+
+```bash
+# 1. Copy the read-only starter into your writable workspace.
+cp -r /opt/mode40/remotion-starter ~/video && cd ~/video
+
+# 2. Install project deps (Remotion itself is per-project, not baked).
+npm install         # or: bun install
+
+# 3. (Optional) reuse the image's Chromium instead of downloading one.
+export REMOTION_BROWSER_EXECUTABLE="$(node -e "console.log(require('playwright').chromium.executablePath())")"
+
+# 4. Render the example composition to an mp4.
+npx remotion render src/index.ts BrandCard out/brand-card.mp4
+```
+
+Preview interactively with `npm start` (Remotion Studio) when you have a browser.
+
+## Layout
+
+```
+src/
+  index.ts                  registerRoot entry
+  Root.tsx                  composition registry — add your <Composition/> here
+  fonts.ts                  IBM Plex Sans/Mono loaded via @remotion/google-fonts
+  theme.ts                  mode40 brand + motion tokens (the source of truth)
+  compositions/
+    BrandCard.tsx           minimal example wiring up every token — copy this
+remotion.config.ts          jpeg frames, concurrency, optional browser override
+```
+
+## Making a new video
+
+1. Duplicate `src/compositions/BrandCard.tsx` and edit the content/animation.
+2. Register it in `src/Root.tsx` with a unique `id`, `durationInFrames`, `fps`,
+   and dimensions (1920×1080 @ 30fps is the house default).
+3. Render: `npx remotion render src/index.ts <id> out/<name>.mp4`.
+
+## Brand guardrails (from Canon — do not drift)
+
+- **Cyan `#00D4DE` is a signal, not a surface** — eyebrows, marks, numbers,
+  single rules. Never a large fill or body text.
+- **Navy `#001D25` is the only dark background** — never pure black.
+- **Text on navy is white**, with cyan reserved for the eyebrow/label line.
+- **Type**: IBM Plex Sans Light (300) titles with slightly tighter kerning,
+  Regular (400) body; IBM Plex Mono SemiBold (600) ALL-CAPS cyan eyebrows.
+- Need a shade that isn't in `theme.ts`? Tint navy or cyan toward white using
+  the ramp in `tint` — never invent a new hue.
+
+Versions are pinned in `package.json`. Bump deliberately with `npm run upgrade`.

--- a/assets/mode40-video-starter/package.json
+++ b/assets/mode40-video-starter/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "mode40-video-starter",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Reusable, mode40-branded Remotion scaffold. Copy this project, add a composition, render an mp4. Brand tokens (IBM Plex Sans/Mono, navy/cyan, motion) live in src/theme.ts.",
+  "scripts": {
+    "start": "remotion studio",
+    "render": "remotion render src/index.ts BrandCard out/brand-card.mp4",
+    "upgrade": "remotion upgrade"
+  },
+  "dependencies": {
+    "@remotion/cli": "4.0.450",
+    "@remotion/google-fonts": "4.0.450",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "remotion": "4.0.450"
+  },
+  "devDependencies": {
+    "@types/react": "18.3.3",
+    "typescript": "5.5.4"
+  }
+}

--- a/assets/mode40-video-starter/remotion.config.ts
+++ b/assets/mode40-video-starter/remotion.config.ts
@@ -1,0 +1,18 @@
+import { Config } from "@remotion/cli/config";
+
+// JPEG frames keep intermediate size down; concurrency 1 is the safe default
+// inside a constrained worker container. Bump concurrency locally if you have
+// the cores. `angle` is the most reliable GL renderer in headless Linux.
+Config.setVideoImageFormat("jpeg");
+Config.setConcurrency(1);
+Config.setChromiumOpenGlRenderer("angle");
+
+// Optional: reuse a browser already baked into the worker image instead of
+// letting Remotion download its own Chrome Headless Shell on first render.
+// The worker image ships Playwright's Chromium at $PLAYWRIGHT_BROWSERS_PATH
+// (/opt/playwright). Point REMOTION_BROWSER_EXECUTABLE at that binary — or any
+// Chrome/Chromium — to skip the download. Left unset, Remotion manages its own.
+const browserExecutable = process.env.REMOTION_BROWSER_EXECUTABLE;
+if (browserExecutable) {
+  Config.setBrowserExecutable(browserExecutable);
+}

--- a/assets/mode40-video-starter/src/Root.tsx
+++ b/assets/mode40-video-starter/src/Root.tsx
@@ -1,0 +1,27 @@
+import { Composition } from "remotion";
+import "./fonts";
+import { BrandCard } from "./compositions/BrandCard";
+
+// Each Composition is a standalone video. Add your own here — the `id` becomes
+// the render target: `npx remotion render src/index.ts <id> out/<name>.mp4`.
+// BrandCard is a minimal, on-brand example wiring up every token in theme.ts;
+// copy it as a starting point rather than building a composition from scratch.
+export const Root: React.FC = () => {
+  return (
+    <>
+      <Composition
+        id="BrandCard"
+        component={BrandCard}
+        durationInFrames={150}
+        fps={30}
+        width={1920}
+        height={1080}
+        defaultProps={{
+          eyebrow: "MODE40",
+          title: "Autonomous operations, made legible.",
+          body: "A reusable, on-brand starting point for product video.",
+        }}
+      />
+    </>
+  );
+};

--- a/assets/mode40-video-starter/src/compositions/BrandCard.tsx
+++ b/assets/mode40-video-starter/src/compositions/BrandCard.tsx
@@ -1,0 +1,108 @@
+import { AbsoluteFill, Easing, interpolate, useCurrentFrame } from "remotion";
+import { color, font, motion } from "../theme";
+
+export type BrandCardProps = {
+  eyebrow: string;
+  title: string;
+  body: string;
+};
+
+// Minimal, on-brand example. Every visual choice traces back to a token in
+// theme.ts: navy surface, cyan eyebrow signal, IBM Plex type, and a staggered
+// eased entrance. Duplicate this file and swap the content to make a new video.
+const ease = Easing.bezier(...motion.easing);
+
+// Staggered slide-up + fade. Element `index` starts `index * motion.stagger`
+// frames after the one before it, then eases in over 20 frames.
+const entrance = (frame: number, index: number) => {
+  const start = index * motion.stagger;
+  const progress = interpolate(frame, [start, start + 20], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+    easing: ease,
+  });
+  return {
+    opacity: progress,
+    transform: `translateY(${(1 - progress) * motion.rise}px)`,
+  };
+};
+
+export const BrandCard: React.FC<BrandCardProps> = ({ eyebrow, title, body }) => {
+  const frame = useCurrentFrame();
+
+  return (
+    <AbsoluteFill
+      style={{
+        backgroundColor: color.navy,
+        justifyContent: "center",
+        padding: "0 160px",
+      }}
+    >
+      <div style={{ maxWidth: 1200 }}>
+        {/* Eyebrow — IBM Plex Mono, SemiBold, ALL CAPS, looser tracking, cyan. */}
+        <div
+          style={{
+            ...entrance(frame, 0),
+            fontFamily: font.mono,
+            fontWeight: font.weight.semibold,
+            fontSize: 28,
+            letterSpacing: 28 * font.tracking.eyebrow,
+            textTransform: "uppercase",
+            color: color.cyan,
+            marginBottom: 28,
+          }}
+        >
+          {eyebrow}
+        </div>
+
+        {/* Cyan signal rule — a single hairline, never a fill. */}
+        <div
+          style={{
+            ...entrance(frame, 1),
+            width: 96,
+            height: 3,
+            backgroundColor: color.cyan,
+            marginBottom: 40,
+          }}
+        />
+
+        {/* Title — IBM Plex Sans Light, slightly tighter kerning, white on navy. */}
+        <div
+          style={{
+            ...entrance(frame, 2),
+            fontFamily: font.sans,
+            fontWeight: font.weight.light,
+            fontSize: 96,
+            lineHeight: 1.05,
+            letterSpacing: 96 * font.tracking.title,
+            color: color.white,
+            marginBottom: 36,
+          }}
+        >
+          {title}
+        </div>
+
+        {/* Body — IBM Plex Sans Regular, default tracking, white-on-navy at 85%. */}
+        {(() => {
+          const anim = entrance(frame, 3);
+          return (
+            <div
+              style={{
+                ...anim,
+                // Fade in, but settle at 85% for a muted-on-dark body tone.
+                opacity: anim.opacity * 0.85,
+                fontFamily: font.sans,
+                fontWeight: font.weight.regular,
+                fontSize: 36,
+                lineHeight: 1.4,
+                color: color.white,
+              }}
+            >
+              {body}
+            </div>
+          );
+        })()}
+      </div>
+    </AbsoluteFill>
+  );
+};

--- a/assets/mode40-video-starter/src/fonts.ts
+++ b/assets/mode40-video-starter/src/fonts.ts
@@ -1,0 +1,15 @@
+import { loadFont as loadIBMPlexSans } from "@remotion/google-fonts/IBMPlexSans";
+import { loadFont as loadIBMPlexMono } from "@remotion/google-fonts/IBMPlexMono";
+
+// Remotion's Google Fonts loader — safe to call at module level. Weights match
+// the mode40 Canon type rules: Sans Light (300) titles, Regular (400) body,
+// Medium (500) emphasis; Mono SemiBold (600) eyebrows.
+loadIBMPlexSans("normal", {
+  weights: ["300", "400", "500"],
+  subsets: ["latin"],
+});
+
+loadIBMPlexMono("normal", {
+  weights: ["600"],
+  subsets: ["latin"],
+});

--- a/assets/mode40-video-starter/src/index.ts
+++ b/assets/mode40-video-starter/src/index.ts
@@ -1,0 +1,4 @@
+import { registerRoot } from "remotion";
+import { Root } from "./Root";
+
+registerRoot(Root);

--- a/assets/mode40-video-starter/src/theme.ts
+++ b/assets/mode40-video-starter/src/theme.ts
@@ -1,0 +1,71 @@
+// mode40 brand tokens for Remotion video.
+//
+// Source of truth: the mode40 Canon brand skills (canon-brand-color,
+// canon-typography-rules). Values are copied verbatim from Canon — do NOT
+// substitute, approximate, or invent new hues. If you need a shade that is not
+// here, tint navy or cyan toward white using the ramp below.
+//
+// Cyan is a SIGNAL, not a surface: marks, eyebrows, numbers, links, single
+// rules. Navy is the ONLY approved dark background (never pure black). Text on
+// navy is always white, with cyan reserved for the eyebrow/label line.
+
+export const color = {
+  // Core
+  cyan: "#00D4DE", // primary accent / signal — eyebrows, marks, links, numbers
+  navy: "#001D25", // the only dark surface
+  ink: "#1A1A1A", // headings / strong text on light
+  body: "#262626", // default body text on light
+  grey: "#8A8A8A", // captions, metadata, secondary text
+  white: "#FFFFFF", // page background; text on navy
+
+  // Surface fills (the only approved light fills)
+  zebra: "#F0F0F0",
+  scopeBox: "#E6F8FB", // pale-cyan info box
+  hairline: "#E2E2E2", // light dividers on white
+
+  // Semantic aliases
+  accent: "#00D4DE",
+  heading: "#1A1A1A",
+  muted: "#8A8A8A",
+  divider: "#E2E2E2",
+  onDark: "#FFFFFF",
+} as const;
+
+// Approved tints — navy/cyan toward white. Never invent new hues.
+export const tint = {
+  navy80: "#33484F",
+  navy60: "#667579",
+  navy40: "#99A4A7",
+  navy20: "#CCD2D3",
+  cyan60: "#66E5EB",
+  cyan30: "#B3F2F5",
+} as const;
+
+// Typography — IBM Plex Sans (titles + body), IBM Plex Mono (eyebrows only).
+// Loaded at module level in src/fonts.ts via @remotion/google-fonts.
+//   Title   : IBM Plex Sans, Light (300), slightly tighter kerning.
+//   Body    : IBM Plex Sans, Regular (400), default tracking.
+//   Eyebrow : IBM Plex Mono, SemiBold (600), ALL CAPS, looser kerning, cyan.
+export const font = {
+  sans: "'IBM Plex Sans', system-ui, -apple-system, sans-serif",
+  mono: "'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace",
+  weight: { light: 300, regular: 400, medium: 500, semibold: 600 },
+  // Kerning as a fraction of font size (multiply by fontSize at the call site).
+  tracking: { title: -0.015, body: 0, eyebrow: 0.08 },
+} as const;
+
+// Motion tokens — keep entrances calm and consistent across compositions.
+export const motion = {
+  // Canonical entrance ease (easeOutExpo-like). Feed to Remotion's
+  // Easing.bezier(...easing) or a CSS cubic-bezier().
+  easing: [0.16, 1, 0.3, 1] as const,
+  // Per-element delay for staggered entrances, in frames (~130ms @ 30fps).
+  stagger: 4,
+  // Standard entrance travel distance in px (slide-up).
+  rise: 24,
+  // Soft navy elevation shadow for cards/callouts on light or dark.
+  shadow: "0 24px 60px rgba(0, 29, 37, 0.28)",
+  shadowSoft: "0 8px 24px rgba(0, 29, 37, 0.18)",
+} as const;
+
+export const theme = { color, tint, font, motion } as const;

--- a/assets/mode40-video-starter/tsconfig.json
+++ b/assets/mode40-video-starter/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "remotion.config.ts"]
+}


### PR DESCRIPTION
## What & why

Product-video production has been a fragile per-session hand-install (ffmpeg, a browser, a Remotion project — every time). This bakes the render toolchain into the **worker image** so video tasks start from a template instead of from scratch. Green-lit by Chip Martens for the mode40 product-video pipeline.

> **Draft / infra-owner call.** `agent-swarm` is our own runtime image — the sanctioned path for "how we're built" changes. This is a proposal for human review, **not** an auto-mergeable change: the actual image rebuild + merge is the infra owner's decision. Opened as draft and assigned to @tarasyarema.

## Changes

- **`ffmpeg`** added to the worker apt layer (`Dockerfile.worker`). Encode/mux, and lets tools shell out to it directly rather than relying only on Remotion's bundled compositor.
- **Minimal mode40-branded Remotion starter** baked at `/opt/mode40/remotion-starter` (`assets/mode40-video-starter/`, COPY'd read-only into the image; workers copy it into their workspace).
  - Brand tokens in `src/theme.ts` — **IBM Plex Sans/Mono, navy `#001D25` / cyan `#00D4DE`**, plus a motion system (**easing / stagger / rise / shadow / tint**) — copied verbatim from mode40 Canon.
  - A `BrandCard` example composition wires up every token, so a new video is copy-and-edit, not build-from-zero.
  - Per-project Remotion deps are **intentionally not vendored** (large, version-specific) — the starter is source-only; workers `npm install` after copying. Versions are pinned in `package.json`.
- **`.dockerignore`** — narrow exception so the starter's `README.md` survives the global `*.md` ignore and lands in the image.

## Already present — deliberately not duplicated

**Playwright + Chromium is already baked in** (`qa-use install-deps`, browsers at `$PLAYWRIGHT_BROWSERS_PATH=/opt/playwright`, with a smoke test in the build). The task originally listed it as an add; on inspection it's already there, so I didn't touch it. The starter reuses that browser via an optional `REMOTION_BROWSER_EXECUTABLE` env override to skip Remotion's per-render Chrome Headless Shell download.

## Validation

Locally, from a clean checkout of the starter:

```
npm install                                              # 219 pkgs
npx remotion render src/index.ts BrandCard out/*.mp4     # 150 frames, 1080p, ~394 kB
npx remotion still  src/index.ts BrandCard out/frame.png
```

The still is on-brand: navy surface, cyan IBM Plex Mono all-caps eyebrow + hairline, IBM Plex Sans Light title with tightened kerning, muted body.

No repo lint/type/test/CI gate matches the changed paths (`Dockerfile.worker`, `.dockerignore`, `assets/**`) — biome/tsc/konsistent/tests are scoped to `src/`, `apps/**`, `plugin/**`. Nothing bypassed; no `--no-verify`.

## Notes for the reviewer

- Image-size impact: `ffmpeg` pulls a fair amount of apt deps; the starter itself is a few KB of source (no `node_modules`).
- Submitted from a fork (`mode40joubert/agent-swarm`) — the bot account has no push rights to `desplega-ai/agent-swarm`.

## Related gap (worth a second PR — flagging, not fixing here)

Workers currently **can't write to the shared agent-fs drive at startup** — it isn't provisioned for the worker at session start, so the video worker had to publish deliverables to its own org drive + a Page instead of the shared drive. That's a separate provisioning fix; calling it out so it doesn't get lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
