### PR TITLE
fix(entrypoint): reclaim /home/worker/.claude for worker to prevent session-env EACCES

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -818,6 +818,17 @@ echo ""
 # into .local would otherwise block worker-side mkdir into .local/share.
 chown -R worker:worker /home/worker/.local 2>/dev/null || true
 
+# Reclaim /home/worker/.claude for worker before dropping privileges.
+# The harness runs `mkdir /home/worker/.claude/session-env/<session-id>` as the
+# worker user before spawning each shell. If root wrote into .claude earlier in
+# this entrypoint (settings.json, skills/) and left the tree root-owned, that
+# mkdir fails with EACCES and NO shell ever starts — every task in the container
+# dies at harness setup. Reclaiming the whole tree keeps session-env (and
+# anything else the harness writes under .claude) writable by worker. The
+# narrower .claude/skills chown above is now subsumed by this but is kept for
+# documentation of the skill-fs-writer intent.
+chown -R worker:worker /home/worker/.claude 2>/dev/null || true
+
 # Optional: initialize a local PostgreSQL 16 cluster before dropping privileges.
 # command -v guard: postgres/redis servers only ship in the full image — on the
 # slim image these flags log a warning instead of killing the boot (set -e).


### PR DESCRIPTION
## Problem

A worker container hard-failed **before running anything** with:

```
EACCES: permission denied, mkdir '/home/worker/.claude/session-env/<session-uuid>'
```

The harness creates a per-session scratch dir under `/home/worker/.claude/session-env/` (as the `worker` user) before spawning each shell. When that `mkdir` is denied, **no shell ever starts** — every Bash/Write call in the container dies at harness setup, and the whole container is unusable until a host-side `chown` is run by hand.

## Root cause

`docker-entrypoint.sh` runs as **root** with `HOME=/home/worker` and writes into `.claude` earlier in the boot (e.g. `settings.json`, `skills/`). It already reclaims a few subtrees for the worker before dropping privileges:

- `chown -R worker:worker /home/worker/.claude/skills`
- `chown -R worker:worker /home/worker/.local`

…but it never reclaims **`/home/worker/.claude` itself**. So the top of the tree stays root-owned, and the worker-side `mkdir .claude/session-env/<id>` fails with `EACCES`.

## Fix

Add a recursive reclaim of `/home/worker/.claude`, mirroring the existing `.local` reclaim block, right after it. Scoped to the chown only — one added block, no behavior change elsewhere. The narrower `.claude/skills` chown above it is now subsumed but kept for documentation of the skill-fs-writer intent.

```sh
chown -R worker:worker /home/worker/.claude 2>/dev/null || true
```

## Notes

- Opened as **draft** for human review — please don't merge without a maintainer's sign-off.
- Reviewer tagged in a comment below (fork contributor can't set upstream reviewers directly).