### PR TITLE
feat(steering): codex queue steering via harness-side lifecycle hooks

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -247,6 +247,36 @@ RUN mkdir -p /home/worker/.claude/commands /home/worker/.claude/agents \
   } \
 }' > /home/worker/.claude/settings.json
 
+# Codex steering hooks as ADMIN-MANAGED requirements: /etc/codex/requirements.toml
+# hooks are "managed, trusted by policy" (developers.openai.com/codex/hooks), so
+# they run without the per-hook trusted_hash review that user-level hooks.json
+# needs — codex silently skips untrusted hooks, which in a headless worker means
+# steering would never deliver. PreToolUse is deliberately absent: codex drops
+# its additionalContext (openai/codex#19385). Runtime no-ops unless
+# STEERING_ENABLED reaches the codex env (live-reconciled by the runner).
+# Root-owned on purpose: it's the admin-enforced layer (and /etc needs root).
+USER root
+RUN mkdir -p /etc/codex && printf '%s\n' \
+  '[features]' \
+  'hooks = true' \
+  '' \
+  '[[hooks.SessionStart]]' \
+  '[[hooks.SessionStart.hooks]]' \
+  'type = "command"' \
+  'command = "/usr/local/bin/agent-swarm codex-hook"' \
+  '' \
+  '[[hooks.PostToolUse]]' \
+  '[[hooks.PostToolUse.hooks]]' \
+  'type = "command"' \
+  'command = "/usr/local/bin/agent-swarm codex-hook"' \
+  '' \
+  '[[hooks.Stop]]' \
+  '[[hooks.Stop.hooks]]' \
+  'type = "command"' \
+  'command = "/usr/local/bin/agent-swarm codex-hook"' \
+  > /etc/codex/requirements.toml
+USER worker
+
 # Base global npm tools (pinned versions for cache stability): the set the
 # entrypoint and core agent workflows depend on. Full-image extras (qa-use,
 # sentry-cli, localtunnel, claude-bridge) live in a SEPARATE staging dir in

