### PR TITLE
feat(ui): filter the task list by requester

### DIFF
--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -317,6 +317,8 @@ class ApiClient {
     orderBy?: "lastUpdatedAt" | "createdAt";
     /** Filter to tasks whose `source` is in this list. Empty/undefined → all. */
     source?: string[];
+    /** Exact requester user id, or the sentinel `none` for unattributed (NULL) rows. */
+    requestedByUserId?: string;
   }): Promise<TasksResponse> {
     const params = new URLSearchParams();
     if (filters?.status) params.set("status", filters.status);
@@ -333,6 +335,7 @@ class ApiClient {
     if (filters?.orderBy) params.set("orderBy", filters.orderBy);
     if (filters?.source && filters.source.length > 0)
       params.set("source", filters.source.join(","));
+    if (filters?.requestedByUserId) params.set("requestedByUserId", filters.requestedByUserId);
     const queryString = params.toString();
     const url = `${this.getBaseUrl()}/api/tasks${queryString ? `?${queryString}` : ""}`;
     const res = await fetch(url, { headers: this.getHeaders() });

--- a/apps/ui/src/api/hooks/use-tasks.ts
+++ b/apps/ui/src/api/hooks/use-tasks.ts
@@ -32,6 +32,8 @@ export interface TaskFilters {
   orderBy?: "lastUpdatedAt" | "createdAt";
   /** Filter to tasks whose `source` is in this list. Empty/undefined → all. */
   source?: string[];
+  /** Exact requester user id, or the sentinel `none` for unattributed (NULL) rows. */
+  requestedByUserId?: string;
 }
 
 export interface UseTasksOptions {
@@ -144,6 +146,13 @@ function matchesTaskFilters(task: AgentTask, filters?: TaskFilters): boolean {
   if (filters.createdBefore && task.createdAt >= filters.createdBefore) return false;
   if (filters.source && filters.source.length > 0 && !filters.source.includes(task.source)) {
     return false;
+  }
+  if (filters.requestedByUserId) {
+    if (filters.requestedByUserId === "none") {
+      if (task.requestedByUserId) return false;
+    } else if (task.requestedByUserId !== filters.requestedByUserId) {
+      return false;
+    }
   }
   if (filters.search) {
     const needle = filters.search.toLowerCase();

--- a/apps/ui/src/pages/tasks/page.tsx
+++ b/apps/ui/src/pages/tasks/page.tsx
@@ -2,9 +2,11 @@ import { ChevronLeft, ChevronRight, Clock, Plus, Search, X } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useAgents } from "@/api/hooks/use-agents";
+import { useFeatureGate } from "@/api/hooks/use-feature-gate";
 import { useScheduledTasks } from "@/api/hooks/use-schedules";
 import { useTaskTemplates } from "@/api/hooks/use-task-templates";
 import { useCreateTask, useTasks } from "@/api/hooks/use-tasks";
+import { useUsers } from "@/api/hooks/use-users";
 import { type AgentTask, REASONING_EFFORT_LEVELS } from "@/api/types";
 import { StatusBadge } from "@/components/shared/status-badge";
 import {
@@ -317,6 +319,7 @@ export default function TasksPage() {
   const statusFilter = searchParams.get("status") ?? "all";
   const agentFilter = searchParams.get("agent") ?? "all";
   const scheduleFilter = searchParams.get("schedule") ?? "all";
+  const requesterFilter = searchParams.get("requester") ?? "all";
   const searchParam = searchParams.get("search") ?? "";
   const includeHeartbeat = searchParams.get("heartbeat") === "true";
   const page = searchParams.has("page") ? Number(searchParams.get("page")) : 0;
@@ -337,6 +340,7 @@ export default function TasksPage() {
           status: "all",
           agent: "all",
           schedule: "all",
+          requester: "all",
           search: "",
           page: "0",
           pageSize: String(DEFAULT_PAGE_SIZE),
@@ -356,6 +360,9 @@ export default function TasksPage() {
 
   const { data: agents } = useAgents();
   const { data: schedules } = useScheduledTasks();
+  const { data: users } = useUsers();
+  const { userId: currentUserId, state: currentUserState } = useCurrentUser();
+  const { supported: requesterFacetSupported } = useFeatureGate("1.127.0");
   const agentMapRef = useRef(new Map<string, string>());
   useMemo(() => {
     const m = new Map<string, string>();
@@ -365,6 +372,10 @@ export default function TasksPage() {
     agentMapRef.current = m;
   }, [agents]);
 
+  // "me" resolves client-side to the current identity's user id before it
+  // hits the API — the server only understands an exact user id or the
+  // `none` sentinel (IS NULL). If identity isn't ready yet, "me" sends
+  // nothing rather than an empty/invalid id.
   const filters = useMemo(() => {
     const f: {
       status?: string;
@@ -372,6 +383,7 @@ export default function TasksPage() {
       scheduleId?: string;
       search?: string;
       includeHeartbeat?: boolean;
+      requestedByUserId?: string;
       limit: number;
       offset: number;
     } = {
@@ -383,12 +395,26 @@ export default function TasksPage() {
     if (scheduleFilter !== "all") f.scheduleId = scheduleFilter;
     if (searchParam) f.search = searchParam;
     if (includeHeartbeat) f.includeHeartbeat = true;
+    if (requesterFilter === "me") {
+      if (currentUserId) f.requestedByUserId = currentUserId;
+    } else if (requesterFilter !== "all") {
+      f.requestedByUserId = requesterFilter;
+    }
     return f;
-  }, [statusFilter, agentFilter, scheduleFilter, searchParam, includeHeartbeat, page, pageSize]);
+  }, [
+    statusFilter,
+    agentFilter,
+    scheduleFilter,
+    requesterFilter,
+    currentUserId,
+    searchParam,
+    includeHeartbeat,
+    page,
+    pageSize,
+  ]);
 
   const { data: tasksData, isLoading } = useTasks(filters);
   const createTask = useCreateTask();
-  const { userId: currentUserId } = useCurrentUser();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogInitialValues, setDialogInitialValues] = useState<Partial<TaskFormData> | undefined>(
     undefined,
@@ -464,6 +490,7 @@ export default function TasksPage() {
     statusFilter !== "all" ||
     agentFilter !== "all" ||
     scheduleFilter !== "all" ||
+    requesterFilter !== "all" ||
     searchParam !== "" ||
     includeHeartbeat ||
     page !== 0;
@@ -551,6 +578,27 @@ export default function TasksPage() {
             })),
           ]}
         />
+        {requesterFacetSupported && (
+          <SearchableSelect
+            value={requesterFilter}
+            onChange={(v) => setParam("requester", v)}
+            triggerClassName="w-[200px]"
+            placeholder="Requested by"
+            searchPlaceholder="Search requesters…"
+            options={[
+              { value: "all", label: "All requesters" },
+              ...(currentUserState === "ready" && currentUserId
+                ? [{ value: "me", label: "Me" }]
+                : []),
+              { value: "none", label: "Unattributed" },
+              ...(users ?? []).map((u) => ({
+                value: u.id,
+                label: u.name?.trim() || u.email?.trim() || u.id,
+                hint: u.role,
+              })),
+            ]}
+          />
+        )}
         <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none">
           <Switch
             size="sm"

--- a/openapi.json
+++ b/openapi.json
@@ -15724,6 +15724,15 @@
           {
             "schema": {
               "type": "string",
+              "minLength": 1
+            },
+            "required": false,
+            "name": "requestedByUserId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "enum": [
                 "lastUpdatedAt",
                 "createdAt"

--- a/src/be/db.ts
+++ b/src/be/db.ts
@@ -2217,6 +2217,8 @@ export interface TaskFilters {
   createdBefore?: string;
   /** Only return tasks requested by this canonical user. NULL rows are excluded. */
   requestedByUserId?: string;
+  /** When set, restrict to rows where `requestedByUserId` IS NULL. Takes priority over `requestedByUserId`. */
+  requestedByUserIdIsNull?: boolean;
   /** Sort list rows for either table freshness or timeline paging. */
   orderBy?: "lastUpdatedAt" | "createdAt";
   limit?: number;
@@ -2315,7 +2317,9 @@ export function getAllTasks(
     params.push(filters.createdBefore);
   }
 
-  if (filters?.requestedByUserId) {
+  if (filters?.requestedByUserIdIsNull) {
+    conditions.push("requestedByUserId IS NULL");
+  } else if (filters?.requestedByUserId) {
     conditions.push("requestedByUserId = ?");
     params.push(filters.requestedByUserId);
   }
@@ -2449,7 +2453,9 @@ export function getTasksCount(filters?: Omit<TaskFilters, "limit" | "readyOnly">
     params.push(filters.createdBefore);
   }
 
-  if (filters?.requestedByUserId) {
+  if (filters?.requestedByUserIdIsNull) {
+    conditions.push("requestedByUserId IS NULL");
+  } else if (filters?.requestedByUserId) {
     conditions.push("requestedByUserId = ?");
     params.push(filters.requestedByUserId);
   }

--- a/src/http/tasks.ts
+++ b/src/http/tasks.ts
@@ -89,6 +89,12 @@ const listTasks = route({
     createdBefore: z.string().datetime().optional(),
     /** Comma-separated source filter (e.g. `ui,slack`). Omit to include all. */
     source: z.string().optional(),
+    /**
+     * When present, restrict results to tasks where `agent_tasks.requestedByUserId`
+     * equals this value. The sentinel `none` matches rows where it IS NULL
+     * instead. Omit to return every task regardless of requester.
+     */
+    requestedByUserId: z.string().min(1).optional(),
     /** `createdAt` enables stable time-axis paging; default preserves table freshness ordering. */
     orderBy: z.enum(["lastUpdatedAt", "createdAt"]).optional(),
     limit: z.coerce.number().int().optional(),
@@ -553,6 +559,11 @@ export async function handleTasks(
       createdAfter: parsed.query.createdAfter || undefined,
       createdBefore: parsed.query.createdBefore || undefined,
       source,
+      requestedByUserId:
+        parsed.query.requestedByUserId && parsed.query.requestedByUserId !== "none"
+          ? parsed.query.requestedByUserId
+          : undefined,
+      requestedByUserIdIsNull: parsed.query.requestedByUserId === "none" || undefined,
       orderBy: parsed.query.orderBy,
       limit: parsed.query.limit,
       offset: parsed.query.offset,

--- a/src/tests/tasks-requested-by-filter.test.ts
+++ b/src/tests/tasks-requested-by-filter.test.ts
@@ -1,6 +1,12 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { unlink } from "node:fs/promises";
 import {
+  createServer as createHttpServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import {
   closeDb,
   createAgent,
   createTaskExtended,
@@ -9,6 +15,9 @@ import {
   getTasksCount,
   initDb,
 } from "../be/db";
+import { handleCore } from "../http/core";
+import { handleTasks } from "../http/tasks";
+import { getPathSegments, parseQueryParams } from "../http/utils";
 
 const TEST_DB_PATH = "./test-tasks-requested-by-filter.sqlite";
 
@@ -75,5 +84,128 @@ describe("getAllTasks / getTasksCount requestedByUserId filter", () => {
     expect(getTasksCount({ requestedByUserIdIsNull: true, includeHeartbeat: true })).toBe(
       nullList.length,
     );
+  });
+});
+
+// Route-level coverage for the HTTP handler wiring — the block above only
+// exercises `getAllTasks`/`getTasksCount` directly, so it never proves the
+// `GET /api/tasks` handler actually translates the `?requestedByUserId=none`
+// sentinel into `requestedByUserIdIsNull`, or that the omitted-param path
+// stays backwards compatible.
+const ROUTE_TEST_DB_PATH = "./test-tasks-requested-by-filter-route.sqlite";
+const ROUTE_API_KEY = "test-tasks-requested-by-filter-route";
+
+async function removeDbFiles(path: string): Promise<void> {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      await unlink(path + suffix);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+}
+
+async function listen(server: Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const addr = server.address();
+  if (!addr || typeof addr === "string") throw new Error("no port");
+  return addr.port;
+}
+
+function createTestServer(apiKey: string): Server {
+  return createHttpServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const myAgentId = req.headers["x-agent-id"] as string | undefined;
+    const handled = await handleCore(req, res, myAgentId, apiKey);
+    if (handled) return;
+    const pathSegments = getPathSegments(req.url || "");
+    const queryParams = parseQueryParams(req.url || "");
+    const ok = await handleTasks(req, res, pathSegments, queryParams, myAgentId);
+    if (!ok) {
+      res.writeHead(404);
+      res.end("Not Found");
+    }
+  });
+}
+
+describe("GET /api/tasks — requestedByUserId route wiring", () => {
+  let server: Server;
+  let port: number;
+  let routeAgentId: string;
+  let routeUserId: string;
+
+  beforeAll(async () => {
+    await removeDbFiles(ROUTE_TEST_DB_PATH);
+    initDb(ROUTE_TEST_DB_PATH);
+    routeAgentId = createAgent({
+      name: "route-requested-by-filter-agent",
+      isLead: false,
+      status: "idle",
+    }).id;
+    routeUserId = createUser({ name: "Route User", email: "route-user@example.com" }).id;
+    server = createTestServer(ROUTE_API_KEY);
+    port = await listen(server);
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    closeDb();
+    await removeDbFiles(ROUTE_TEST_DB_PATH);
+  });
+
+  function listTasks(query: string): Promise<Response> {
+    return fetch(`http://localhost:${port}/api/tasks?includeHeartbeat=true${query}`, {
+      headers: {
+        Authorization: `Bearer ${ROUTE_API_KEY}`,
+        "X-Agent-ID": routeAgentId,
+      },
+    });
+  }
+
+  test("omitted param returns all rows (attributed and unattributed)", async () => {
+    const attributed = createTaskExtended("route test — attributed", {
+      agentId: routeAgentId,
+      requestedByUserId: routeUserId,
+    });
+    const unattributed = createTaskExtended("route test — unattributed", {
+      agentId: routeAgentId,
+    });
+
+    const res = await listTasks("");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { tasks: { id: string }[]; total: number };
+    const ids = body.tasks.map((t) => t.id);
+    expect(ids).toContain(attributed.id);
+    expect(ids).toContain(unattributed.id);
+  });
+
+  test("requestedByUserId=none returns only NULL rows", async () => {
+    const attributed = createTaskExtended("route test — attributed for none-filter", {
+      agentId: routeAgentId,
+      requestedByUserId: routeUserId,
+    });
+    const unattributed = createTaskExtended("route test — unattributed for none-filter", {
+      agentId: routeAgentId,
+    });
+
+    const res = await listTasks("&requestedByUserId=none");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { tasks: { id: string; requestedByUserId?: string }[] };
+    const ids = body.tasks.map((t) => t.id);
+    expect(ids).toContain(unattributed.id);
+    expect(ids).not.toContain(attributed.id);
+    expect(body.tasks.every((t) => !t.requestedByUserId)).toBe(true);
+  });
+
+  test("requestedByUserId=<unknown id> returns an empty list and zero total", async () => {
+    createTaskExtended("route test — attributed for unknown-id filter", {
+      agentId: routeAgentId,
+      requestedByUserId: routeUserId,
+    });
+
+    const res = await listTasks("&requestedByUserId=00000000-0000-4000-8000-000000000000");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { tasks: unknown[]; total: number };
+    expect(body.tasks).toEqual([]);
+    expect(body.total).toBe(0);
   });
 });

--- a/src/tests/tasks-requested-by-filter.test.ts
+++ b/src/tests/tasks-requested-by-filter.test.ts
@@ -1,0 +1,79 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { unlink } from "node:fs/promises";
+import {
+  closeDb,
+  createAgent,
+  createTaskExtended,
+  createUser,
+  getAllTasks,
+  getTasksCount,
+  initDb,
+} from "../be/db";
+
+const TEST_DB_PATH = "./test-tasks-requested-by-filter.sqlite";
+
+let agentId: string;
+let userAId: string;
+let userBId: string;
+
+describe("getAllTasks / getTasksCount requestedByUserId filter", () => {
+  beforeAll(async () => {
+    for (const suffix of ["", "-wal", "-shm"]) {
+      try {
+        await unlink(`${TEST_DB_PATH}${suffix}`);
+      } catch {}
+    }
+    initDb(TEST_DB_PATH);
+    agentId = createAgent({
+      id: "requested-by-filter-agent",
+      name: "Requested By Filter Agent",
+      isLead: false,
+      status: "idle",
+    }).id;
+    userAId = createUser({ name: "User A", email: "user-a@example.com" }).id;
+    userBId = createUser({ name: "User B", email: "user-b@example.com" }).id;
+  });
+
+  afterAll(async () => {
+    closeDb();
+    for (const suffix of ["", "-wal", "-shm"]) {
+      try {
+        await unlink(`${TEST_DB_PATH}${suffix}`);
+      } catch {}
+    }
+  });
+
+  test("requestedByUserId=<id> filters to that requester's tasks only, list and count agree", () => {
+    const taskA = createTaskExtended("task for user A", { agentId, requestedByUserId: userAId });
+    const taskB = createTaskExtended("task for user B", { agentId, requestedByUserId: userBId });
+    const taskUnattributed = createTaskExtended("task with no requester", { agentId });
+
+    const listForA = getAllTasks({ requestedByUserId: userAId, includeHeartbeat: true });
+    const ids = listForA.map((t) => t.id);
+    expect(ids).toContain(taskA.id);
+    expect(ids).not.toContain(taskB.id);
+    expect(ids).not.toContain(taskUnattributed.id);
+
+    expect(getTasksCount({ requestedByUserId: userAId, includeHeartbeat: true })).toBe(
+      listForA.length,
+    );
+  });
+
+  test("requestedByUserIdIsNull returns only unattributed rows, list and count agree", () => {
+    const taskA = createTaskExtended("second task for user A", {
+      agentId,
+      requestedByUserId: userAId,
+    });
+    const taskUnattributed = createTaskExtended("second task with no requester", { agentId });
+
+    const nullList = getAllTasks({ requestedByUserIdIsNull: true, includeHeartbeat: true });
+    const ids = nullList.map((t) => t.id);
+    expect(ids).toContain(taskUnattributed.id);
+    expect(ids).not.toContain(taskA.id);
+    expect(nullList.every((t) => !t.requestedByUserId)).toBe(true);
+
+    expect(getTasksCount({ requestedByUserIdIsNull: true, includeHeartbeat: true })).toBe(
+      nullList.length,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a single-select "Requested by" facet to the Tasks page filter bar, plus the matching `requestedByUserId` query parameter on `GET /api/tasks` (sentinel `none` maps to `IS NULL`). This is Option C from the brainstorm — recommended and approved by Daniel.

## Planning artifacts

- Research / brainstorm: `thoughts/6557a439-15b8-4c55-a639-638626f4983e/research/2026-08-03-requested-by-filter-brainstorm.md`
- Implementation plan: `thoughts/d454d1a5-4df9-49bd-8a89-e58d6a657dc3/plans/2026-08-03-requested-by-filter-option-c.md`

## What changed

- `src/http/tasks.ts` — `requestedByUserId` query param; `none` sentinel maps to an `IS NULL` filter.
- `src/be/db.ts` — `getAllTasks` and `getTasksCount` both gained the `IS NULL` branch alongside the existing equality branch, so list and count paginate consistently.
- `openapi.json` — regenerated (`bun run docs:openapi`).
- `apps/ui/src/api/client.ts`, `apps/ui/src/api/hooks/use-tasks.ts` — plumb the new filter through `fetchTasks`/`TaskFilters` (incl. the optimistic-cache matcher).
- `apps/ui/src/pages/tasks/page.tsx` — new `SearchableSelect` facet, URL param `requester`. Options: **All requesters** (default) / **Me** (pinned, only when identity is `ready`) / **Unattributed** (`none`) / one per `useUsers()` user. Feature-gated with `useFeatureGate("1.127.0")` — same mechanism as the 1.81.0 gate on the existing "Requested by" column, so an older server degrades cleanly.
- `src/tests/tasks-requested-by-filter.test.ts` — new: exact-id filtering excludes other requesters and unattributed rows; the `none` sentinel returns only unattributed rows; both assert `getTasksCount` agrees with `getAllTasks`.

## Constraints (Daniel's decisions — not re-opened)

- **Never defaults on.** ~47% of live rows have no requester; a default-on filter would hide most of the board.
- **Single-select only.** No multi-select component; the param stays CSV-extensible for a possible follow-up.
- **No remembered "Me" default.** URL parameter only, no localStorage persistence.
- **Not a security boundary.** UI identity is a localStorage pick and the server sees a shared operator key — this is a convenience filter, not RBAC. No RBAC change, including the unused `task.read.own` verb.
- Workflow-task requester attribution and `src/workflows/engine.ts` are explicitly out of scope.

## Test plan

- [x] `bun run lint`, `bun run tsc:check`, `bash scripts/check-db-boundary.sh`, `bun run check:dep-graph` — all clean.
- [x] `cd apps/ui && bun install --frozen-lockfile && bun run lint && bunx tsc -b` — clean.
- [x] New backend test file passes: `bun run test:root -- src/tests/tasks-requested-by-filter.test.ts` (2/2).
- [x] Full-suite isolation check on every test file that exercises the touched DB functions (`list-endpoint-slimming`, `pagination-metrics`, `sessions`, `task-search-filter`, `tasks-requested-by-filter`): 23/23 pass clean. (Two full `bun run test:root` runs on this branch showed differing failure counts — 48/4 vs 39/1 — in unrelated subsystems (codex credentials, internal-ai, socket-mode), consistent with this repo's documented full-suite-flakiness pattern; none of the failures touch files this PR changes.)
- [x] Manual QA via `qa-use` against a local API + UI dev server (both with `SLACK_DISABLE`/`LINEAR_DISABLE`/etc. set — the container's ambient env carries live Slack/Linear credentials, so this was run carefully with all integrations disabled and a throwaway local-only API key). Screenshots:
<img width="1200" height="800" alt="04-cleared-filters" src="https://github.com/user-attachments/assets/a188a879-70e8-43c1-8a60-39c8397a3cd5" />
<img width="1200" height="800" alt="03-filtered-result" src="https://github.com/user-attachments/assets/401abf9a-0061-4b57-afa8-a77099f767cf" />
<img width="1200" height="800" alt="02-facet-open" src="https://github.com/user-attachments/assets/03788ddc-895b-4ab9-be8b-dbba7488583b" />
<img width="1200" height="800" alt="01-facet-closed" src="https://github.com/user-attachments/assets/879c16ff-dd4f-49ff-98af-c06550fbd28e" />