--- a/docs-site/content/docs/(documentation)/guides/harness-providers.mdx
+++ b/docs-site/content/docs/(documentation)/guides/harness-providers.mdx
@@ -133,7 +133,7 @@ Running tasks can receive more input through the optional `ProviderSession.deliv
 | `opencode` | `queue` | `queued` | `promptAsync` can add input at a turn boundary; abort-and-re-prompt is not advertised because live E2E found it undeliverable. |
 | `devin` | `queue` | `queued` | The message API accepts working sessions but does not guarantee interruption. |
 | `claude` | `queue` | `queued` | Raw CLI stream-json can queue only. |
-| `codex` | none | `promoted` | Becomes a normal follow-up task. |
+| `codex` | `queue` | `queued` | Harness-side delivery via managed Codex hooks; no in-process channel. See below. |
 
 The static `PROVIDER_STEER_CAPABILITIES` map drives `supportedSteerModes` in task responses and `onUnsupported: "fail"` admission. It must match `adapter.traits.steerModes ?? []`. `src/tests/provider-steering-capabilities.test.ts` iterates every name in `ProviderNameSchema`, constructs its adapter, and fails with the provider name if the two drift.
 
@@ -146,6 +146,10 @@ The operator override accepts:
 - `0`, `false`, `off`, `no`: force the queue-steering path off.
 - `1`, `true`, `on`, `yes`: force stream-json on without the automatic version/wrapper decision.
 - unset, empty, or another value: use automatic probing.
+
+#### Codex harness-side delivery (codex-hook)
+
+Codex has no in-process input channel: `@openai/codex-sdk` runs `codex exec` with stdin closed after the prompt, and the app-server's native `turn/steer` is not reachable through the SDK. Codex sessions therefore set `steeringDeliveredExternally`, which tells the worker's dispatch poll to leave `pending` rows alone, and delivery happens inside the Codex lifecycle instead: the worker image bakes `/etc/codex/requirements.toml` registering `agent-swarm codex-hook` for `SessionStart`, `PostToolUse`, and `Stop`. The hook polls the agent's pending steering messages, marks each `delivered`, and injects the rendered envelope as hook `additionalContext` (or a one-shot Stop block for a session about to finish). Requirements-managed hooks are trusted by policy, so no interactive hook-trust review is needed in headless workers. `PreToolUse` is not used because Codex drops its `additionalContext`. Messages a session never picks up are promoted to follow-up tasks by the terminal sweep, like any other provider.
 
 For user-facing modes, degradation, entry points, and message states, see [Steer a running task](/docs/guides/task-steering).
 

--- a/docs-site/content/docs/(documentation)/guides/task-steering.mdx
+++ b/docs-site/content/docs/(documentation)/guides/task-steering.mdx
@@ -21,9 +21,9 @@ Not every harness can interrupt. Task responses include `supportedSteerModes`, a
 | opencode | `queue` | `queued` |
 | Devin | `queue` | `queued` |
 | Claude Code | `queue` | `queued` |
-| Codex | none | `promoted` to a follow-up task |
+| Codex | `queue` | `queued` (delivered by Codex lifecycle hooks at the next tool-call boundary) |
 
-Claude Code queue delivery additionally depends on a supported stock CLI invocation. See [Harness Providers: Claude queue-steering gate](/docs/guides/harness-providers#claude-queue-steering-gate).
+Claude Code queue delivery additionally depends on a supported stock CLI invocation. See [Harness Providers: Claude queue-steering gate](/docs/guides/harness-providers#claude-queue-steering-gate). Codex delivery is harness-side: the worker image registers managed Codex hooks that inject queued messages into the running session; there is no mid-turn interrupt. See [Harness Providers: Codex harness-side delivery](/docs/guides/harness-providers#codex-harness-side-delivery-codex-hook).
 
 ## Enable steering
 

--- a/runbooks/harness-providers.md
+++ b/runbooks/harness-providers.md
@@ -51,7 +51,7 @@ MCP tools return `isError` on the wire `CallToolResult` (see [runbooks/mcp-tool-
 | `opencode` | Lossy: SDK abort, then `promptAsync` | Native `promptAsync` | Interrupt discards the in-flight turn before re-prompting; queue is the zero-loss path. |
 | `devin` | No | Yes | `sendMessage` accepts a working session but does not guarantee interruption, so the adapter always reports `mode: "queue"`. |
 | `claude` | No | Conditional | Raw CLI stream-json queues input at a turn boundary; it does not interrupt. See the gate below. |
-| `codex` | No | No | No live stdin remains after session startup; steering is promoted to a follow-up task. |
+| `codex` | No | Yes (harness-side) | No in-process channel exists (`@openai/codex-sdk` drives `codex exec` with stdin closed; native `turn/steer` is app-server-only — issue #1034). The codex-hook delivers instead. See below. |
 
 The server-side `PROVIDER_STEER_CAPABILITIES` map in `src/types.ts` must deep-equal each adapter's `traits.steerModes ?? []`. `src/tests/provider-steering-capabilities.test.ts` iterates the canonical `ProviderNameSchema` list through `createProviderAdapter()` and names the offending provider on drift. Adding a provider requires updating the schema, factory, adapter traits, and capability map together.
 
@@ -69,6 +69,15 @@ With `CLAUDE_QUEUE_STEERING` unset, the adapter enables stream-json input only w
 `CLAUDE_QUEUE_STEERING=0|false|off|no` forces the feature off and keeps `-p`. `CLAUDE_QUEUE_STEERING=1|true|on|yes` is an operator force-on override and skips the automatic version/wrapper decision. Invalid or empty values behave like unset.
 
 When disabled, the adapter keeps `-p <prompt>` and the live session exposes no `deliverSteering`; an undeliverable message is promoted to a follow-up task. The provider trait remains queue-capable because the stock, supported Claude runtime implements that mode; the per-session gate is an operational availability check.
+
+### Codex harness-side delivery (codex-hook)
+
+Codex sessions have no in-process delivery seam, so `CodexSession`/`CodexSubprocessSession` set `steeringDeliveredExternally: true` and the runner's dispatch poll (`pollAndDispatchSteering`) leaves their rows `pending` instead of synthesizing an undeliverable report. Delivery happens inside the codex lifecycle:
+
+- The worker image bakes `/etc/codex/requirements.toml` (Dockerfile.worker, worker-base) registering `agent-swarm codex-hook` for `SessionStart`, `PostToolUse`, and `Stop`. Requirements-managed hooks are "trusted by policy" — user-level `hooks.json` would be silently skipped without a per-hook `trusted_hash` review, which never happens in a headless worker.
+- `src/hooks/codex-hook.ts` polls `GET /api/steering-messages` (agent-scoped), POSTs `/delivered` per row, and only then injects the rendered envelope (`src/prompts/steering-delivery.ts`) as `hookSpecificOutput.additionalContext` (SessionStart/PostToolUse) or a one-shot `{"decision":"block","reason":...}` on Stop. Delivered-before-inject is the one-shot guarantee; a failed POST leaves the row pending for the next event.
+- `PreToolUse` is deliberately not registered: codex drops its `additionalContext` (openai/codex#19385). Empirical per-event matrix at codex-cli 0.146.0: `thoughts/taras/research/2026-07-30-steering-transport-hooks-and-artificial-steering.md` §4a-bis.
+- Rows a dying session never picks up are promoted by the terminal sweep, same as every other provider. Local dev outside Docker has no `/etc/codex/requirements.toml`, so steers on local codex tasks sit pending until terminal promotion unless you install the hooks yourself.
 
 ## Per-task `outputSchema` support
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -244,6 +244,13 @@ const COMMAND_HELP: Record<
     options: "  -h, --help             Show this help",
     examples: `  ${binName} hook`,
   },
+  "codex-hook": {
+    usage: `${binName} codex-hook`,
+    description:
+      "Handle Codex CLI hook events from stdin (steering delivery).\nUsed internally by the codex hooks registered in the worker image.",
+    options: "  -h, --help             Show this help",
+    examples: `  ${binName} codex-hook`,
+  },
   artifact: {
     usage: `${binName} artifact <subcommand> [options]`,
     description: "Manage agent artifacts (serve, list, etc.).",
@@ -383,6 +390,7 @@ function printHelp(command?: string) {
     ["api", "Start the API + MCP HTTP server"],
     ["claude", "Run Claude CLI"],
     ["hook", "Handle Claude Code hook events (stdin)"],
+    ["codex-hook", "Handle Codex CLI hook events (stdin, steering delivery)"],
     ["artifact", "Manage agent artifacts"],
     ["x", "Execute external command routes"],
     ["scripts", "Reusable scripts maintenance"],
@@ -672,6 +680,10 @@ if (args.showHelp || args.command === "help" || args.command === undefined) {
 } else if (args.command === "hook") {
   const { runHook } = await import("./commands/hook.ts");
   await runHook();
+} else if (args.command === "codex-hook") {
+  const { handleCodexHook } = await import("./hooks/codex-hook.ts");
+  await handleCodexHook();
+  process.exit(0);
 } else if (args.command === "artifact") {
   // Pass all args after "artifact" directly
   const artifactArgs = process.argv.slice(process.argv.indexOf("artifact") + 1);

--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -21,6 +21,7 @@ import {
 } from "../prompts/defaults.ts";
 import { renderMemoriesPrompt } from "../prompts/memories.ts";
 import { configureHttpResolver, resolveTemplateAsync } from "../prompts/resolver.ts";
+import { renderSteeringDelivery } from "../prompts/steering-delivery.ts";
 import { authJsonToCredentialSelection } from "../providers/codex-oauth/auth-json.js";
 import { materializeCodexAuthJson } from "../providers/codex-oauth/auth-json-fs.js";
 import { loadAllCodexOAuthSlots } from "../providers/codex-oauth/storage.js";
@@ -486,29 +487,10 @@ export function createSteeringDispatchState(): SteeringDispatchState {
   };
 }
 
-/**
- * Wrap a steering body in the registered delivery envelope so the injected
- * message carries its own ID. `accept-steer` takes that ID, and it is the only
- * route to `handled` — without the envelope the agent obeys the message but
- * can never acknowledge it, and the row sits at `delivered` forever.
- *
- * Falls back to the bare body if template resolution fails: delivering an
- * un-acknowledgeable message beats not delivering one at all.
- */
-export async function renderSteeringDelivery(
-  steeringMessageId: string,
-  body: string,
-): Promise<string> {
-  try {
-    const result = await resolveTemplateAsync("system.agent.steering.delivery", {
-      steeringMessageId,
-      body,
-    });
-    return result.skipped || !result.text.trim() ? body : result.text;
-  } catch {
-    return body;
-  }
-}
+// Moved to src/prompts/steering-delivery.ts so the codex-hook can render the
+// same envelope without importing the whole runner. Re-exported for existing
+// consumers (steering-transport tests).
+export { renderSteeringDelivery };
 
 export async function pollAndDispatchSteering(
   config: ApiConfig,
@@ -518,6 +500,12 @@ export async function pollAndDispatchSteering(
   fetchImpl: typeof fetch = fetch,
 ): Promise<void> {
   if (!isSteeringEnabled()) return;
+  // Harness-side delivery (codex hooks): the hook polls pending rows and
+  // injects them itself. Dispatching here would race it into a false
+  // "Provider session does not support live steering" undeliverable →
+  // premature promotion. Leave the rows pending; the terminal sweep still
+  // promotes anything the hook never delivered.
+  if (session.steeringDeliveredExternally) return;
 
   const headers = {
     Authorization: `Bearer ${config.apiKey}`,

--- a/src/hooks/codex-hook.ts
+++ b/src/hooks/codex-hook.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env bun
+
+/**
+ * Codex lifecycle hook — harness-side steering delivery.
+ *
+ * Codex has no in-process steering channel: `@openai/codex-sdk` drives
+ * `codex exec` with stdin written once and closed, and the app-server's
+ * native `turn/steer` is not reachable through the SDK (issue #1034). So
+ * delivery happens here instead: this hook runs inside the codex lifecycle
+ * (registered for SessionStart / PostToolUse / Stop via the managed
+ * `/etc/codex/requirements.toml` in the worker image), polls the API for
+ * pending steering rows, marks them `delivered`, and injects the rendered
+ * envelope into the model's context:
+ *
+ *   - SessionStart / PostToolUse → `hookSpecificOutput.additionalContext`
+ *     (verified to reach the model at codex-cli 0.146.0; PreToolUse drops
+ *     additionalContext upstream, so it is deliberately not registered).
+ *   - Stop → `{"decision":"block","reason":...}` so a session about to end
+ *     still receives the message and continues to act on it.
+ *
+ * One-shot guarantee: a message is included in hook output only after its
+ * `/delivered` POST succeeded, so a message is injected at most once. A
+ * failed POST leaves the row `pending` for the next lifecycle event; rows a
+ * dying session never picks up are promoted by the server's terminal sweep.
+ * The runner's dispatch poll skips codex sessions entirely
+ * (`ProviderSession.steeringDeliveredExternally`).
+ */
+
+import { renderSteeringDelivery } from "../prompts/steering-delivery.ts";
+import type { SteeringMessage } from "../types";
+import { getApiKey } from "../utils/api-key";
+import { getMcpBaseUrl } from "../utils/constants";
+import { isSteeringEnabled } from "../utils/steering-enabled";
+
+const FETCH_TIMEOUT_MS = 5_000;
+
+export interface CodexHookMessage {
+  hook_event_name?: string;
+  stop_hook_active?: boolean;
+}
+
+export interface CodexHookConfig {
+  apiUrl: string;
+  apiKey: string;
+  agentId: string;
+}
+
+export function resolveCodexHookConfig(
+  env: Record<string, string | undefined> = process.env,
+): CodexHookConfig | null {
+  const agentId = env.AGENT_ID;
+  const apiKey = getApiKey(env);
+  const apiUrl = getMcpBaseUrl();
+  if (!agentId || !apiKey || !apiUrl) return null;
+  return { apiUrl, apiKey, agentId };
+}
+
+/**
+ * Fetch the agent's pending steering rows, mark each `delivered`, and return
+ * the rendered envelopes of the ones whose delivered-POST succeeded.
+ *
+ * Any error yields an empty result — a hook must never take the harness down
+ * over steering, and `pending` rows are retried on the next lifecycle event.
+ */
+export async function collectDeliverableSteering(
+  config: CodexHookConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string[]> {
+  const headers = {
+    Authorization: `Bearer ${config.apiKey}`,
+    "X-Agent-ID": config.agentId,
+  };
+
+  let messages: SteeringMessage[];
+  try {
+    const response = await fetchImpl(`${config.apiUrl}/api/steering-messages`, {
+      headers,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) return [];
+    const data = (await response.json()) as { messages?: SteeringMessage[] };
+    messages = (data.messages ?? []).filter((message) => message.status === "pending");
+  } catch {
+    return [];
+  }
+
+  const delivered: string[] = [];
+  for (const message of messages) {
+    // Mark delivered BEFORE injecting: if the POST fails the row stays
+    // pending and is retried later; the inverse order could inject the same
+    // message on every tool call ("no polluting").
+    try {
+      const report = await fetchImpl(
+        `${config.apiUrl}/api/steering-messages/${encodeURIComponent(message.id)}/delivered`,
+        {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ mode: "queue" }),
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        },
+      );
+      if (!report.ok) continue;
+    } catch {
+      continue;
+    }
+    delivered.push(await renderSteeringDelivery(message.id, message.body));
+  }
+  return delivered;
+}
+
+/**
+ * Handle one codex hook event. Returns the JSON object to print to stdout
+ * (codex reads hook responses from stdout), or null for no output.
+ */
+export async function handleCodexHookEvent(
+  msg: CodexHookMessage,
+  config: CodexHookConfig | null,
+  env: Record<string, string | undefined> = process.env,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Record<string, unknown> | null> {
+  const event = msg.hook_event_name;
+  if (!event || !config || !isSteeringEnabled(env)) return null;
+  if (event !== "SessionStart" && event !== "PostToolUse" && event !== "Stop") return null;
+
+  const envelopes = await collectDeliverableSteering(config, fetchImpl);
+  if (envelopes.length === 0) return null;
+  const additionalContext = envelopes.join("\n\n");
+
+  if (event === "Stop") {
+    // Delivered rows are marked before this block fires, so the next Stop
+    // finds nothing pending and lets the session end — no block loop.
+    return {
+      decision: "block",
+      reason: `Steering message(s) arrived before you finished:\n\n${additionalContext}`,
+    };
+  }
+
+  return {
+    hookSpecificOutput: { hookEventName: event, additionalContext },
+  };
+}
+
+/** stdin/stdout entry point used by the `codex-hook` CLI command. */
+export async function handleCodexHook(): Promise<void> {
+  let msg: CodexHookMessage;
+  try {
+    msg = (await Bun.stdin.json()) as CodexHookMessage;
+  } catch {
+    return;
+  }
+  try {
+    const output = await handleCodexHookEvent(msg, resolveCodexHookConfig());
+    if (output) console.log(JSON.stringify(output));
+  } catch {
+    // Never fail the harness over steering delivery.
+  }
+}

--- a/src/prompts/steering-delivery.ts
+++ b/src/prompts/steering-delivery.ts
@@ -1,0 +1,29 @@
+import { resolveTemplateAsync } from "./resolver.ts";
+
+/**
+ * Wrap a steering body in the registered delivery envelope so the injected
+ * message carries its own ID. `accept-steer` takes that ID, and it is the only
+ * route to `handled` — without the envelope the agent obeys the message but
+ * can never acknowledge it, and the row sits at `delivered` forever.
+ *
+ * Falls back to the bare body if template resolution fails: delivering an
+ * un-acknowledgeable message beats not delivering one at all.
+ *
+ * Shared by the runner's dispatch poll (in-process `deliverSteering`
+ * providers) and the codex-hook (harness-side delivery via hook
+ * `additionalContext`).
+ */
+export async function renderSteeringDelivery(
+  steeringMessageId: string,
+  body: string,
+): Promise<string> {
+  try {
+    const result = await resolveTemplateAsync("system.agent.steering.delivery", {
+      steeringMessageId,
+      body,
+    });
+    return result.skipped || !result.text.trim() ? body : result.text;
+  } catch {
+    return body;
+  }
+}

--- a/src/providers/codex-adapter.ts
+++ b/src/providers/codex-adapter.ts
@@ -1,8 +1,10 @@
 /**
  * Codex provider adapter.
  *
- * Wraps the `@openai/codex-sdk` (which drives the `codex app-server` JSON-RPC
- * protocol via a child process). This file owns:
+ * Wraps the `@openai/codex-sdk` (which spawns `codex exec --experimental-json`
+ * as a child process, writes the prompt to stdin and closes it, then reads
+ * JSONL events from stdout — NOT the `codex app-server` JSON-RPC protocol;
+ * migrating to app-server is issue #1034). This file owns:
  *
  *   Phase 1 — factory wiring + skeleton classes.
  *   Phase 2 — event stream normalization, CostData, AbortController, log file,
@@ -95,6 +97,7 @@ import type {
   ProviderResult,
   ProviderSession,
   ProviderSessionConfig,
+  ProviderTraits,
 } from "./types";
 
 /** Alias for the SDK's (unexported) `CodexConfigObject` type. */
@@ -514,6 +517,9 @@ export interface SummarizeSessionForCodexDeps {
 
 /** Running session backed by a Codex `Thread`. */
 export class CodexSession implements ProviderSession {
+  // Steering reaches codex via the codex-hook (harness lifecycle hooks), not
+  // an in-process channel — the runner's dispatch poll must skip this session.
+  readonly steeringDeliveredExternally = true;
   private readonly thread: Thread;
   private readonly config: ProviderSessionConfig;
   private readonly agentsMdHandle: CodexAgentsMdHandle;
@@ -1546,6 +1552,8 @@ interface CodexSubprocessInput {
  * stderr is forwarded verbatim into the runner's stdout (for prod logs).
  */
 class CodexSubprocessSession implements ProviderSession {
+  // Mirrors CodexSession: steering is delivered by the codex-hook, not here.
+  readonly steeringDeliveredExternally = true;
   private readonly proc: ReturnType<typeof Bun.spawn>;
   private readonly listeners: Array<(event: ProviderEvent) => void> = [];
   private readonly eventQueue: ProviderEvent[] = [];
@@ -1738,8 +1746,16 @@ class CodexSubprocessSession implements ProviderSession {
 
 export class CodexAdapter implements ProviderAdapter {
   readonly name = "codex";
-  // Decision 4: Codex never accepts live steering; the server promotes it to a follow-up task.
-  readonly traits = { hasMcp: true, hasLocalEnvironment: true, steerModes: [] };
+  // Queue-only steering, delivered harness-side: the codex-hook
+  // (SessionStart/PostToolUse/Stop) polls pending steering rows and injects
+  // them as hook `additionalContext` — there is no in-process channel
+  // (`CodexSession.steeringDeliveredExternally`). Native `turn/steer` needs
+  // the app-server migration (issue #1034).
+  readonly traits: ProviderTraits = {
+    hasMcp: true,
+    hasLocalEnvironment: true,
+    steerModes: ["queue"],
+  };
 
   /**
    * Optional override for the skill resolver's skills directory. When unset,

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -138,6 +138,14 @@ export interface ProviderSession {
   abort(reason?: string): Promise<void>;
   /** Optional. Absent means the provider cannot accept mid-run input. */
   deliverSteering?(delivery: SteerDelivery): Promise<SteerDeliveryResult>;
+  /**
+   * True when steering delivery happens harness-side (lifecycle hooks polling
+   * the API and injecting the message themselves — codex). The runner's
+   * dispatch poll must then leave `pending` rows untouched instead of
+   * synthesizing an undeliverable report; the hook marks them `delivered`.
+   * Rows the hook never picks up are still promoted by the terminal sweep.
+   */
+  readonly steeringDeliveredExternally?: boolean;
 }
 
 /** Result returned when a provider session completes. */

--- a/src/tests/codex-steering-hook.test.ts
+++ b/src/tests/codex-steering-hook.test.ts
@@ -1,0 +1,204 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  type CodexHookConfig,
+  handleCodexHookEvent,
+  resolveCodexHookConfig,
+} from "../hooks/codex-hook";
+import type { SteeringMessage } from "../types";
+
+const config: CodexHookConfig = {
+  apiUrl: "http://steering.test",
+  apiKey: "test-key",
+  agentId: "11111111-1111-4111-8111-111111111111",
+};
+
+const enabledEnv = { STEERING_ENABLED: "true" };
+
+function message(overrides: Partial<SteeringMessage> = {}): SteeringMessage {
+  return {
+    id: crypto.randomUUID(),
+    taskId: crypto.randomUUID(),
+    body: "change course now",
+    mode: "queue",
+    status: "pending",
+    source: "api",
+    createdByKind: "system",
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+/**
+ * Fake fetch capturing delivered-POSTs; `failDeliveredFor` simulates a
+ * delivered-callback outage for specific message IDs.
+ */
+function fakeFetch(
+  messages: SteeringMessage[],
+  options: { failDeliveredFor?: string[]; deliveredCalls?: string[] } = {},
+): typeof fetch {
+  return (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    if (init?.method === "POST" && url.includes("/delivered")) {
+      const id = url.split("/").at(-2) ?? "";
+      if (options.failDeliveredFor?.includes(id)) {
+        return new Response("{}", { status: 500 });
+      }
+      options.deliveredCalls?.push(id);
+      return new Response("{}", { status: 200 });
+    }
+    if (url.endsWith("/api/steering-messages")) {
+      return Response.json({ messages });
+    }
+    return new Response("{}", { status: 404 });
+  }) as typeof fetch;
+}
+
+// The delivery envelope resolves through the prompt template registry; no
+// STEERING_ENABLED in process.env is needed (the hook takes env explicitly),
+// but pin it anyway so ambient state can't flip mid-suite.
+const originalSteeringEnabled = process.env.STEERING_ENABLED;
+beforeAll(() => {
+  delete process.env.STEERING_ENABLED;
+});
+afterAll(() => {
+  if (originalSteeringEnabled === undefined) delete process.env.STEERING_ENABLED;
+  else process.env.STEERING_ENABLED = originalSteeringEnabled;
+});
+
+describe("codex steering hook", () => {
+  test("PostToolUse injects the envelope and marks the row delivered first", async () => {
+    const pending = message();
+    const deliveredCalls: string[] = [];
+    const output = await handleCodexHookEvent(
+      { hook_event_name: "PostToolUse" },
+      config,
+      enabledEnv,
+      fakeFetch([pending], { deliveredCalls }),
+    );
+
+    expect(deliveredCalls).toEqual([pending.id]);
+    const hookOutput = output?.hookSpecificOutput as {
+      hookEventName: string;
+      additionalContext: string;
+    };
+    expect(hookOutput.hookEventName).toBe("PostToolUse");
+    expect(hookOutput.additionalContext).toContain(pending.body);
+    expect(hookOutput.additionalContext).toContain(pending.id);
+    expect(hookOutput.additionalContext).toContain("accept-steer");
+  });
+
+  test("SessionStart delivers pre-start queued rows the same way", async () => {
+    const pending = message();
+    const output = await handleCodexHookEvent(
+      { hook_event_name: "SessionStart" },
+      config,
+      enabledEnv,
+      fakeFetch([pending]),
+    );
+    expect((output?.hookSpecificOutput as { hookEventName: string }).hookEventName).toBe(
+      "SessionStart",
+    );
+  });
+
+  test("Stop blocks with the envelope so a finishing session still receives it", async () => {
+    const pending = message();
+    const deliveredCalls: string[] = [];
+    const output = await handleCodexHookEvent(
+      { hook_event_name: "Stop" },
+      config,
+      enabledEnv,
+      fakeFetch([pending], { deliveredCalls }),
+    );
+
+    expect(output?.decision).toBe("block");
+    expect(String(output?.reason)).toContain(pending.body);
+    // The block marks rows delivered, so a subsequent Stop finds nothing and
+    // lets the session end — no block loop.
+    expect(deliveredCalls).toEqual([pending.id]);
+    const second = await handleCodexHookEvent(
+      { hook_event_name: "Stop", stop_hook_active: true },
+      config,
+      enabledEnv,
+      fakeFetch([]),
+    );
+    expect(second).toBeNull();
+  });
+
+  test("one-shot: a failed delivered-POST withholds the message for retry", async () => {
+    const pending = message();
+    const output = await handleCodexHookEvent(
+      { hook_event_name: "PostToolUse" },
+      config,
+      enabledEnv,
+      fakeFetch([pending], { failDeliveredFor: [pending.id] }),
+    );
+    // Not injected this round — the row is still pending server-side and the
+    // next lifecycle event retries, so the agent never sees a half-delivered
+    // duplicate.
+    expect(output).toBeNull();
+  });
+
+  test("non-pending rows and unrelated events are ignored", async () => {
+    const rows = [message({ status: "delivered" }), message({ status: "handled" })];
+    expect(
+      await handleCodexHookEvent(
+        { hook_event_name: "PostToolUse" },
+        config,
+        enabledEnv,
+        fakeFetch(rows),
+      ),
+    ).toBeNull();
+    expect(
+      await handleCodexHookEvent(
+        { hook_event_name: "PreToolUse" },
+        config,
+        enabledEnv,
+        fakeFetch([message()]),
+      ),
+    ).toBeNull();
+  });
+
+  test("no-ops when steering is disabled or config is missing", async () => {
+    expect(
+      await handleCodexHookEvent(
+        { hook_event_name: "PostToolUse" },
+        config,
+        { STEERING_ENABLED: "false" },
+        fakeFetch([message()]),
+      ),
+    ).toBeNull();
+    expect(
+      await handleCodexHookEvent(
+        { hook_event_name: "PostToolUse" },
+        null,
+        enabledEnv,
+        fakeFetch([message()]),
+      ),
+    ).toBeNull();
+  });
+
+  test("API failure yields silence, never a harness-visible error", async () => {
+    const failingFetch = (async () => {
+      throw new Error("connection refused");
+    }) as unknown as typeof fetch;
+    expect(
+      await handleCodexHookEvent(
+        { hook_event_name: "PostToolUse" },
+        config,
+        enabledEnv,
+        failingFetch,
+      ),
+    ).toBeNull();
+  });
+
+  test("resolveCodexHookConfig requires agent id, key, and url", () => {
+    expect(
+      resolveCodexHookConfig({
+        AGENT_ID: config.agentId,
+        AGENT_SWARM_API_KEY: "k",
+      }),
+    ).toMatchObject({ agentId: config.agentId, apiKey: "k" });
+    expect(resolveCodexHookConfig({ AGENT_SWARM_API_KEY: "k" })).toBeNull();
+    expect(resolveCodexHookConfig({ AGENT_ID: config.agentId })).toBeNull();
+  });
+});

--- a/src/tests/steering-core.test.ts
+++ b/src/tests/steering-core.test.ts
@@ -191,7 +191,10 @@ describe("task steering core", () => {
     ]);
   });
 
-  test("codex requests are promoted into a follow-up task", () => {
+  test("codex steer requests degrade to queue and stay pending for the hook", () => {
+    // Codex is queue-capable via harness-side hook delivery: the row must
+    // stay `pending` (never promoted at request time, never dispatched by the
+    // runner) until the codex-hook marks it delivered.
     const task = runningTask("codex", "codex parent");
     const result = requestSteering({
       taskId: task.id,
@@ -203,27 +206,21 @@ describe("task steering core", () => {
     });
 
     expect(result).toMatchObject({
-      outcome: "promoted",
-      effectiveMode: "steer",
+      outcome: "queued",
+      effectiveMode: "queue",
+      degradedFrom: "steer",
     });
-    expect(result.promotedTaskId).toBeDefined();
-    const child = getTaskById(result.promotedTaskId!);
-    expect(child).toMatchObject({
-      parentTaskId: task.id,
-      task: "continue with a safer approach",
-      agentId: task.agentId,
-    });
+    expect(result.promotedTaskId).toBeUndefined();
     expect(getSteeringMessagesForTask(task.id)).toEqual([
       expect.objectContaining({
         id: result.steeringMessageId,
         mode: "steer",
-        status: "promoted",
-        promotedTaskId: result.promotedTaskId,
+        status: "pending",
       }),
     ]);
   });
 
-  test("codex promotion bypasses Linear tracker context dedup", () => {
+  test("undeliverable promotion bypasses Linear tracker context dedup", () => {
     const parent = createTaskExtended("linear-backed codex parent", {
       agentId: agentIds.get("codex"),
       source: "linear",
@@ -237,10 +234,12 @@ describe("task steering core", () => {
       source: "api",
       createdByKind: "system",
     });
+    expect(result.outcome).toBe("queued");
 
-    expect(result.outcome).toBe("promoted");
-    expect(result.promotedTaskId).not.toBe(parent.id);
-    expect(getTaskById(result.promotedTaskId!)).toMatchObject({
+    const promoted = markSteeringUndeliverable(result.steeringMessageId, "session died");
+    expect(promoted.message.status).toBe("promoted");
+    expect(promoted.promotedTaskId).not.toBe(parent.id);
+    expect(getTaskById(promoted.promotedTaskId!)).toMatchObject({
       parentTaskId: parent.id,
       contextKey: parent.contextKey,
       task: "promote this into distinct follow-up work",
@@ -351,7 +350,7 @@ describe("task steering core", () => {
     expect(getSteeringMessageById(result.steeringMessageId)?.status).toBe("pending");
   });
 
-  test("pending codex tasks still promote (no live steering at any point)", () => {
+  test("pending codex tasks queue for hook delivery once the session starts", () => {
     const task = createTaskExtended("pending codex target", {
       agentId: agentIds.get("codex"),
       source: "api",
@@ -364,8 +363,9 @@ describe("task steering core", () => {
       createdByKind: "system",
     });
 
-    expect(result.outcome).toBe("promoted");
-    expect(result.promotedTaskId).toBeDefined();
+    expect(result.outcome).toBe("queued");
+    expect(result.promotedTaskId).toBeUndefined();
+    expect(getSteeringMessageById(result.steeringMessageId)?.status).toBe("pending");
   });
 
   test("latest lead task lookup excludes newer worker-assigned Slack tasks", () => {

--- a/src/tests/steering-transport.test.ts
+++ b/src/tests/steering-transport.test.ts
@@ -204,7 +204,11 @@ describe("steering worker transport", () => {
     ]);
   });
 
-  test("codex steering is promoted before the runner can poll it", () => {
+  test("codex rows stay pending: the runner skips externally-delivered sessions", async () => {
+    // Codex delivery is harness-side (codex-hook). The row must queue at
+    // request time, and the runner's dispatch poll must leave it untouched —
+    // dispatching would synthesize a false undeliverable and promote it out
+    // from under the hook.
     const agent = createAgent({
       name: "codex steering worker",
       isLead: false,
@@ -226,8 +230,22 @@ describe("steering worker transport", () => {
       createdByKind: "system",
     });
 
-    expect(requested.outcome).toBe("promoted");
-    expect(getPendingSteeringForTask(task.id)).toEqual([]);
+    expect(requested).toMatchObject({ outcome: "queued", degradedFrom: "steer" });
+
+    // Session without deliverSteering — would normally be reported
+    // undeliverable — but the external-delivery flag short-circuits the poll.
+    const codexLikeSession = { ...session(), steeringDeliveredExternally: true };
+    await pollAndDispatchSteering(
+      { apiUrl: baseUrl, apiKey: "test-key", agentId: agent.id },
+      task.id,
+      codexLikeSession,
+      createSteeringDispatchState(),
+    );
+
+    expect(getPendingSteeringForTask(task.id)).toEqual([
+      expect.objectContaining({ id: requested.steeringMessageId, status: "pending" }),
+    ]);
+    expect(getChildTasks(task.id)).toEqual([]);
   });
 
   test("accept-steer marks a delivered row handled and is idempotent", async () => {

--- a/src/tools/steer-task.ts
+++ b/src/tools/steer-task.ts
@@ -126,7 +126,7 @@ export const registerSteerTaskTool = (server: McpServer) => {
     {
       title: "Steer Task",
       description:
-        'Send a message to a task that is already running. `mode:"steer"` is honored on pi and claude-managed; claude, devin and opencode support queue only; codex always promotes the message to a follow-up task. Pass `onUnsupported:"fail"` to get an error instead of a downgrade.',
+        'Send a message to a task that is already running. `mode:"steer"` is honored on pi and claude-managed; claude, devin, opencode and codex support queue only (codex delivery lands at the next tool-call boundary via its lifecycle hooks). Pass `onUnsupported:"fail"` to get an error instead of a downgrade.',
       annotations: { destructiveHint: true },
       inputSchema: steerTaskInputSchema,
       outputSchema: steerTaskOutputSchema,

--- a/src/types.ts
+++ b/src/types.ts
@@ -400,7 +400,13 @@ export const PROVIDER_STEER_CAPABILITIES: Record<ProviderName, SteerMode[]> = {
   // only what we can honor; revisit if the abort+prompt path is fixed.
   opencode: ["queue"],
   claude: ["queue"],
-  codex: [],
+  // Codex has no in-process delivery primitive (`@openai/codex-sdk` drives
+  // `codex exec` with stdin closed; `turn/steer` is app-server-only, see
+  // issue #1034). Delivery happens harness-side instead: the codex-hook
+  // (SessionStart/PostToolUse/Stop) polls pending rows and injects them as
+  // hook `additionalContext`, so the runner must leave codex rows `pending`
+  // (`ProviderSession.steeringDeliveredExternally`).
+  codex: ["queue"],
 };
 
 export type DevinProviderMeta = {

--- a/thoughts/taras/research/2026-07-30-steering-transport-hooks-and-artificial-steering.md
+++ b/thoughts/taras/research/2026-07-30-steering-transport-hooks-and-artificial-steering.md
@@ -1,0 +1,168 @@
+---
+date: 2026-07-30T15:01:11+0200
+researcher: Claude (Fable 5)
+git_commit: 0c15fc28f553dcf77e291b49bcdfa3d8c533f177
+branch: worktree-research-harness-steering (from main)
+repository: agent-swarm
+topic: "Steering transport per harness, hook involvement, and possibilities for artificial steering (codex) + pending-steer notices"
+tags: [research, steering, harness-providers, hooks, codex, mcp-tools, prompts]
+status: complete
+autonomy: verbose
+last_updated: 2026-07-30
+last_updated_by: Claude (Fable 5)
+---
+
+# Research: Steering Transport, Hooks, and "Artificial Steering" Possibilities
+
+**Date**: 2026-07-30 15:01 CEST
+**Researcher**: Claude (Fable 5)
+**Git Commit**: `0c15fc28` (main + brainstorm commit)
+**Branch**: `worktree-research-harness-steering`
+
+## Research Question
+
+Three questions from Taras:
+
+1. Codex does not support steering natively, right?
+2. How much are we using each harness's hooks to "remind" the agent to handle steers? Could codex get an "artificial" steering via hooks?
+3. For the other harnesses, could we proactively tell the agent "FYI, you have a steer pending that you'll receive soon"?
+
+Scope: the shipped PR #1014 implementation (`STEERING_ENABLED`, pre-start queueing, `handledNote`), `src/providers/*`, the three hook surfaces, `docker-entrypoint.sh`. The "possibilities" section was explicitly requested.
+
+## Summary
+
+**Q1 — correct.** Codex has literally zero steering path: `CodexAdapter` implements no `deliverSteering` method at all, `traits.steerModes` is `[]` (`src/providers/codex-adapter.ts:1742`, comment: "Decision 4: Codex never accepts live steering"), and the server mirrors that in `PROVIDER_STEER_CAPABILITIES.codex = []` (`src/types.ts:403`). Consequence: `requestSteering()` promotes a codex steer to a follow-up task **synchronously inside the same request** (`src/be/steering.ts:231-243`) — the row is born `promoted`, never becomes `pending`, and the worker's dispatch poll never sees it. The running codex process is completely unaware anything happened; "steering codex" today is functionally "create a child task."
+
+**Q2 — hooks are used exactly zero for steering.** `grep -i steer` across all three hook surfaces (`src/hooks/hook.ts`, `src/providers/pi-mono-extension.ts`, `plugin/opencode-plugins/agent-swarm.ts`) returns nothing. Steering delivery is a completely separate transport: the worker's main loop polls `GET /api/steering-messages?taskId=` once per loop iteration per active task (`src/commands/runner.ts:5413-5427`) and calls the provider adapter's `deliverSteering()` directly on the live session object. The "remind the agent" work is done prompt-side instead: (a) the `system.agent.steering` section in the base system prompt, gated on `STEERING_ENABLED` + `traits.steerModes` non-empty + `serverCapabilities` including `core` (`src/prompts/base-prompt.ts:195-203`; pinned by `steering-transport.test.ts:326-352`); (b) the delivery envelope itself (`system.agent.steering.delivery` template, `src/prompts/session-templates.ts:217-228`), which embeds the message ID and the instruction to call `accept-steer` after acting on it; (c) the resume context preamble, which lists undelivered `pending`/`promoted` steers when building a resume task's prompt (`src/commands/context-preamble.ts:372-483`).
+
+**Q3 — feasible, and the plumbing half-exists.** There are three realistic notice/injection channels that don't require any harness to gain new native capability: the central `NUDGES` map on MCP tool results (harness-agnostic, reaches codex too), harness-native hook injection (claude/pi/opencode have blocking or context-injecting hook points already wired; codex's own hook system is enabled in our config but unused by swarm code), and the existing dispatch-poll loop. The main design caveat: for queue-capable harnesses a "you'll receive a steer soon" pre-notice is mostly redundant (the steer text itself arrives at the same turn boundary the notice would); the notice idea only pays off where delivery is impossible (codex, gate-failed claude sessions) — and in those channels, if we can deliver a notice we can usually deliver the steer text itself, making the notice channel the transport. Details in "Possibilities" below.
+
+**Post-review addendum**: follow-up research (review round 1) resolved the codex unknown — Codex CLI 0.146.0 (our exact pin) has a stable 9-event hook system with working `additionalContext` injection (proven locally by the context-mode plugin), a `Stop` hook that can block-and-continue the model, and — the headline — a native **`turn/steer`** mid-turn input-injection method in its app-server JSON-RPC protocol, currently unexposed by the `@openai/codex-sdk` we wrap. "Artificial steering for codex" is therefore not just feasible; a *native* path exists one layer below our SDK. See §4a.
+
+## Detailed Findings
+
+### 1. Core lifecycle (PR #1014, shipped, default-off)
+
+Single write path `requestSteering()` (`src/be/steering.ts:163-251`), used by all five surfaces: agent-MCP `steer-task` (`src/tools/steer-task.ts:56-121`), user-MCP variant (`src/server-user.ts:167-181`), HTTP `POST /api/tasks/{id}/steer` (`src/http/tasks.ts:776-828`), Script SDK `task_steer`, and Slack thread steering (`src/slack/steering.ts:34-54`, gated by `SLACK_THREAD_STEERING=lead|all` + `SLACK_THREAD_STEERING_MODE`).
+
+- **Table**: `task_steering_messages` (migration 121), status `pending → delivered → handled`, with `promoted`/`cancelled` branches; `handled_note` added by migration 122. Zod: `SteeringMessageSchema` (`src/types.ts:350-367`).
+- **Flag**: `STEERING_ENABLED`, default **false** (`src/utils/steering-enabled.ts:10-12`, placed outside `src/be` so worker code can read it without crossing the DB boundary). Gates: request path (403 before any row, `steering.ts:164-169`), MCP tool registration on both servers, Slack path, worker polling, resume-preamble section. Deliberately NOT gated: history reads and worker drain callbacks (`/delivered`, `/handled`, `/undeliverable`) so in-flight messages reach terminal state after a kill-switch flip (`src/http/tasks.ts:831-955` comments). It's also one of the live-reconciled env keys the runner re-reads per poll without restart (`runner.ts:786-805`).
+- **Pre-start queueing**: tasks in `unassigned`/`offered`/`pending` accept queued steers; the row stays `pending` until the session goes live. `steer` mode on a pre-start task degrades to `queue` ("nothing to interrupt yet", `steering.ts:199-219`). Paused tasks auto-resume first (`steering.ts:193-196`).
+- **Degradation**: `onUnsupported: "degrade"` (default) silently downgrades `steer → queue`; `"fail"` returns 422 with **no row created**. The persisted row records the *requested* mode; `delivered_mode` records what actually happened.
+- **Promotion** (steer → follow-up task) happens on three paths: (a) synchronously at request time when the provider can never reach a live session (codex); (b) worker reports `/undeliverable` (adapter missing/failed); (c) terminal sweep — `completeTask`/`failTask`/`cancelTask` (`src/be/db.ts:2516/2577/2645`) and heartbeat crash-recovery supersede (`src/heartbeat/heartbeat.ts:481`) promote all still-pending steers, bypassing `followUpConfig.disabled`.
+- **Heartbeat interplay**: a fresh pending steer (younger than `HEARTBEAT_STEERING_GRACE_MIN`, default 5 min) defers stall remediation for the task (`heartbeat.ts:314-338`).
+- **`handledNote`**: the assigned agent acknowledges via `accept-steer` (`src/tools/accept-steer.ts:62-125`; explicit assignment check, not RBAC; idempotent) with optional `note` (max 500 chars, scrubbed). Only `delivered → handled` transitions are allowed. Surfaces in the UI steering chips' tooltip in italics (`apps/ui/src/components/steering/steering-message-chips.tsx:93-119`), on the 5s REST poll (no websocket).
+
+### 2. Per-harness transport matrix
+
+Contract: `ProviderSession.deliverSteering?` is optional; absence = "cannot accept mid-run input" (`src/providers/types.ts:127-141`). Server-side mirror `PROVIDER_STEER_CAPABILITIES` (`src/types.ts:390-404`) must stay in sync with each adapter's `traits.steerModes` — enforced by `src/tests/provider-steering-capabilities.test.ts`, not convention.
+
+| Harness | Declared modes | Transport | True mid-turn interrupt? | Notes |
+|---|---|---|---|---|
+| **pi** | `["steer","queue"]` | Native SDK: `agentSession.steer(text)` / `followUp(text)` (`pi-mono-adapter.ts:1045-1058`) | **Yes** (only local harness with it) | Fails closed if session ended |
+| **claude-managed** | `["steer","queue"]` | Anthropic SDK `sessions.events.send` with `user.message` events (`claude-managed-adapter.ts:341-351`) | Yes (ordered event stream into cloud session) | Reports back the requested mode |
+| **claude** | `["queue"]` | JSON `user` message written to child stdin (`stream-json`) (`claude-adapter.ts:662-689`) | No — queued at next turn boundary | **Per-session gate**: CLI ≥ 2.1.205, not tmux/bridge-wrapped, `CLAUDE_QUEUE_STEERING` override (`claude-adapter.ts:91-125, 1212-1257`). Gate fails → no `deliverSteering` → promoted |
+| **opencode** | `["queue"]` | `client.session.promptAsync` regardless of requested mode (`opencode-adapter.ts:637-660`) | No | abort+re-prompt "steer" was lossy in E2E, abandoned |
+| **devin** | `["queue"]` | REST `sendMessage` to Cognition API (`devin-adapter.ts:217-230`) | No — accepts message during `working`, no interrupt guarantee | `mode` param not even destructured |
+| **codex** | `[]` | **None** — no `deliverSteering` exists | No | Promoted synchronously server-side at request time; worker poll never involved (`steering-transport.test.ts:207-231`) |
+
+Worker dispatch: `pollAndDispatchSteering` (`runner.ts:513-586`) per active task per main-loop tick; per-boot `dispatchedIds` set prevents double-delivery; adapter errors are secret-scrubbed before being reported `/undeliverable`; the reported mode is the adapter's **actual** delivery mode, not the requested one. Missing `deliverSteering` on a live session synthesizes "Provider session does not support live steering" → promotion (this is the path a gate-failed claude session takes).
+
+### 3. Hooks: what exists per harness, and their (non-)role in steering
+
+Three behaviorally-mirrored lifecycle-hook implementations exist — **none mentions steering**:
+
+- **claude** — `src/hooks/hook.ts`, one script for 6 events. `SessionStart` (CLAUDE.md write, lead concurrent-session awareness), `PreCompact` (goal reminder), `PreToolUse` (**blocks** with `{"decision":"block","reason":...}` on task cancellation / tool loops / poll-limit — reason text reaches the model), `PostToolUse` (heartbeat, identity/memory sync, lead post-`send-task` reminder), `UserPromptSubmit` (cancellation re-check), `Stop` (sync, session summary, `/close`).
+- **pi** — `src/providers/pi-mono-extension.ts` (`createSwarmHooksExtension`), 1:1 parity by design: `session_start`/`tool_call` (can return `{block:true,reason}`)/`tool_result`/`context`/`input`/`session_shutdown`.
+- **opencode** — `plugin/opencode-plugins/agent-swarm.ts` in-process plugin: `tool.execute.before` (blocks by **throwing**), `tool.execute.after`, `event` (file.edited / session.idle), `experimental.chat.system.transform` (injects into system prompt), `experimental.session.compacting` (goal reminder into context).
+- **codex** — no swarm hook at all. Swarm behavior rides an in-process `ProviderEvent` listener (`src/providers/codex-swarm-events.ts` + `src/providers/swarm-events-shared.ts:237-278`): `tool_start` → throttled cancellation poll + tool-loop check, but can only **abort the whole turn via AbortController** — "Codex's SDK lacks a preToolUse blocking hook" (`codex-swarm-events.ts:17-21`). No goal-reminder, no session-start injection. Notably, `~/.codex/config.toml` **does** bake `features: { hooks: true, plugin_hooks: true }` (`codex-adapter.ts:475-493`) — enabled for the context-mode plugin ("routing injection, PreToolUse safety blocks") — i.e. codex's *own* hook system is on, we just don't use it for swarm behaviors.
+- **docker-entrypoint.sh** — provider branches only do credentials/config seeding; zero steering content. `STEERING_ENABLED` is deliberately not baked at boot: it's in the runner's live-reconciled key list.
+
+Where the "remind about steers" work actually lives today (all prompt-side, not hooks):
+
+1. **Base system prompt** — `getBasePrompt()` resolves the `system.agent.steering` template (`session-templates.ts:199-209`) programmatically at `src/prompts/base-prompt.ts:202`, only when `isSteeringEnabled()` AND `traits.steerModes` is non-empty AND `serverCapabilities` includes `core` (`base-prompt.ts:195-203`; pinned by `steering-transport.test.ts:326-352`). So the static "you may receive steering messages… act, then `accept-steer`" block is env-gated exactly as intended. Codex never gets it (empty modes).
+2. **Delivery envelope** — `system.agent.steering.delivery` (`session-templates.ts:217-228`): `[steering <id>] <body>` + "Once you have acted on this, call accept-steer…". Rendered by `renderSteeringDelivery` (`runner.ts:498-511`); falls back to the bare body on template failure ("delivering an un-acknowledgeable message beats not delivering one at all").
+3. **Resume preamble** — "Undelivered Steering Messages" section when building resume-task prompts (`context-preamble.ts:372-483`), gated on the flag.
+4. Note: `system.agent.steering` is not referenced via `{{@template[...]}}` from any `system.session.*` composite — inclusion happens only through the programmatic base-prompt resolution in (1). (An earlier draft of this doc mis-read that as "dormant"; corrected in review round 1.)
+
+### 4. Possibilities (explicitly requested)
+
+#### 4a. "Artificial" steering for codex
+
+**Updated after review-round-1 research (web + local plugin inspection). We ship Codex CLI 0.146.0 everywhere** (`Dockerfile.worker:134` ARG, `@openai/codex-sdk ^0.146.0` in `package.json:156`, host CLI 0.146.0; pin sync enforced by `scripts/check-codex-default-model.sh` + CI). Hooks went **stable upstream in v0.124.0** — we are well past it. Ranked options:
+
+1. **`turn/steer` — codex's own native mid-turn steering (the real prize).** The Codex app-server JSON-RPC protocol (which `@openai/codex-sdk` drives via a child process — `codex-adapter.ts:4-5`) has a first-class `turn/steer` method: "appends user input to the active in-flight turn" (plus `turn/interrupt`). Sources: [codex-rs/app-server README](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md), [developers.openai.com/codex/app-server](https://developers.openai.com/codex/app-server). That's semantically *stronger* than claude's queue-only stdin. **Blocker**: the TS SDK doesn't expose it — `Thread` only has `run()`/`runStreamed()` ([openai/codex#12329](https://github.com/openai/codex/issues/12329), open). Paths: upstream PR to the SDK, or a thin vendored extension speaking the JSON-RPC method to the SDK's child process. If wired, codex flips to `["steer","queue"]`-class support and the "Decision 4" promotion disappears.
+2. **Codex-native hooks (proven locally, protocol verified in working code).** Codex 0.146.0 supports 9 hook events (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, PreCompact, PostCompact, SubagentStart, SubagentStop, Stop; JSON on stdin → JSON on stdout; exit 2 = hard block with stderr fed to the model). The **context-mode codex plugin on this machine demonstrates injection working**: its SessionStart hook returns `{hookSpecificOutput: {hookEventName, additionalContext}}` with a routing block + session directives (`~/.codex/plugins/cache/context-mode/context-mode/1.0.169/hooks/codex/sessionstart.mjs:39-93`), and its PreToolUse formatter emits an `additionalContext` shape via a `context` action (`hooks/core/formatters.mjs:65-69`). Per upstream docs/issues: `UserPromptSubmit` + `SessionStart` `additionalContext` confirmed; `PostToolUse` `additionalContext` reported supported; `PreToolUse` `additionalContext` is contested upstream ([#19385](https://github.com/openai/codex/issues/19385) says rejected, fix PR [#20692](https://github.com/openai/codex/pull/20692)) — but PreToolUse block-with-reason definitely reaches the model. A swarm `hooks.json` (we bake `features = {hooks, plugin_hooks}` already but install **no swarm hooks for codex today**) could poll `GET /api/steering-messages?taskId=` on PostToolUse and deliver the steer body as `additionalContext` → effective `["queue"]` for codex, using the exact endpoint + envelope the runner already uses. Needs a small hands-on spike to confirm which events honor `additionalContext` at exactly 0.146.0.
+3. **Codex Stop-hook gate** — Codex's `Stop` hook, when it blocks, "feeds your reason back to the model and asks it to continue": the "don't finish while a pending steer exists" gate (see 4b) is available *natively on codex*, independent of options 1-2.
+4. **MCP tool-result nudge** (cheapest, universal — see 4b). Reaches codex with zero codex-specific work, but only fires when the agent happens to call a swarm MCP tool.
+5. **The in-process event listener** (`swarm-events-shared.ts`) is *not* a viable injection channel — it observes and aborts; it has no path to put text into codex's conversation.
+
+Server-side consequence of any of these: flipping `PROVIDER_STEER_CAPABILITIES.codex` to non-empty + adding `deliverSteering` (or a hook-based delivery seam) changes `canReachLiveSession` and stops the synchronous promotion — the existing degrade/promote ladder then handles failures for free (undeliverable → promoted is already idempotent and tested).
+
+#### 4a-bis. Hands-on spike results (2026-07-30, codex-cli 0.146.0, isolated `CODEX_HOME=/tmp/codex-spike-home`, Taras-approved trust bypass)
+
+Probe: a single hook script registered for 5 events, each logging its stdin payload and emitting `additionalContext: "MAGIC-<event>-<n>"` (Stop: one-time `{"decision":"block","reason":"MAGIC-STOP-13: …"}`). Prompt asked the model to run one command and report every `MAGIC-*` string visible in its context. **Empirical matrix:**
+
+| Event | `additionalContext` reaches model? | Payload fields received |
+|---|---|---|
+| SessionStart | **YES** | cwd, session_id, source, model, transcript_path |
+| UserPromptSubmit | **YES** | + prompt, turn_id |
+| **PostToolUse** | **YES** ← the steering delivery channel | + tool_name, tool_input, tool_response, tool_use_id, turn_id |
+| PreToolUse | **NO** (hook fires, context silently dropped — confirms [#19385](https://github.com/openai/codex/issues/19385)) | + tool_name, tool_input, tool_use_id, turn_id |
+| Stop (block) | **YES** — model was blocked, continued, and complied with the reason text | + last_assistant_message, stop_hook_active, turn_id |
+
+Two operational findings:
+
+- **Hook trust gate**: hooks are **silently skipped** unless each hook has a `trusted_hash` entry under `[hooks.state]` in `config.toml` (hash format unidentified; not sha256 of the bare command string). `codex exec --dangerously-bypass-hook-trust` (documented "intended only for automation that already vets hook sources") makes them run; the bypass is per-invocation, nothing is auto-persisted. Worker-image consequence: either seed correct `trusted_hash` entries at build time (format TBD from codex-rs source) or inject the flag — note `@openai/codex-sdk` builds its own fixed argv, so the flag would go in via an executable shim (`codexPathOverride`-style), not SDK options.
+- **`turn/steer` is NOT reachable through our SDK** — despite `codex-adapter.ts:4-5`'s comment saying the SDK "drives the codex app-server", `@openai/codex-sdk@0.146.0` actually spawns **`codex exec --experimental-json`**, writes the prompt to stdin and immediately closes it (`dist/index.js:174,262-263`), reading JSONL from stdout. No JSON-RPC channel, no open stdin, no `steer` in the SDK's type surface (grep: zero hits). Using `turn/steer` would mean replacing the transport with our own `codex app-server` JSON-RPC client — a much bigger lift than hooks.
+
+**Conclusion**: the pragmatic codex fix is **hook-based queue delivery on PostToolUse** (+ optional Stop-gate), with `turn/steer` as a future upgrade if/when the SDK exposes it ([#12329](https://github.com/openai/codex/issues/12329)).
+
+Caveat on sourcing for the upstream-docs claims in §4a: search snippets + GitHub issues (WebFetch was unavailable during web research) — but the load-bearing rows of the matrix above are now verified empirically at our exact pinned version.
+
+#### 4b. Proactive "you have a steer pending" notice
+
+- **Central `NUDGES` map on MCP tool results** (`src/tools/utils.ts`; the registrar composes conditional one-sentence steers onto results already). A registrar-level check — "does the calling agent's active task have a pending steering row?" — could append "FYI: a steering message is pending for task X" to any tool result. Harness-agnostic: works for codex, gate-failed claude, everything. Cost: one DB lookup per tool call (cheap: partial index `idx_task_steering_messages_pending` exists precisely for `(task_id, status='pending')`); frequency: only as often as the agent calls swarm tools.
+- **Hook-side notice** for claude/pi/opencode: `PostToolUse`/`tool_result`/`tool.execute.after` already do fire-and-forget HTTP per tool call — adding a pending-steer check there is mechanically trivial and the claude/pi block channels can even carry the notice text.
+- **Honest assessment of value**: for queue-capable harnesses the notice is largely redundant — the dispatch poll delivers the actual steer text at the same cadence (per main-loop tick) that any notice would arrive, and it lands at the same turn boundary. The notice only adds value where **delivery is impossible** (codex today, gate-failed claude) — and in exactly those channels, if the notice text can reach the model, the steer body itself can, making "notify" collapse into "deliver" (option 4a). The one genuinely distinct use for a pre-notice: pi's true `steer` mode aside, an agent about to conclude a long turn could be told "check/wait for pending steering before finishing" — i.e. a *Stop-hook* gate ("don't stop while a pending steer exists") is the variant that does something the current transport can't. No such Stop-hook check exists today.
+
+## Code References
+
+| File | Line | Description |
+|------|------|-------------|
+| `src/be/steering.ts` | 163-251 | `requestSteering` — sole write path; degrade ladder, pre-start queueing, sync promotion for codex |
+| `src/types.ts` | 390-404 | `PROVIDER_STEER_CAPABILITIES` (codex `[]`); sync with adapter traits enforced by test |
+| `src/providers/types.ts` | 127-141 | `deliverSteering?` optional contract; absence = no mid-run input |
+| `src/providers/codex-adapter.ts` | 1742 | `steerModes: []`, "Decision 4" comment; no `deliverSteering` anywhere in the class |
+| `src/providers/codex-adapter.ts` | 475-493 | `features: { hooks: true, plugin_hooks: true }` in baked codex config (unused by swarm code) |
+| `src/providers/claude-adapter.ts` | 91-125, 1212-1257, 662-689 | Queue-steering version/wrapper gate + stdin `stream-json` delivery |
+| `src/providers/pi-mono-adapter.ts` | 1045-1058 | Native `steer()`/`followUp()` |
+| `src/providers/opencode-adapter.ts` | 637-660 | `promptAsync` always-queue delivery |
+| `src/providers/devin-adapter.ts` | 217-230 | REST `sendMessage`, mode ignored |
+| `src/providers/claude-managed-adapter.ts` | 341-351 | `sessions.events.send` user.message delivery |
+| `src/commands/runner.ts` | 477-586, 5413-5427 | Dispatch state, envelope rendering, per-tick poll-and-deliver loop |
+| `src/providers/codex-swarm-events.ts` | 17-21 | "Codex's SDK lacks a preToolUse blocking hook" — abort-only channel |
+| `src/hooks/hook.ts` | 919-1239 | All 6 claude hook events — zero steering mentions |
+| `src/providers/pi-mono-extension.ts` | 405-655 | Pi extension events (blockable `tool_call`) — zero steering mentions |
+| `plugin/opencode-plugins/agent-swarm.ts` | 226-343 | Opencode plugin hooks — zero steering mentions |
+| `src/prompts/session-templates.ts` | 199-228 | `system.agent.steering` (registered, unreferenced) + delivery envelope template |
+| `src/commands/context-preamble.ts` | 372-483 | Resume preamble "Undelivered Steering Messages" section |
+| `src/tools/accept-steer.ts` | 62-125 | Acknowledgement + `handledNote` (≤500 chars, scrubbed, idempotent) |
+| `src/tools/utils.ts` | — | Central `NUDGES` map (candidate channel for pending-steer notice) |
+| `src/be/migrations/121_task_steering_messages.sql` | 5-24 | Table + partial pending index |
+| `src/heartbeat/heartbeat.ts` | 314-338, 481 | Steering stall-grace window; crash-recovery promotion sweep |
+| `src/tests/steering-transport.test.ts` | 97-352 | Transport pins: once-only delivery, actual-mode reporting, codex pre-poll promotion, prompt gating |
+| `runbooks/harness-providers.md` | 43-71 | Per-provider delivery table + claude gate + capability-sync test doc |
+| `docs-site/.../guides/task-steering.mdx` | 8-141 | User-facing modes, fallback ladder, lifecycle state machine |
+
+## Open Questions
+
+- ~~Does the codex CLI hook API support context injection?~~ — **ANSWERED (review round 1)**: yes, with per-event nuance — see the rewritten §4a. Codex 0.146.0 (our pin) has stable hooks with `additionalContext` injection (SessionStart/UserPromptSubmit confirmed; PostToolUse reported; PreToolUse contested upstream, block-with-reason always works), demonstrated working locally by the context-mode codex plugin. Bigger discovery: the app-server protocol has a native **`turn/steer`** mid-turn injection method, unexposed by the TS SDK ([#12329](https://github.com/openai/codex/issues/12329)). Spike completed same day (see §4a-bis): PostToolUse/UserPromptSubmit/SessionStart inject; PreToolUse does not; Stop-block works; hooks need trust seeding or the bypass flag; `turn/steer` unreachable through the SDK (it runs `codex exec`, not app-server). Decision: hook-based queue delivery.
+- ~~Whether `system.agent.steering` is dormant~~ — **RESOLVED (review round 1)**: the template is NOT dormant. `getBasePrompt()` resolves it programmatically via `resolveTemplateAsync("system.agent.steering", {})` at `src/prompts/base-prompt.ts:202`, gated on `isSteeringEnabled() && steerModes.length > 0 && serverCapabilities.includes("core")` (`base-prompt.ts:195-203`) — i.e. it already IS included based on env, exactly as intended. The earlier "unreferenced" claim came from only checking `{{@template[...]}}` references inside `session-templates.ts` composites, missing the programmatic resolution.
+- ~~Nudge frequency/dedup semantics~~ — **DECIDED (Taras, review round 1)**: if the `NUDGES` pending-steer notice is built, it must be **one-shot per steering message** — no repeating it on every tool call until handled ("no polluting").
+
+## Appendix
+
+- **Architecture notes**: capability declaration lives in adapter `traits.steerModes`, mirrored server-side and drift-guarded by test; enforcement is entirely server-side in `requestSteering`; delivery is worker-side via the main poll loop, entirely bypassing the hook systems; every failure path funnels into idempotent promotion-to-follow-up.
+- **Historical context (from thoughts/)**: `thoughts/taras/research/2026-07-24-harness-steering.md` — the pre-implementation research that produced PR #1014's design (Decision 4 = codex promotes; identified cancellation-block as the one proven live-injection channel and pi's `steer()` as the richest primitive). Its "codex has no upstream primitive" claim predates `features.hooks` being enabled in our codex config.
+- **Related research**: `thoughts/taras/plans/` PR #1014 planning docs; memory note `project_harness_steering`.


### PR DESCRIPTION
## Summary

Codex tasks can now be steered. Previously `PROVIDER_STEER_CAPABILITIES.codex = []` meant every `steer-task` against a codex task was promoted to a follow-up task at request time — the running session never learned anything happened. This PR flips codex to **`["queue"]`, delivered harness-side via Codex lifecycle hooks**, since there is no in-process channel: `@openai/codex-sdk` drives `codex exec` with stdin closed after the prompt, and the app-server's native `turn/steer` is unreachable through the SDK (tracked separately in #1034).

Research + empirical spike behind the design: `thoughts/taras/research/2026-07-30-steering-transport-hooks-and-artificial-steering.md` (first commit of this branch). Key spike facts at our pinned codex-cli **0.146.0**: hook `additionalContext` reaches the model on `SessionStart`/`UserPromptSubmit`/`PostToolUse`, is silently dropped on `PreToolUse` (openai/codex#19385), and a `Stop` block-with-reason makes the model continue and comply.

## How it works

- **`src/hooks/codex-hook.ts`** (new, `agent-swarm codex-hook` CLI command): runs inside the codex lifecycle for `SessionStart` / `PostToolUse` / `Stop`. Polls `GET /api/steering-messages` (agent-scoped), POSTs `/delivered` per row, and only then injects the rendered envelope — as `hookSpecificOutput.additionalContext` (SessionStart/PostToolUse) or a one-shot `{"decision":"block","reason":...}` on Stop so a finishing session still receives the message. Delivered-before-inject is the one-shot guarantee (per review: notices must never repeat). No-ops when `STEERING_ENABLED` is off; any API failure yields silence, never a harness error.
- **Runner seam**: new optional `ProviderSession.steeringDeliveredExternally` — `pollAndDispatchSteering` leaves such sessions' rows `pending` instead of synthesizing "does not support live steering" undeliverable reports (which would have raced the hook into premature promotion). Both `CodexSession` and `CodexSubprocessSession` set it.
- **Trust**: worker image bakes **`/etc/codex/requirements.toml`** (admin-managed layer — hooks are "trusted by policy"). User-level `hooks.json` would be silently skipped without an interactive per-hook `trusted_hash` review, which can't happen in a headless worker. `PreToolUse` deliberately not registered.
- **Envelope extraction**: `renderSteeringDelivery` moved to `src/prompts/steering-delivery.ts` (runner re-exports) so the hook doesn't import the whole runner.
- Fallback semantics unchanged: rows a session never picks up are promoted by the existing terminal sweep; `steer` requests degrade to `queue`; `onUnsupported:"fail"` now 422s only for `mode:"steer"` on codex.
- Stale `codex-adapter.ts` header comment fixed (the SDK runs `codex exec`, not app-server).

## Behavior changes

| Before | After |
|---|---|
| Steer a codex task → instant `promoted` follow-up task; running session unaware | → `queued`; delivered into the live session at the next SessionStart/PostToolUse/Stop hook fire |
| Codex never saw the base-prompt "Live Task Steering" section | Gets it (steerModes non-empty), so it knows to `accept-steer` |
| — | Local dev outside Docker: no `/etc/codex/requirements.toml`, so codex steers stay pending until terminal promotion unless hooks are installed manually (documented in runbook) |

## Testing

- `bun test src/tests/codex-steering-hook.test.ts` — 8 new tests: delivered-before-inject ordering, one-shot on failed delivered-POST, Stop block + no-loop, disabled/missing-config no-ops, API-failure silence.
- Updated `steering-core` / `steering-transport` pins: codex rows stay pending; runner skips externally-delivered sessions; undeliverable promotion (incl. tracker-dedup bypass) re-pinned via `markSteeringUndeliverable`.
- `provider-steering-capabilities` drift test passes with both sides flipped.
- Full merge-gate mirror locally: lint, tsc, full `bun test`, db/api-key boundary, dep-graph.
- `docker build --target worker-slim` locally + in-container validation: swapped the baked requirements command for a probe hook and ran a real `codex exec` — the managed hook fired with a full payload, trusted by policy, **no** `--dangerously-bypass-hook-trust` needed. The compiled `agent-swarm codex-hook` also exits 0 on a bare event in-container.

## Docs

- `runbooks/harness-providers.md` — codex row + new "Codex harness-side delivery (codex-hook)" section.
- `docs-site/.../guides/harness-providers.mdx` + `task-steering.mdx` — codex now `queue`.
- `steer-task` tool description updated.

## Follow-ups

- #1034 — migrate codex integration to `codex app-server` for native `turn/steer` (mid-turn) + `turn/interrupt`, removing the hook path from steering entirely.

https://claude.ai/code/session_013nwwRQs7j2SQ6JKTAELoT8
