### PR TITLE
feat(workflows): foreach node — fan-out agent-task children with parent join

### DIFF
--- a/apps/ui/src/api/types.ts
+++ b/apps/ui/src/api/types.ts
@@ -1061,6 +1061,7 @@ export type WorkflowRunStepStatus =
   | "waiting"
   | "completed"
   | "failed"
+  | "cancelled"
   | "skipped";
 
 export interface WorkflowRunStep {

--- a/apps/ui/src/components/shared/workflow-node-shell.tsx
+++ b/apps/ui/src/components/shared/workflow-node-shell.tsx
@@ -70,7 +70,10 @@ export function WorkflowNodeShell({
       className={cn(
         "bg-card border-2 rounded-lg shadow-sm px-3 py-2 min-w-[240px] max-w-[280px]",
         borderClass,
-        selected && "ring-2 ring-status-active ring-offset-1 ring-offset-background",
+        // Run-view borders already carry status colors, so selection needs its own layer: a
+        // thick offset primary ring plus a soft glow reads as "selected" against any border.
+        selected &&
+          "ring-[3px] ring-primary ring-offset-2 ring-offset-background shadow-lg shadow-primary/40",
         className,
       )}
     >

--- a/apps/ui/src/components/workflows/action-node.tsx
+++ b/apps/ui/src/components/workflows/action-node.tsx
@@ -2,9 +2,11 @@ import type { NodeProps } from "@xyflow/react";
 import {
   Bell,
   Bot,
+  Library,
   ListPlus,
   type LucideIcon,
   MessageCircle,
+  Repeat,
   Share2,
   Terminal,
   UserCheck,
@@ -73,6 +75,20 @@ const nodeStyleMap: Record<string, NodeStyle> = {
     handle: "!bg-action-delegate-to-agent",
     icon: Share2,
   },
+  foreach: {
+    border: "border-action-foreach/50",
+    bg: "bg-action-foreach/10",
+    text: "text-action-foreach",
+    handle: "!bg-action-foreach",
+    icon: Repeat,
+  },
+  "swarm-script": {
+    border: "border-action-swarm-script/50",
+    bg: "bg-action-swarm-script/10",
+    text: "text-action-swarm-script",
+    handle: "!bg-action-swarm-script",
+    icon: Library,
+  },
 };
 
 const defaultStyle: NodeStyle = {
@@ -83,7 +99,7 @@ const defaultStyle: NodeStyle = {
   icon: Zap,
 };
 
-const ASYNC_TYPES = new Set(["agent-task", "create-task", "delegate-to-agent"]);
+const ASYNC_TYPES = new Set(["agent-task", "create-task", "delegate-to-agent", "foreach"]);
 
 export function ActionNode({ data }: NodeProps) {
   const d = data as unknown as FlowNodeData;

--- a/apps/ui/src/components/workflows/foreach-step-group.tsx
+++ b/apps/ui/src/components/workflows/foreach-step-group.tsx
@@ -1,0 +1,134 @@
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+import type { WorkflowNode, WorkflowRunStep } from "@/api/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { effectiveChildStatus } from "@/components/workflows/graph-utils";
+import { StepCard } from "@/components/workflows/step-card";
+
+/** Children rendered before the "Show all N items" escape hatch kicks in. */
+const CHILD_PAGE_SIZE = 50;
+
+export interface ForeachStepGroupProps {
+  parent: WorkflowRunStep;
+  childSteps: WorkflowRunStep[];
+  workflowNodes?: WorkflowNode[];
+  selectedNodeId: string | null;
+  isOpen: boolean;
+  onToggleOpen: () => void;
+  expandedStepIds: ReadonlySet<string>;
+  onStepClick: (nodeId: string) => void;
+  onToggleStepExpand: (nodeId: string) => void;
+  registerStepRef: (nodeId: string, el: HTMLDivElement | null) => void;
+}
+
+/** Aggregate counts across a `foreach`'s children, using the same failure semantics as the graph. */
+export function foreachChildSummary(childSteps: WorkflowRunStep[]): {
+  total: number;
+  ok: number;
+  failed: number;
+  hasPending: boolean;
+} {
+  let ok = 0;
+  let failed = 0;
+  let hasPending = false;
+  for (const step of childSteps) {
+    const status = effectiveChildStatus(step);
+    if (status === "completed") ok++;
+    else if (status === "failed") failed++;
+    if (status === "pending" || status === "running" || status === "waiting") hasPending = true;
+  }
+  return { total: childSteps.length, ok, failed, hasPending };
+}
+
+/** Whether a group starts open: anything failed or still in flight deserves attention. */
+export function foreachDefaultOpen(childSteps: WorkflowRunStep[]): boolean {
+  const { failed, hasPending } = foreachChildSummary(childSteps);
+  return failed > 0 || hasPending;
+}
+
+/**
+ * A `foreach` parent step plus its synthetic children, rendered as a nested accordion: the parent
+ * card keeps its own details chevron (level 2) while the caret row below toggles the children list.
+ */
+export function ForeachStepGroup({
+  parent,
+  childSteps,
+  workflowNodes,
+  selectedNodeId,
+  isOpen,
+  onToggleOpen,
+  expandedStepIds,
+  onStepClick,
+  onToggleStepExpand,
+  registerStepRef,
+}: ForeachStepGroupProps) {
+  const [showAll, setShowAll] = useState(false);
+  const summary = foreachChildSummary(childSteps);
+  const visibleChildren = showAll ? childSteps : childSteps.slice(0, CHILD_PAGE_SIZE);
+  const hiddenCount = childSteps.length - visibleChildren.length;
+
+  return (
+    <div className="space-y-1.5">
+      <StepCard
+        step={parent}
+        workflowNodes={workflowNodes}
+        isSelected={selectedNodeId === parent.nodeId}
+        isExpanded={expandedStepIds.has(parent.nodeId)}
+        onClick={() => onStepClick(parent.nodeId)}
+        onToggleExpand={() => onToggleStepExpand(parent.nodeId)}
+        ref={(el) => registerStepRef(parent.nodeId, el)}
+      />
+
+      <div className="pl-3 space-y-1.5">
+        <button
+          type="button"
+          onClick={onToggleOpen}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          title={isOpen ? "Hide items" : "Show items"}
+        >
+          {isOpen ? (
+            <ChevronDown className="h-3 w-3 shrink-0" />
+          ) : (
+            <ChevronRight className="h-3 w-3 shrink-0" />
+          )}
+          <Badge variant="outline" size="tag">
+            {summary.total} item{summary.total !== 1 ? "s" : ""}
+          </Badge>
+          <span>&middot; {summary.ok} ok</span>
+          {summary.failed > 0 && (
+            <span className="text-status-error">&middot; {summary.failed} failed</span>
+          )}
+        </button>
+
+        {isOpen && (
+          <div className="pl-3 border-l border-border/50 space-y-1.5">
+            {visibleChildren.map((step) => (
+              <StepCard
+                key={step.id}
+                step={step}
+                workflowNodes={workflowNodes}
+                isSelected={selectedNodeId === step.nodeId || selectedNodeId === parent.nodeId}
+                isExpanded={expandedStepIds.has(step.nodeId)}
+                onClick={() => onStepClick(step.nodeId)}
+                onToggleExpand={() => onToggleStepExpand(step.nodeId)}
+                inGroup
+                ref={(el) => registerStepRef(step.nodeId, el)}
+              />
+            ))}
+            {hiddenCount > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-1.5 text-xs text-muted-foreground"
+                onClick={() => setShowAll(true)}
+              >
+                Show all {childSteps.length} items
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/workflows/graph-utils.ts
+++ b/apps/ui/src/components/workflows/graph-utils.ts
@@ -58,11 +58,12 @@ function aggregateStepStatus(statuses: WorkflowRunStepStatus[]): WorkflowRunStep
 
 /**
  * A `foreach` child that failed under `onNodeFailure: 'continue'` is persisted as `completed` with
- * a `[FAILED: …]` task output — count it as failed when aggregating onto the parent node.
+ * the failure reason on `step.error` — count it as failed when aggregating onto the parent node.
+ * (Classification uses that explicit metadata, not the `[FAILED: …]` output text, which a
+ * successful child could legitimately produce.)
  */
 function effectiveChildStatus(step: WorkflowRunStep): WorkflowRunStepStatus {
-  const taskOutput = (step.output as { taskOutput?: unknown } | null | undefined)?.taskOutput;
-  if (typeof taskOutput === "string" && taskOutput.startsWith("[FAILED:")) return "failed";
+  if (step.status === "completed" && step.error) return "failed";
   return step.status;
 }
 

--- a/apps/ui/src/components/workflows/graph-utils.ts
+++ b/apps/ui/src/components/workflows/graph-utils.ts
@@ -8,7 +8,7 @@ import type {
   WorkflowRunStep,
   WorkflowRunStepStatus,
 } from "@/api/types";
-import { parseSyntheticStepId } from "@/lib/synthetic-step-id";
+import { foreachParentIds, parseSyntheticStepId } from "@/lib/synthetic-step-id";
 
 const CONDITION_TYPES = new Set(["property-match", "code-match", "validate", "raw-llm"]);
 export type NodeCategory = "triggerNode" | "conditionNode" | "actionNode";
@@ -75,9 +75,10 @@ export function toReactFlowGraph(
   // of their own, so they aggregate by precedence onto their parent node instead.
   const statusMap = new Map<string, WorkflowRunStepStatus>();
   if (steps) {
+    const foreachIds = foreachParentIds(definition.nodes);
     const childStatuses = new Map<string, WorkflowRunStepStatus[]>();
     for (const step of steps) {
-      const { parentNodeId, itemKey } = parseSyntheticStepId(step.nodeId);
+      const { parentNodeId, itemKey } = parseSyntheticStepId(step.nodeId, foreachIds);
       if (itemKey === null) {
         statusMap.set(step.nodeId, step.status);
         continue;

--- a/apps/ui/src/components/workflows/graph-utils.ts
+++ b/apps/ui/src/components/workflows/graph-utils.ts
@@ -62,7 +62,7 @@ function aggregateStepStatus(statuses: WorkflowRunStepStatus[]): WorkflowRunStep
  * (Classification uses that explicit metadata, not the `[FAILED: …]` output text, which a
  * successful child could legitimately produce.)
  */
-function effectiveChildStatus(step: WorkflowRunStep): WorkflowRunStepStatus {
+export function effectiveChildStatus(step: WorkflowRunStep): WorkflowRunStepStatus {
   if (step.status === "completed" && step.error) return "failed";
   return step.status;
 }

--- a/apps/ui/src/components/workflows/graph-utils.ts
+++ b/apps/ui/src/components/workflows/graph-utils.ts
@@ -8,6 +8,7 @@ import type {
   WorkflowRunStep,
   WorkflowRunStepStatus,
 } from "@/api/types";
+import { parseSyntheticStepId } from "@/lib/synthetic-step-id";
 
 const CONDITION_TYPES = new Set(["property-match", "code-match", "validate", "raw-llm"]);
 export type NodeCategory = "triggerNode" | "conditionNode" | "actionNode";
@@ -33,14 +34,66 @@ export interface FlowNodeData {
   [key: string]: unknown;
 }
 
+/**
+ * Order in which the statuses of a `foreach` node's synthetic child steps collapse into the single
+ * status shown on the parent graph node — the most actionable one wins (any running → running,
+ * then any failed → failed, …, all completed → completed).
+ */
+const STATUS_PRECEDENCE: WorkflowRunStepStatus[] = [
+  "running",
+  "failed",
+  "cancelled",
+  "waiting",
+  "pending",
+  "completed",
+  "skipped",
+];
+
+function aggregateStepStatus(statuses: WorkflowRunStepStatus[]): WorkflowRunStepStatus {
+  for (const candidate of STATUS_PRECEDENCE) {
+    if (statuses.includes(candidate)) return candidate;
+  }
+  return statuses[0];
+}
+
+/**
+ * A `foreach` child that failed under `onNodeFailure: 'continue'` is persisted as `completed` with
+ * a `[FAILED: …]` task output — count it as failed when aggregating onto the parent node.
+ */
+function effectiveChildStatus(step: WorkflowRunStep): WorkflowRunStepStatus {
+  const taskOutput = (step.output as { taskOutput?: unknown } | null | undefined)?.taskOutput;
+  if (typeof taskOutput === "string" && taskOutput.startsWith("[FAILED:")) return "failed";
+  return step.status;
+}
+
 export function toReactFlowGraph(
   definition: WorkflowDefinition,
   steps?: WorkflowRunStep[],
 ): { nodes: Node<FlowNodeData>[]; edges: Edge[] } {
-  const stepMap = new Map<string, WorkflowRunStep>();
+  // Steps that own a node keep latest-wins semantics (a loop node re-executes, and the graph shows
+  // the current iteration). Synthetic `foreach` children (`<parentNodeId>#<itemKey>`) have no node
+  // of their own, so they aggregate by precedence onto their parent node instead.
+  const statusMap = new Map<string, WorkflowRunStepStatus>();
   if (steps) {
+    const childStatuses = new Map<string, WorkflowRunStepStatus[]>();
     for (const step of steps) {
-      stepMap.set(step.nodeId, step);
+      const { parentNodeId, itemKey } = parseSyntheticStepId(step.nodeId);
+      if (itemKey === null) {
+        statusMap.set(step.nodeId, step.status);
+        continue;
+      }
+      const statuses = childStatuses.get(parentNodeId);
+      if (statuses) {
+        statuses.push(effectiveChildStatus(step));
+      } else {
+        childStatuses.set(parentNodeId, [effectiveChildStatus(step)]);
+      }
+    }
+    for (const [nodeId, statuses] of childStatuses) {
+      // A parent-level failure (the fan-out or the join itself) outranks the children's aggregate.
+      const own = statusMap.get(nodeId);
+      const withOwn = own === "failed" || own === "cancelled" ? [own, ...statuses] : statuses;
+      statusMap.set(nodeId, aggregateStepStatus(withOwn));
     }
   }
 
@@ -54,7 +107,6 @@ export function toReactFlowGraph(
   }
 
   const nodes: Node<FlowNodeData>[] = definition.nodes.map((node) => {
-    const step = stepMap.get(node.id);
     const ports = outputPortsMap.get(node.id);
     const outputPorts = ports ? Array.from(ports) : [];
     return {
@@ -65,16 +117,15 @@ export function toReactFlowGraph(
         label: getNodeLabel(node),
         nodeType: node.type,
         config: node.config,
-        stepStatus: step?.status,
+        stepStatus: statusMap.get(node.id),
         outputPorts,
       },
     };
   });
 
   const edges: Edge[] = (definition.edges ?? []).map((edge: WorkflowEdge) => {
-    const sourceStep = stepMap.get(edge.source);
-    const targetStep = stepMap.get(edge.target);
-    const bothCompleted = sourceStep?.status === "completed" && targetStep?.status === "completed";
+    const bothCompleted =
+      statusMap.get(edge.source) === "completed" && statusMap.get(edge.target) === "completed";
     return {
       id: edge.id,
       source: edge.source,

--- a/apps/ui/src/components/workflows/node-styles.ts
+++ b/apps/ui/src/components/workflows/node-styles.ts
@@ -6,5 +6,6 @@ export const statusBorderColor: Record<WorkflowRunStepStatus, string> = {
   waiting: "border-status-pending",
   completed: "border-status-success",
   failed: "border-status-error",
+  cancelled: "border-status-neutral",
   skipped: "border-status-neutral/40",
 };

--- a/apps/ui/src/components/workflows/step-card.tsx
+++ b/apps/ui/src/components/workflows/step-card.tsx
@@ -93,7 +93,10 @@ export const StepCard = forwardRef<HTMLDivElement, StepCardProps>(
         onClick={onClick}
         className={cn(
           "rounded-md border bg-background transition-colors cursor-pointer",
-          isSelected && "border-l-2 border-l-status-active",
+          // Same selection language as the graph nodes: a primary ring + soft glow
+          // (scaled down for list density) instead of a barely-visible left border.
+          isSelected &&
+            "ring-2 ring-primary ring-offset-1 ring-offset-background shadow-md shadow-primary/30",
         )}
       >
         {/* Header row - always visible */}

--- a/apps/ui/src/components/workflows/step-card.tsx
+++ b/apps/ui/src/components/workflows/step-card.tsx
@@ -15,6 +15,7 @@ import { StatusBadge } from "@/components/shared/status-badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { JsonTree } from "@/components/workflows/json-tree";
+import { parseSyntheticStepId } from "@/lib/synthetic-step-id";
 import { cn, formatElapsed, formatSmartTime } from "@/lib/utils";
 
 export interface StepCardProps {
@@ -54,8 +55,11 @@ function parseDiagnostics(raw: string | undefined): { unresolvedTokens?: string[
 
 export const StepCard = forwardRef<HTMLDivElement, StepCardProps>(
   ({ step, workflowNodes, isSelected, isExpanded, onClick, onToggleExpand }, ref) => {
-    const node = workflowNodes?.find((n) => n.id === step.nodeId);
-    const label = node?.label || step.nodeId;
+    // `foreach` children carry synthetic `<parentNodeId>#<itemKey>` ids — the definition only holds
+    // the parent node, so label and config always resolve against the parent.
+    const { parentNodeId, itemKey } = parseSyntheticStepId(step.nodeId);
+    const node = workflowNodes?.find((n) => n.id === parentNodeId);
+    const label = node?.label || parentNodeId;
     const duration =
       step.startedAt && step.finishedAt ? formatElapsed(step.startedAt, step.finishedAt) : null;
 
@@ -74,6 +78,12 @@ export const StepCard = forwardRef<HTMLDivElement, StepCardProps>(
         {/* Header row - always visible */}
         <div className="w-full flex items-center gap-2 px-3 py-2">
           <span className="text-sm font-medium truncate">{label}</span>
+
+          {itemKey && (
+            <span className="text-xs text-muted-foreground font-mono truncate">
+              &middot; {itemKey}
+            </span>
+          )}
 
           <Badge variant="outline" size="tag" className="shrink-0">
             {step.nodeType}

--- a/apps/ui/src/components/workflows/step-card.tsx
+++ b/apps/ui/src/components/workflows/step-card.tsx
@@ -76,6 +76,17 @@ export const StepCard = forwardRef<HTMLDivElement, StepCardProps>(
     // matching the graph's classification and the group's ok/failed chip.
     const displayStatus = itemKey ? effectiveChildStatus(step) : step.status;
 
+    // Foreach children carry their zero-based iteration in step.input — badge them as
+    // `foreach #<iteration>` instead of the (always agent-task) executor type.
+    const iteration =
+      itemKey && typeof step.input === "object" && step.input !== null
+        ? (step.input as Record<string, unknown>).index
+        : undefined;
+    const typeBadge =
+      itemKey != null
+        ? `foreach ${typeof iteration === "number" ? `#${iteration}` : "item"}`
+        : step.nodeType;
+
     return (
       <div
         ref={ref}
@@ -102,7 +113,7 @@ export const StepCard = forwardRef<HTMLDivElement, StepCardProps>(
           )}
 
           <Badge variant="outline" size="tag" className="shrink-0">
-            {step.nodeType}
+            {typeBadge}
           </Badge>
 
           {step.nextPort && step.nextPort !== "default" && (

--- a/apps/ui/src/components/workflows/step-card.tsx
+++ b/apps/ui/src/components/workflows/step-card.tsx
@@ -14,6 +14,7 @@ import { AgentLink } from "@/components/shared/agent-link";
 import { StatusBadge } from "@/components/shared/status-badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
+import { effectiveChildStatus } from "@/components/workflows/graph-utils";
 import { JsonTree } from "@/components/workflows/json-tree";
 import { foreachParentIds, parseSyntheticStepId } from "@/lib/synthetic-step-id";
 import { cn, formatElapsed, formatSmartTime } from "@/lib/utils";
@@ -25,6 +26,8 @@ export interface StepCardProps {
   isExpanded: boolean;
   onClick: () => void;
   onToggleExpand: () => void;
+  /** Rendered inside a `foreach` group — the parent label is already on the group header. */
+  inGroup?: boolean;
 }
 
 /** Format a byte count as a human-readable string (B, KB, MB). */
@@ -54,7 +57,7 @@ function parseDiagnostics(raw: string | undefined): { unresolvedTokens?: string[
 }
 
 export const StepCard = forwardRef<HTMLDivElement, StepCardProps>(
-  ({ step, workflowNodes, isSelected, isExpanded, onClick, onToggleExpand }, ref) => {
+  ({ step, workflowNodes, isSelected, isExpanded, onClick, onToggleExpand, inGroup }, ref) => {
     // `foreach` children carry synthetic `<parentNodeId>#<itemKey>` ids — the definition only holds
     // the parent node, so label and config always resolve against the parent.
     const { parentNodeId, itemKey } = parseSyntheticStepId(
@@ -69,6 +72,10 @@ export const StepCard = forwardRef<HTMLDivElement, StepCardProps>(
     const diagnostics = parseDiagnostics(step.diagnostics);
     const unresolvedTokens = diagnostics?.unresolvedTokens;
 
+    // An onNodeFailure:"continue" child completes WITH a persisted error — badge it as failed,
+    // matching the graph's classification and the group's ok/failed chip.
+    const displayStatus = itemKey ? effectiveChildStatus(step) : step.status;
+
     return (
       <div
         ref={ref}
@@ -80,12 +87,18 @@ export const StepCard = forwardRef<HTMLDivElement, StepCardProps>(
       >
         {/* Header row - always visible */}
         <div className="w-full flex items-center gap-2 px-3 py-2">
-          <span className="text-sm font-medium truncate">{label}</span>
+          {inGroup && itemKey ? (
+            <span className="text-sm font-medium font-mono truncate">{itemKey}</span>
+          ) : (
+            <>
+              <span className="text-sm font-medium truncate">{label}</span>
 
-          {itemKey && (
-            <span className="text-xs text-muted-foreground font-mono truncate">
-              &middot; {itemKey}
-            </span>
+              {itemKey && (
+                <span className="text-xs text-muted-foreground font-mono truncate">
+                  &middot; {itemKey}
+                </span>
+              )}
+            </>
           )}
 
           <Badge variant="outline" size="tag" className="shrink-0">
@@ -102,7 +115,7 @@ export const StepCard = forwardRef<HTMLDivElement, StepCardProps>(
             </Badge>
           )}
 
-          <StatusBadge status={step.status} className="shrink-0" />
+          <StatusBadge status={displayStatus} className="shrink-0" />
 
           <div className="ml-auto flex items-center gap-1.5 shrink-0">
             {duration && (

--- a/apps/ui/src/components/workflows/step-card.tsx
+++ b/apps/ui/src/components/workflows/step-card.tsx
@@ -15,7 +15,7 @@ import { StatusBadge } from "@/components/shared/status-badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { JsonTree } from "@/components/workflows/json-tree";
-import { parseSyntheticStepId } from "@/lib/synthetic-step-id";
+import { foreachParentIds, parseSyntheticStepId } from "@/lib/synthetic-step-id";
 import { cn, formatElapsed, formatSmartTime } from "@/lib/utils";
 
 export interface StepCardProps {
@@ -57,7 +57,10 @@ export const StepCard = forwardRef<HTMLDivElement, StepCardProps>(
   ({ step, workflowNodes, isSelected, isExpanded, onClick, onToggleExpand }, ref) => {
     // `foreach` children carry synthetic `<parentNodeId>#<itemKey>` ids — the definition only holds
     // the parent node, so label and config always resolve against the parent.
-    const { parentNodeId, itemKey } = parseSyntheticStepId(step.nodeId);
+    const { parentNodeId, itemKey } = parseSyntheticStepId(
+      step.nodeId,
+      foreachParentIds(workflowNodes),
+    );
     const node = workflowNodes?.find((n) => n.id === parentNodeId);
     const label = node?.label || parentNodeId;
     const duration =

--- a/apps/ui/src/components/workflows/step-card.tsx
+++ b/apps/ui/src/components/workflows/step-card.tsx
@@ -112,7 +112,15 @@ export const StepCard = forwardRef<HTMLDivElement, StepCardProps>(
             </>
           )}
 
-          <Badge variant="outline" size="tag" className="shrink-0">
+          <Badge
+            variant="outline"
+            size="tag"
+            className={cn(
+              "shrink-0",
+              (itemKey != null || step.nodeType === "foreach") &&
+                "border-action-foreach/40 text-action-foreach",
+            )}
+          >
             {typeBadge}
           </Badge>
 

--- a/apps/ui/src/components/workflows/workflow-graph.tsx
+++ b/apps/ui/src/components/workflows/workflow-graph.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import "@xyflow/react/dist/style.css";
 import type { WorkflowDefinition, WorkflowRunStep } from "@/api/types";
 import { useTheme } from "@/hooks/use-theme";
-import { parseSyntheticStepId } from "@/lib/synthetic-step-id";
+import { foreachParentIds, parseSyntheticStepId } from "@/lib/synthetic-step-id";
 import { cn } from "@/lib/utils";
 import { ActionNode } from "./action-node";
 import { ConditionNode } from "./condition-node";
@@ -36,7 +36,7 @@ export function WorkflowGraph({
     const graph = toReactFlowGraph(definition, steps);
     // A selected synthetic `foreach` child step highlights the parent node it fanned out from.
     const selectedParentNodeId = selectedNodeId
-      ? parseSyntheticStepId(selectedNodeId).parentNodeId
+      ? parseSyntheticStepId(selectedNodeId, foreachParentIds(definition.nodes)).parentNodeId
       : null;
     if (selectedParentNodeId) {
       for (const node of graph.nodes) {

--- a/apps/ui/src/components/workflows/workflow-graph.tsx
+++ b/apps/ui/src/components/workflows/workflow-graph.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import "@xyflow/react/dist/style.css";
 import type { WorkflowDefinition, WorkflowRunStep } from "@/api/types";
 import { useTheme } from "@/hooks/use-theme";
+import { parseSyntheticStepId } from "@/lib/synthetic-step-id";
 import { cn } from "@/lib/utils";
 import { ActionNode } from "./action-node";
 import { ConditionNode } from "./condition-node";
@@ -33,15 +34,19 @@ export function WorkflowGraph({
   const { theme } = useTheme();
   const { nodes, edges } = useMemo(() => {
     const graph = toReactFlowGraph(definition, steps);
-    if (selectedNodeId) {
+    // A selected synthetic `foreach` child step highlights the parent node it fanned out from.
+    const selectedParentNodeId = selectedNodeId
+      ? parseSyntheticStepId(selectedNodeId).parentNodeId
+      : null;
+    if (selectedParentNodeId) {
       for (const node of graph.nodes) {
-        if (node.id === selectedNodeId) {
+        if (node.id === selectedParentNodeId) {
           node.data = { ...node.data, selected: true };
         }
       }
       // Highlight adjacent edges with animated marching-ants style
       for (const edge of graph.edges) {
-        if (edge.source === selectedNodeId || edge.target === selectedNodeId) {
+        if (edge.source === selectedParentNodeId || edge.target === selectedParentNodeId) {
           edge.animated = true;
           edge.style = {
             ...edge.style,

--- a/apps/ui/src/lib/synthetic-step-id.ts
+++ b/apps/ui/src/lib/synthetic-step-id.ts
@@ -1,0 +1,17 @@
+/**
+ * `foreach` nodes fan out one child step per item, and those children carry synthetic node ids of
+ * the form `<parentNodeId>#<itemKey>` — ids that do not exist in the workflow definition. Node ids
+ * never contain `#`, so the split happens at the first one.
+ *
+ * Returns `itemKey: null` for a regular (non-synthetic) node id.
+ *
+ * Twin of the server-side `parseSyntheticNodeId` in `src/workflows/foreach-join.ts` — keep in sync.
+ */
+export function parseSyntheticStepId(nodeId: string): {
+  parentNodeId: string;
+  itemKey: string | null;
+} {
+  const separator = nodeId.indexOf("#");
+  if (separator === -1) return { parentNodeId: nodeId, itemKey: null };
+  return { parentNodeId: nodeId.slice(0, separator), itemKey: nodeId.slice(separator + 1) };
+}

--- a/apps/ui/src/lib/synthetic-step-id.ts
+++ b/apps/ui/src/lib/synthetic-step-id.ts
@@ -1,17 +1,31 @@
 /**
  * `foreach` nodes fan out one child step per item, and those children carry synthetic node ids of
- * the form `<parentNodeId>#<itemKey>` — ids that do not exist in the workflow definition. Node ids
- * never contain `#`, so the split happens at the first one.
+ * the form `<parentNodeId>#<itemKey>` — ids that do not exist in the workflow definition. New
+ * definitions reject `#` in node ids, but workflows created before that rule may legally contain
+ * it, so a step id is only treated as synthetic when its prefix names an actual `foreach` node.
  *
  * Returns `itemKey: null` for a regular (non-synthetic) node id.
  *
- * Twin of the server-side `parseSyntheticNodeId` in `src/workflows/foreach-join.ts` — keep in sync.
+ * Sibling of the server-side `parseSyntheticNodeId` in `src/workflows/foreach-join.ts`, whose
+ * callers all verify the parsed parent against the definition — keep the semantics in sync.
  */
-export function parseSyntheticStepId(nodeId: string): {
+export function parseSyntheticStepId(
+  nodeId: string,
+  foreachIds: ReadonlySet<string>,
+): {
   parentNodeId: string;
   itemKey: string | null;
 } {
   const separator = nodeId.indexOf("#");
   if (separator === -1) return { parentNodeId: nodeId, itemKey: null };
-  return { parentNodeId: nodeId.slice(0, separator), itemKey: nodeId.slice(separator + 1) };
+  const parentNodeId = nodeId.slice(0, separator);
+  if (!foreachIds.has(parentNodeId)) return { parentNodeId: nodeId, itemKey: null };
+  return { parentNodeId, itemKey: nodeId.slice(separator + 1) };
+}
+
+/** The set of `foreach` node ids in a definition — the only legal synthetic-step parents. */
+export function foreachParentIds(
+  nodes: ReadonlyArray<{ id: string; type: string }> | undefined,
+): Set<string> {
+  return new Set((nodes ?? []).filter((node) => node.type === "foreach").map((node) => node.id));
 }

--- a/apps/ui/src/pages/workflow-runs/[id]/page.tsx
+++ b/apps/ui/src/pages/workflow-runs/[id]/page.tsx
@@ -31,7 +31,7 @@ export default function WorkflowRunDetailPage() {
   const { data: workflow } = useWorkflow(run?.workflowId ?? "");
   const retryRun = useRetryWorkflowRun();
 
-  const { searchParams, setParam } = useUrlSearchState();
+  const { searchParams, setParam, setParams } = useUrlSearchState();
   const selectedNodeId = readStringParam(searchParams, "node") || null;
   const expandedStepsParam = readStringParam(searchParams, "steps");
   const expandedStepIds = useMemo(
@@ -153,9 +153,15 @@ export default function WorkflowRunDetailPage() {
 
   // When a graph node is clicked, expand and scroll to that step. A `foreach` node owns several
   // synthetic child steps (`<nodeId>#<itemKey>`) — expand all of them and scroll to the first.
+  // Clicking the already-selected node deselects it. NOTE: `node` and `steps` must go through ONE
+  // setParams call — two setSearchParams calls in the same tick both start from the same stale
+  // params, so the second silently drops the first's update.
   const handleGraphNodeClick = useCallback(
     (nodeId: string) => {
-      setSelectedNodeId(nodeId);
+      if (selectedNodeId === nodeId) {
+        setSelectedNodeId(null);
+        return;
+      }
       if (foreachIds.has(nodeId)) setGroupOpen(nodeId, true);
       const ownStepIds = steps
         .map((step) => step.nodeId)
@@ -166,22 +172,34 @@ export default function WorkflowRunDetailPage() {
       for (const stepNodeId of ownStepIds.length > 0 ? ownStepIds : [nodeId]) {
         next.add(stepNodeId);
       }
-      setExpandedSteps(next);
+      setParams({
+        node: nodeId,
+        steps: Array.from(next).filter(Boolean).join(","),
+      });
       // Scroll to the step card after a tick (to allow expansion to render)
       requestAnimationFrame(() => {
         const el = stepRefs.current.get(ownStepIds[0] ?? nodeId);
         el?.scrollIntoView({ behavior: "smooth", block: "nearest" });
       });
     },
-    [expandedStepIds, setExpandedSteps, setSelectedNodeId, setGroupOpen, steps, foreachIds],
+    [
+      expandedStepIds,
+      selectedNodeId,
+      setParams,
+      setSelectedNodeId,
+      setGroupOpen,
+      steps,
+      foreachIds,
+    ],
   );
 
-  // When a step card is clicked, highlight the node in the graph (don't toggle expand)
+  // When a step card is clicked, highlight the node in the graph (don't toggle expand);
+  // clicking the selected card again clears the selection.
   const handleStepClick = useCallback(
     (nodeId: string) => {
-      setSelectedNodeId(nodeId);
+      setSelectedNodeId(selectedNodeId === nodeId ? null : nodeId);
     },
-    [setSelectedNodeId],
+    [selectedNodeId, setSelectedNodeId],
   );
 
   const statusCounts = useMemo(() => {

--- a/apps/ui/src/pages/workflow-runs/[id]/page.tsx
+++ b/apps/ui/src/pages/workflow-runs/[id]/page.tsx
@@ -14,7 +14,7 @@ import { JsonTree } from "@/components/workflows/json-tree";
 import { StepCard } from "@/components/workflows/step-card";
 import { WorkflowGraph } from "@/components/workflows/workflow-graph";
 import { readStringParam, useUrlSearchState } from "@/hooks/use-url-search-state";
-import { parseSyntheticStepId } from "@/lib/synthetic-step-id";
+import { foreachParentIds, parseSyntheticStepId } from "@/lib/synthetic-step-id";
 import { cn, formatElapsed, formatSmartTime } from "@/lib/utils";
 
 export default function WorkflowRunDetailPage() {
@@ -33,6 +33,10 @@ export default function WorkflowRunDetailPage() {
   );
   const stepRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const steps = useMemo(() => run?.steps ?? [], [run?.steps]);
+  const foreachIds = useMemo(
+    () => foreachParentIds(workflow?.definition.nodes),
+    [workflow?.definition.nodes],
+  );
 
   const setSelectedNodeId = useCallback(
     (nodeId: string | null) => setParam("node", nodeId),
@@ -70,7 +74,9 @@ export default function WorkflowRunDetailPage() {
       setSelectedNodeId(nodeId);
       const ownStepIds = steps
         .map((step) => step.nodeId)
-        .filter((stepNodeId) => parseSyntheticStepId(stepNodeId).parentNodeId === nodeId);
+        .filter(
+          (stepNodeId) => parseSyntheticStepId(stepNodeId, foreachIds).parentNodeId === nodeId,
+        );
       const next = new Set(expandedStepIds);
       for (const stepNodeId of ownStepIds.length > 0 ? ownStepIds : [nodeId]) {
         next.add(stepNodeId);
@@ -82,7 +88,7 @@ export default function WorkflowRunDetailPage() {
         el?.scrollIntoView({ behavior: "smooth", block: "nearest" });
       });
     },
-    [expandedStepIds, setExpandedSteps, setSelectedNodeId, steps],
+    [expandedStepIds, setExpandedSteps, setSelectedNodeId, steps, foreachIds],
   );
 
   // When a step card is clicked, highlight the node in the graph (don't toggle expand)
@@ -111,12 +117,12 @@ export default function WorkflowRunDetailPage() {
       !run.steps.some(
         (s) =>
           s.nodeId === selectedNodeId ||
-          parseSyntheticStepId(s.nodeId).parentNodeId === selectedNodeId,
+          parseSyntheticStepId(s.nodeId, foreachIds).parentNodeId === selectedNodeId,
       )
     ) {
       setSelectedNodeId(null);
     }
-  }, [selectedNodeId, run?.steps, setSelectedNodeId]);
+  }, [selectedNodeId, run?.steps, setSelectedNodeId, foreachIds]);
 
   useEffect(() => {
     if (!run?.steps || expandedStepIds.size === 0) return;
@@ -286,7 +292,7 @@ export default function WorkflowRunDetailPage() {
                   workflowNodes={workflow?.definition.nodes}
                   isSelected={
                     selectedNodeId === step.nodeId ||
-                    selectedNodeId === parseSyntheticStepId(step.nodeId).parentNodeId
+                    selectedNodeId === parseSyntheticStepId(step.nodeId, foreachIds).parentNodeId
                   }
                   isExpanded={expandedStepIds.has(step.nodeId)}
                   onClick={() => handleStepClick(step.nodeId)}

--- a/apps/ui/src/pages/workflow-runs/[id]/page.tsx
+++ b/apps/ui/src/pages/workflow-runs/[id]/page.tsx
@@ -14,6 +14,7 @@ import { JsonTree } from "@/components/workflows/json-tree";
 import { StepCard } from "@/components/workflows/step-card";
 import { WorkflowGraph } from "@/components/workflows/workflow-graph";
 import { readStringParam, useUrlSearchState } from "@/hooks/use-url-search-state";
+import { parseSyntheticStepId } from "@/lib/synthetic-step-id";
 import { cn, formatElapsed, formatSmartTime } from "@/lib/utils";
 
 export default function WorkflowRunDetailPage() {
@@ -31,6 +32,7 @@ export default function WorkflowRunDetailPage() {
     [expandedStepsParam],
   );
   const stepRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const steps = useMemo(() => run?.steps ?? [], [run?.steps]);
 
   const setSelectedNodeId = useCallback(
     (nodeId: string | null) => setParam("node", nodeId),
@@ -61,20 +63,26 @@ export default function WorkflowRunDetailPage() {
     [expandedStepIds, setExpandedSteps],
   );
 
-  // When a graph node is clicked, expand and scroll to that step
+  // When a graph node is clicked, expand and scroll to that step. A `foreach` node owns several
+  // synthetic child steps (`<nodeId>#<itemKey>`) — expand all of them and scroll to the first.
   const handleGraphNodeClick = useCallback(
     (nodeId: string) => {
       setSelectedNodeId(nodeId);
+      const ownStepIds = steps
+        .map((step) => step.nodeId)
+        .filter((stepNodeId) => parseSyntheticStepId(stepNodeId).parentNodeId === nodeId);
       const next = new Set(expandedStepIds);
-      next.add(nodeId);
+      for (const stepNodeId of ownStepIds.length > 0 ? ownStepIds : [nodeId]) {
+        next.add(stepNodeId);
+      }
       setExpandedSteps(next);
       // Scroll to the step card after a tick (to allow expansion to render)
       requestAnimationFrame(() => {
-        const el = stepRefs.current.get(nodeId);
+        const el = stepRefs.current.get(ownStepIds[0] ?? nodeId);
         el?.scrollIntoView({ behavior: "smooth", block: "nearest" });
       });
     },
-    [expandedStepIds, setExpandedSteps, setSelectedNodeId],
+    [expandedStepIds, setExpandedSteps, setSelectedNodeId, steps],
   );
 
   // When a step card is clicked, highlight the node in the graph (don't toggle expand)
@@ -84,8 +92,6 @@ export default function WorkflowRunDetailPage() {
     },
     [setSelectedNodeId],
   );
-
-  const steps = run?.steps ?? [];
 
   const statusCounts = useMemo(() => {
     const counts: Record<string, number> = {};
@@ -97,8 +103,17 @@ export default function WorkflowRunDetailPage() {
 
   // Clear selection when clicking graph background (deselect)
   useEffect(() => {
-    // If selectedNodeId doesn't match any step, clear it
-    if (selectedNodeId && run?.steps && !run.steps.find((s) => s.nodeId === selectedNodeId)) {
+    // If selectedNodeId doesn't match any step, clear it. A `foreach` parent node id is matched by
+    // its synthetic child steps even though no step carries that exact id.
+    if (
+      selectedNodeId &&
+      run?.steps &&
+      !run.steps.some(
+        (s) =>
+          s.nodeId === selectedNodeId ||
+          parseSyntheticStepId(s.nodeId).parentNodeId === selectedNodeId,
+      )
+    ) {
       setSelectedNodeId(null);
     }
   }, [selectedNodeId, run?.steps, setSelectedNodeId]);
@@ -269,7 +284,10 @@ export default function WorkflowRunDetailPage() {
                   key={step.id}
                   step={step}
                   workflowNodes={workflow?.definition.nodes}
-                  isSelected={selectedNodeId === step.nodeId}
+                  isSelected={
+                    selectedNodeId === step.nodeId ||
+                    selectedNodeId === parseSyntheticStepId(step.nodeId).parentNodeId
+                  }
                   isExpanded={expandedStepIds.has(step.nodeId)}
                   onClick={() => handleStepClick(step.nodeId)}
                   onToggleExpand={() => toggleStep(step.nodeId)}

--- a/apps/ui/src/pages/workflow-runs/[id]/page.tsx
+++ b/apps/ui/src/pages/workflow-runs/[id]/page.tsx
@@ -1,7 +1,8 @@
 import { ArrowLeft, ChevronsDownUp, ChevronsUpDown, RefreshCw } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useRetryWorkflowRun, useWorkflow, useWorkflowRun } from "@/api/hooks/use-workflows";
+import type { WorkflowRunStep } from "@/api/types";
 import { CollapsibleSection } from "@/components/shared/collapsible-section";
 import { StatusBadge } from "@/components/shared/status-badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -10,12 +11,18 @@ import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/ui/page-header";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ForeachStepGroup, foreachDefaultOpen } from "@/components/workflows/foreach-step-group";
 import { JsonTree } from "@/components/workflows/json-tree";
 import { StepCard } from "@/components/workflows/step-card";
 import { WorkflowGraph } from "@/components/workflows/workflow-graph";
 import { readStringParam, useUrlSearchState } from "@/hooks/use-url-search-state";
 import { foreachParentIds, parseSyntheticStepId } from "@/lib/synthetic-step-id";
 import { cn, formatElapsed, formatSmartTime } from "@/lib/utils";
+
+/** A row in the Steps panel: a plain step, or a `foreach` parent with its fanned-out children. */
+type StepListEntry =
+  | { kind: "step"; step: WorkflowRunStep }
+  | { kind: "foreach"; parent: WorkflowRunStep; children: WorkflowRunStep[] };
 
 export default function WorkflowRunDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -37,6 +44,83 @@ export default function WorkflowRunDetailPage() {
     () => foreachParentIds(workflow?.definition.nodes),
     [workflow?.definition.nodes],
   );
+
+  // Synthetic `foreach` children (`<parentNodeId>#<itemKey>`) collapse under their parent step so a
+  // wide fan-out doesn't flood the panel. Order is preserved; an orphan child still renders flat.
+  const stepEntries = useMemo(() => {
+    const entries: StepListEntry[] = [];
+    const groups = new Map<
+      string,
+      { kind: "foreach"; parent: WorkflowRunStep; children: WorkflowRunStep[] }
+    >();
+    for (const step of steps) {
+      const { parentNodeId, itemKey } = parseSyntheticStepId(step.nodeId, foreachIds);
+      if (itemKey === null) {
+        if (foreachIds.has(step.nodeId)) {
+          const group = { kind: "foreach" as const, parent: step, children: [] };
+          groups.set(step.nodeId, group);
+          entries.push(group);
+        } else {
+          entries.push({ kind: "step", step });
+        }
+        continue;
+      }
+      const group = groups.get(parentNodeId);
+      if (group) {
+        group.children.push(step);
+      } else {
+        entries.push({ kind: "step", step });
+      }
+    }
+    return entries;
+  }, [steps, foreachIds]);
+
+  // Children-list open state is UI-only (not in the URL). Each group is seeded once with its
+  // default — open when anything failed or is still in flight — and user toggles then win.
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
+
+  const setGroupOpen = useCallback((nodeId: string, open: boolean) => {
+    setOpenGroups((prev) => ({ ...prev, [nodeId]: open }));
+  }, []);
+
+  // Seed each group once (polling must not re-close a group the user opened), and drop the previous
+  // run's toggles when navigating between runs without unmounting.
+  const seededRunId = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const isNewRun = seededRunId.current !== id;
+    seededRunId.current = id;
+    setOpenGroups((prev) => {
+      const base = isNewRun ? {} : prev;
+      let next = base;
+      for (const entry of stepEntries) {
+        if (entry.kind !== "foreach" || entry.parent.nodeId in base) continue;
+        if (next === base) next = { ...base };
+        next[entry.parent.nodeId] = foreachDefaultOpen(entry.children);
+      }
+      return next;
+    });
+  }, [stepEntries, id]);
+
+  const setAllGroupsOpen = useCallback(
+    (open: boolean) => {
+      setOpenGroups(
+        Object.fromEntries(
+          stepEntries
+            .filter((entry) => entry.kind === "foreach")
+            .map((entry) => [entry.parent.nodeId, open]),
+        ),
+      );
+    },
+    [stepEntries],
+  );
+
+  const registerStepRef = useCallback((nodeId: string, el: HTMLDivElement | null) => {
+    if (el) {
+      stepRefs.current.set(nodeId, el);
+    } else {
+      stepRefs.current.delete(nodeId);
+    }
+  }, []);
 
   const setSelectedNodeId = useCallback(
     (nodeId: string | null) => setParam("node", nodeId),
@@ -72,6 +156,7 @@ export default function WorkflowRunDetailPage() {
   const handleGraphNodeClick = useCallback(
     (nodeId: string) => {
       setSelectedNodeId(nodeId);
+      if (foreachIds.has(nodeId)) setGroupOpen(nodeId, true);
       const ownStepIds = steps
         .map((step) => step.nodeId)
         .filter(
@@ -88,7 +173,7 @@ export default function WorkflowRunDetailPage() {
         el?.scrollIntoView({ behavior: "smooth", block: "nearest" });
       });
     },
-    [expandedStepIds, setExpandedSteps, setSelectedNodeId, steps, foreachIds],
+    [expandedStepIds, setExpandedSteps, setSelectedNodeId, setGroupOpen, steps, foreachIds],
   );
 
   // When a step card is clicked, highlight the node in the graph (don't toggle expand)
@@ -147,6 +232,22 @@ export default function WorkflowRunDetailPage() {
   if (!run) {
     return <p className="text-muted-foreground">Workflow run not found.</p>;
   }
+
+  const renderStepCard = (step: WorkflowRunStep) => (
+    <StepCard
+      key={step.id}
+      step={step}
+      workflowNodes={workflow?.definition.nodes}
+      isSelected={
+        selectedNodeId === step.nodeId ||
+        selectedNodeId === parseSyntheticStepId(step.nodeId, foreachIds).parentNodeId
+      }
+      isExpanded={expandedStepIds.has(step.nodeId)}
+      onClick={() => handleStepClick(step.nodeId)}
+      onToggleExpand={() => toggleStep(step.nodeId)}
+      ref={(el) => registerStepRef(step.nodeId, el)}
+    />
+  );
 
   return (
     <div className="flex flex-col flex-1 min-h-0 gap-4">
@@ -266,7 +367,10 @@ export default function WorkflowRunDetailPage() {
                   variant="ghost"
                   size="sm"
                   className="h-6 px-1.5 text-xs text-muted-foreground"
-                  onClick={() => setExpandedSteps(steps.map((s) => s.nodeId))}
+                  onClick={() => {
+                    setExpandedSteps(steps.map((s) => s.nodeId));
+                    setAllGroupsOpen(true);
+                  }}
                   title="Expand all"
                 >
                   <ChevronsUpDown className="h-3.5 w-3.5" />
@@ -275,7 +379,10 @@ export default function WorkflowRunDetailPage() {
                   variant="ghost"
                   size="sm"
                   className="h-6 px-1.5 text-xs text-muted-foreground"
-                  onClick={() => setExpandedSteps([])}
+                  onClick={() => {
+                    setExpandedSteps([]);
+                    setAllGroupsOpen(false);
+                  }}
                   title="Collapse all"
                 >
                   <ChevronsDownUp className="h-3.5 w-3.5" />
@@ -285,27 +392,27 @@ export default function WorkflowRunDetailPage() {
           </div>
           <ScrollArea className="flex-1 min-h-0">
             <div className="p-2 space-y-1.5">
-              {steps.map((step) => (
-                <StepCard
-                  key={step.id}
-                  step={step}
-                  workflowNodes={workflow?.definition.nodes}
-                  isSelected={
-                    selectedNodeId === step.nodeId ||
-                    selectedNodeId === parseSyntheticStepId(step.nodeId, foreachIds).parentNodeId
-                  }
-                  isExpanded={expandedStepIds.has(step.nodeId)}
-                  onClick={() => handleStepClick(step.nodeId)}
-                  onToggleExpand={() => toggleStep(step.nodeId)}
-                  ref={(el) => {
-                    if (el) {
-                      stepRefs.current.set(step.nodeId, el);
-                    } else {
-                      stepRefs.current.delete(step.nodeId);
+              {stepEntries.map((entry) =>
+                entry.kind === "foreach" && entry.children.length > 0 ? (
+                  <ForeachStepGroup
+                    key={entry.parent.id}
+                    parent={entry.parent}
+                    childSteps={entry.children}
+                    workflowNodes={workflow?.definition.nodes}
+                    selectedNodeId={selectedNodeId}
+                    isOpen={openGroups[entry.parent.nodeId] ?? false}
+                    onToggleOpen={() =>
+                      setGroupOpen(entry.parent.nodeId, !openGroups[entry.parent.nodeId])
                     }
-                  }}
-                />
-              ))}
+                    expandedStepIds={expandedStepIds}
+                    onStepClick={handleStepClick}
+                    onToggleStepExpand={toggleStep}
+                    registerStepRef={registerStepRef}
+                  />
+                ) : (
+                  renderStepCard(entry.kind === "foreach" ? entry.parent : entry.step)
+                ),
+              )}
               {steps.length === 0 && (
                 <p className="text-sm text-muted-foreground p-4 text-center">
                   No steps executed yet.

--- a/apps/ui/src/styles/globals.css
+++ b/apps/ui/src/styles/globals.css
@@ -87,6 +87,8 @@
   --color-action-create-task: oklch(0.585 0.233 277.117);     /* indigo-500 */
   --color-action-send-message: oklch(0.656 0.241 354.308);    /* pink-500 */
   --color-action-delegate-to-agent: oklch(0.627 0.265 303.9); /* purple-500 */
+  --color-action-foreach: oklch(0.768 0.233 130.85);          /* lime-500 — fan-out */
+  --color-action-swarm-script: oklch(0.696 0.17 162.48);      /* emerald-500 — catalog script */
   --color-action-default: oklch(0.623 0.214 259.815);         /* blue-500 — fallback action */
   --color-action-property-match: oklch(0.769 0.188 70.08);    /* amber-500 — condition */
   --color-action-code-match: oklch(0.795 0.184 86.047);       /* yellow-500 — condition */
@@ -179,6 +181,8 @@
   --color-action-create-task: oklch(0.673 0.182 276.935);     /* indigo-400 */
   --color-action-send-message: oklch(0.718 0.202 349.761);    /* pink-400 */
   --color-action-delegate-to-agent: oklch(0.714 0.203 305.504); /* purple-400 */
+  --color-action-foreach: oklch(0.841 0.238 128.85);          /* lime-400 */
+  --color-action-swarm-script: oklch(0.765 0.177 163.223);    /* emerald-400 */
   --color-action-default: oklch(0.707 0.165 254.624);         /* blue-400 */
   --color-action-property-match: oklch(0.828 0.189 84.429);   /* amber-400 */
   --color-action-code-match: oklch(0.852 0.199 91.936);       /* yellow-400 */

--- a/runbooks/workflows.md
+++ b/runbooks/workflows.md
@@ -10,6 +10,7 @@ Upstream outputs are **not** available by default. Declare an `inputs` mapping:
 - Values are context paths (usually a node ID).
 - Agent-task output shape is `{ taskId, taskOutput }`, so access via `localName.taskOutput.field`.
 - For trigger data: `{ "pr": "trigger.pullRequest" }` → `{{pr.number}}`.
+- For the current run: `{ "runId": "run.id" }` → `{{runId}}` (builtin, like `trigger`/`input` — useful for receipts/audit nodes correlating their output with the run).
 
 Without `inputs`, upstream references silently resolve to empty strings — check `diagnostics.unresolvedTokens`.
 

--- a/runbooks/workflows.md
+++ b/runbooks/workflows.md
@@ -75,6 +75,55 @@ Do not include patch bodies, diff hunks, raw `git log --stat` output, downloaded
 - `model`
 - `parentTaskId`
 
+## Foreach nodes
+
+`foreach` fans out one `agent-task` child per array item, waits for every child, then exposes one
+parent-owned aggregate to downstream nodes.
+
+```yaml
+- id: reflect
+  type: foreach
+  inputs: { agents: "gather.result.agents" }
+  config:
+    over: "{{agents}}"
+    itemKey: id
+    body:
+      type: agent-task
+      config:
+        agentId: "{{item.id}}"
+        template: "Reflect for {{item.name}} (index {{index}})"
+  next: critique
+```
+
+- `over` must resolve to an array. An exact interpolation token preserves the array value instead
+  of JSON-stringifying it.
+- `itemKey` names a required non-empty string property whose value is unique across the array.
+- `body.type` is restricted to `agent-task` in v1. `body.config` accepts the normal agent-task
+  fields and is interpolated separately for each child with `item` and zero-based `index`.
+- Child steps have synthetic IDs `<foreachNodeId>#<itemKey>`. The parent remains waiting until all
+  children are terminal; only the parent aggregate is written to workflow context.
+- Empty arrays complete synchronously and still route to the successor.
+- `concurrency` is rejected in v1. All children are materialized in one fan-out.
+- A `foreach` node in a cycle is rejected in v1. Child steps are scoped to the run, so a later
+  parent iteration cannot safely re-adopt them.
+
+The parent output shape is:
+
+```json
+{
+  "results": [
+    { "itemKey": "agent-id", "status": "completed", "output": { "taskId": "...", "taskOutput": {} } }
+  ],
+  "okCount": 1,
+  "failedCount": 0
+}
+```
+
+The workflow-level `onNodeFailure` policy applies to foreach children. The default `fail` stops the
+run on the first failed/cancelled child. With `onNodeFailure: "continue"`, the child contributes a
+`failed` result whose output contains the existing `[FAILED: <reason>]` marker; the remaining
+children finish and the parent closes the join.
+
 ## Script node types
 
 There are two script-oriented workflow nodes:

--- a/src/be/db.ts
+++ b/src/be/db.ts
@@ -9139,7 +9139,7 @@ export function updateWorkflowRun(
   data: {
     status?: WorkflowRunStatus;
     context?: Record<string, unknown>;
-    error?: string;
+    error?: string | null;
     finishedAt?: string;
   },
 ): WorkflowRun | null {
@@ -9345,7 +9345,7 @@ export function updateWorkflowRunStep(
   data: {
     status?: WorkflowRunStepStatus;
     output?: unknown;
-    error?: string;
+    error?: string | null;
     finishedAt?: string;
     retryCount?: number;
     maxRetries?: number;
@@ -9422,6 +9422,7 @@ export interface StuckWorkflowRun {
   runId: string;
   stepId: string;
   nodeId: string;
+  taskId: string;
   taskStatus: string;
   taskOutput: string | null;
   workflowId: string;
@@ -9434,6 +9435,7 @@ export function getStuckWorkflowRuns(): StuckWorkflowRun[] {
         wr.id as runId,
         wrs.id as stepId,
         wrs.nodeId,
+        at.id as taskId,
         at.status as taskStatus,
         at.output as taskOutput,
         wr.workflowId
@@ -9441,7 +9443,8 @@ export function getStuckWorkflowRuns(): StuckWorkflowRun[] {
       JOIN workflow_run_steps wrs ON wrs.runId = wr.id AND wrs.status = 'waiting'
       JOIN agent_tasks at ON at.workflowRunStepId = wrs.id
       WHERE wr.status = 'waiting'
-        AND at.status IN ('completed', 'failed', 'cancelled')`,
+        AND at.status IN ('completed', 'failed', 'cancelled')
+      ORDER BY at.createdAt ASC, at.rowid ASC`,
     )
     .all();
 }
@@ -9501,6 +9504,10 @@ export function getTaskByWorkflowRunStepId(stepId: string): AgentTask | null {
     )
     .get(stepId);
   return row ? rowToAgentTask(row) : null;
+}
+
+export function detachTaskFromWorkflowRunStep(taskId: string): void {
+  getDb().run("UPDATE agent_tasks SET workflowRunStepId = NULL WHERE id = ?", [taskId]);
 }
 
 export function getStepByIdempotencyKey(key: string): WorkflowRunStep | null {

--- a/src/http/workflows.ts
+++ b/src/http/workflows.ts
@@ -28,7 +28,12 @@ import {
 } from "../types";
 import { getRequestAuth } from "../utils/request-auth-context";
 import { getExecutorRegistry, startWorkflowExecution } from "../workflows";
-import { applyDefinitionPatch, generateEdges, validateDefinition } from "../workflows/definition";
+import {
+  applyDefinitionPatch,
+  definitionNodeIds,
+  generateEdges,
+  validateDefinition,
+} from "../workflows/definition";
 import { TriggerSchemaError } from "../workflows/engine";
 import { validateJsonSchema } from "../workflows/json-schema-validator";
 import { cancelWorkflowRun, retryFailedRun } from "../workflows/resume";
@@ -524,7 +529,9 @@ export async function handleWorkflows(
       return true;
     }
 
-    const validation = validateDefinition(patchResult.definition, getExecutorRegistry());
+    const validation = validateDefinition(patchResult.definition, getExecutorRegistry(), {
+      legacyNodeIds: definitionNodeIds(existing.definition),
+    });
     if (!validation.valid) {
       jsonError(res, `Invalid definition: ${validation.errors.join("; ")}`, 400);
       return true;
@@ -568,7 +575,9 @@ export async function handleWorkflows(
       return true;
     }
 
-    const validation = validateDefinition(patchResult.definition, getExecutorRegistry());
+    const validation = validateDefinition(patchResult.definition, getExecutorRegistry(), {
+      legacyNodeIds: definitionNodeIds(existing.definition),
+    });
     if (!validation.valid) {
       jsonError(res, `Invalid definition: ${validation.errors.join("; ")}`, 400);
       return true;
@@ -627,7 +636,9 @@ export async function handleWorkflows(
 
     // Validate new definition if provided
     if (body.definition) {
-      const validation = validateDefinition(body.definition, getExecutorRegistry());
+      const validation = validateDefinition(body.definition, getExecutorRegistry(), {
+        legacyNodeIds: definitionNodeIds(existing.definition),
+      });
       if (!validation.valid) {
         jsonError(res, `Invalid definition: ${validation.errors.join("; ")}`, 400);
         return true;

--- a/src/tests/workflow-executors.test.ts
+++ b/src/tests/workflow-executors.test.ts
@@ -751,7 +751,7 @@ describe("ValidateExecutor", () => {
 // ─── Registry Wiring ─────────────────────────────────────────
 
 describe("createExecutorRegistry", () => {
-  test("registers all 11 executors (8 instant + 3 async)", () => {
+  test("registers all 12 executors (8 instant + 4 async)", () => {
     const registry = createExecutorRegistry(mockDeps);
     const types = registry.types();
 
@@ -764,9 +764,10 @@ describe("createExecutorRegistry", () => {
     expect(types).toContain("vcs");
     expect(types).toContain("validate");
     expect(types).toContain("agent-task");
+    expect(types).toContain("foreach");
     expect(types).toContain("human-in-the-loop");
     expect(types).toContain("wait");
-    expect(types).toHaveLength(11);
+    expect(types).toHaveLength(12);
   });
 
   test("instant executors have mode instant, async executors have mode async", () => {
@@ -785,6 +786,7 @@ describe("createExecutorRegistry", () => {
       expect(registry.get(type).mode).toBe("instant");
     }
     expect(registry.get("agent-task").mode).toBe("async");
+    expect(registry.get("foreach").mode).toBe("async");
     expect(registry.get("human-in-the-loop").mode).toBe("async");
     expect(registry.get("wait").mode).toBe("async");
   });

--- a/src/tests/workflow-foreach.test.ts
+++ b/src/tests/workflow-foreach.test.ts
@@ -689,6 +689,84 @@ describe("workflow foreach", () => {
     ).toBe(true);
   });
 
+  test("a foreach cannot share its synthetic child id space with a legacy hash node", () => {
+    // A grandfathered `reflect#foo` node beside a `reflect` foreach would be
+    // indistinguishable from reflect's own children — reject the foreach.
+    const result = validateDefinition(
+      {
+        nodes: [
+          {
+            id: "reflect",
+            type: "foreach",
+            config: {
+              over: [],
+              itemKey: "id",
+              body: { type: "agent-task", config: { template: "Reflect" } },
+            },
+            next: "reflect#foo",
+          },
+          { id: "reflect#foo", type: "record", config: { message: "legacy" } },
+        ],
+      },
+      undefined,
+      { legacyNodeIds: new Set(["reflect#foo"]) },
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((error) => error.includes("collides with its synthetic child id space")),
+    ).toBe(true);
+  });
+
+  test("static foreach body config is validated against the agent-task schema at authoring", () => {
+    const { registry } = createRegistry(false);
+    const invalid = validateDefinition(
+      {
+        nodes: [
+          {
+            id: "reflect",
+            type: "foreach",
+            config: {
+              over: "{{trigger.items}}",
+              itemKey: "id",
+              body: {
+                type: "agent-task",
+                config: { template: "Reflect", priority: 101, tags: "review" },
+              },
+            },
+          },
+        ],
+      },
+      registry,
+    );
+    expect(invalid.valid).toBe(false);
+    expect(invalid.errors.some((error) => error.includes("config.body.config.priority"))).toBe(
+      true,
+    );
+    expect(invalid.errors.some((error) => error.includes("config.body.config.tags"))).toBe(true);
+
+    // Interpolated fields still defer to execution-time validation.
+    const deferred = validateDefinition(
+      {
+        nodes: [
+          {
+            id: "reflect",
+            type: "foreach",
+            config: {
+              over: "{{trigger.items}}",
+              itemKey: "id",
+              body: {
+                type: "agent-task",
+                config: { template: "Reflect {{item.name}}", agentId: "{{item.id}}" },
+              },
+            },
+          },
+        ],
+      },
+      registry,
+    );
+    expect(deferred.valid).toBe(true);
+  });
+
   test("definition validation rejects reserved hashes and foreach concurrency", () => {
     const hashResult = validateDefinition({
       nodes: [{ id: "reflect#bad", type: "record", config: { message: "bad" } }],

--- a/src/tests/workflow-foreach.test.ts
+++ b/src/tests/workflow-foreach.test.ts
@@ -19,6 +19,7 @@ import { startWorkflowExecution, walkGraph } from "../workflows/engine";
 import { InProcessEventBus } from "../workflows/event-bus";
 import { AgentTaskExecutor } from "../workflows/executors/agent-task";
 import {
+  type AsyncExecutorResult,
   BaseExecutor,
   type ExecutorDependencies,
   type ExecutorResult,
@@ -31,6 +32,7 @@ import {
   retryFailedRun,
   setupWorkflowResumeListener,
 } from "../workflows/resume";
+import { startRetryPoller, stopRetryPoller } from "../workflows/retry-poller";
 import { interpolate } from "../workflows/template";
 
 const TEST_DB_PATH = "./test-workflow-foreach.sqlite";
@@ -51,6 +53,35 @@ class RecordExecutor extends BaseExecutor<
     config: z.infer<typeof RecordExecutor.configSchema>,
   ): Promise<ExecutorResult<z.infer<typeof RecordExecutor.outputSchema>>> {
     return { status: "success", output: { message: config.message } };
+  }
+}
+
+class FlakyAsyncExecutor extends BaseExecutor<
+  typeof FlakyAsyncExecutor.configSchema,
+  typeof FlakyAsyncExecutor.outputSchema
+> {
+  static readonly configSchema = z.object({});
+  static readonly outputSchema = z.object({ ok: z.boolean() });
+
+  readonly type = "flaky-async";
+  readonly mode = "async" as const;
+  readonly configSchema = FlakyAsyncExecutor.configSchema;
+  readonly outputSchema = FlakyAsyncExecutor.outputSchema;
+  attempts = 0;
+
+  protected async execute(): Promise<
+    ExecutorResult<z.infer<typeof FlakyAsyncExecutor.outputSchema>>
+  > {
+    this.attempts += 1;
+    if (this.attempts === 1) {
+      return { status: "failed", error: "transient dispatch failure" };
+    }
+    return {
+      status: "success",
+      async: true,
+      waitFor: "task.completed",
+      correlationId: "flaky",
+    } as AsyncExecutorResult<z.infer<typeof FlakyAsyncExecutor.outputSchema>>;
   }
 }
 
@@ -223,6 +254,71 @@ describe("workflow foreach", () => {
     expect(getWorkflowRun(runId)?.error).toBeUndefined();
   });
 
+  test("stale events from a superseded task cannot fail or complete a retried step", async () => {
+    const { bus, registry } = createRegistry(true);
+    const workflow = makeWorkflow(foreachDefinition());
+    const runId = await startWorkflowExecution(
+      workflow,
+      { items: agentItems.slice(0, 1) },
+      registry,
+    );
+    const child = foreachChildren(runId)[0]!;
+    const originalTask = getTaskByWorkflowRunStepId(child.id)!;
+
+    await failChild(runId, child.id, "first attempt broke", bus);
+    await waitFor(() => getWorkflowRun(runId)?.status === "failed");
+    await retryFailedRun(runId, registry);
+    expect(getWorkflowRun(runId)?.status).toBe("waiting");
+
+    // failTask's own after-commit bus emit lands on a later tick and can arrive
+    // AFTER the retry re-dispatched the step with a new task (the exact sequence
+    // that flaked CI shard 3). Neither a duplicate failure nor a completion for
+    // the superseded task may touch the step.
+    bus.emit("task.failed", {
+      taskId: originalTask.id,
+      failureReason: "first attempt broke",
+      workflowRunId: runId,
+      workflowRunStepId: child.id,
+    });
+    bus.emit("task.completed", {
+      taskId: originalTask.id,
+      output: "zombie output",
+      workflowRunId: runId,
+      workflowRunStepId: child.id,
+    });
+    await Bun.sleep(20);
+
+    expect(getWorkflowRun(runId)?.status).toBe("waiting");
+    expect(stepById(runId, child.id)?.status).toBe("waiting");
+
+    await completeChild(runId, child.id, "real retry output", bus);
+    await waitFor(() => getWorkflowRun(runId)?.status === "completed");
+    const aggregate = getContext(runId).reflect as {
+      results: Array<{ output: { taskOutput: string } }>;
+    };
+    expect(aggregate.results[0]?.output.taskOutput).toBe("real retry output");
+  });
+
+  test("nodes can reference their own run via the run.id context builtin", async () => {
+    const { registry } = createRegistry(false);
+    const workflow = makeWorkflow({
+      nodes: [
+        {
+          id: "receipt",
+          type: "record",
+          inputs: { runId: "run.id" },
+          config: { message: "run {{runId}}" },
+        },
+      ],
+    });
+    const runId = await startWorkflowExecution(workflow, {}, registry);
+
+    expect(getWorkflowRun(runId)?.status).toBe("completed");
+    expect((stepByNodeId(runId, "receipt")?.output as { message: string }).message).toBe(
+      `run ${runId}`,
+    );
+  });
+
   test("late task cancellation cannot resurrect a cancelled run", async () => {
     const { bus, registry } = createRegistry(true);
     const workflow = makeWorkflow({ ...foreachDefinition(), onNodeFailure: "continue" });
@@ -317,6 +413,143 @@ describe("workflow foreach", () => {
         process.env.WORKFLOW_MAX_STEPS_PER_RUN = originalLimit;
       }
     }
+  });
+
+  test("foreach rejects a fan-out that lands exactly on the step cap when reaching it", async () => {
+    // 1 existing (parent) + 3 children == cap of 4. Admitting this would spend all
+    // child work and then trip walkGraph's inclusive `>=` breaker when routing the
+    // "after" successor — so the executor must refuse upfront, before any dispatch.
+    const originalLimit = process.env.WORKFLOW_MAX_STEPS_PER_RUN;
+    process.env.WORKFLOW_MAX_STEPS_PER_RUN = "4";
+    try {
+      const { registry } = createRegistry(false);
+      const workflow = makeWorkflow(foreachDefinition());
+      const runId = await startWorkflowExecution(workflow, { items: agentItems }, registry);
+
+      expect(getWorkflowRun(runId)?.status).toBe("failed");
+      expect(stepByNodeId(runId, "reflect")?.error).toContain("WORKFLOW_MAX_STEPS_PER_RUN");
+      expect(foreachChildren(runId)).toHaveLength(0);
+      expect(taskCountForForeachChildren(runId)).toBe(0);
+    } finally {
+      if (originalLimit === undefined) {
+        delete process.env.WORKFLOW_MAX_STEPS_PER_RUN;
+      } else {
+        process.env.WORKFLOW_MAX_STEPS_PER_RUN = originalLimit;
+      }
+    }
+  });
+
+  test("all child rows are materialized before any child task is dispatched", async () => {
+    // A real agent can complete an early child while later children are still
+    // being set up; the join must never observe a partial child set. The
+    // executor's pre-dispatch linkedTask lookup is the first per-child call on
+    // the dispatch side, so the full fan-out must already be materialized then.
+    let childRowsAtFirstDispatch: number | null = null;
+    const wrappedDb: ExecutorDependencies["db"] = {
+      ...db,
+      getTaskByWorkflowRunStepId: (stepId: string) => {
+        if (childRowsAtFirstDispatch === null) {
+          const step = db.getWorkflowRunStep(stepId);
+          if (step) {
+            childRowsAtFirstDispatch = getWorkflowRunStepsByRunId(step.runId).filter((s) =>
+              s.nodeId.startsWith("reflect#"),
+            ).length;
+          }
+        }
+        return getTaskByWorkflowRunStepId(stepId);
+      },
+    };
+    const bus = new InProcessEventBus();
+    const deps: ExecutorDependencies = {
+      db: wrappedDb,
+      eventBus: bus,
+      interpolate: (template, ctx) => interpolate(template, ctx).result,
+    };
+    const registry = new ExecutorRegistry();
+    registry.register(new ForeachExecutor(deps));
+    registry.register(new AgentTaskExecutor(deps));
+    registry.register(new RecordExecutor(deps));
+
+    const workflow = makeWorkflow(foreachDefinition());
+    const runId = await startWorkflowExecution(workflow, { items: agentItems }, registry);
+
+    expect(childRowsAtFirstDispatch).toBe(3);
+    expect(foreachChildren(runId)).toHaveLength(3);
+    expect(taskCountForForeachChildren(runId)).toBe(3);
+  });
+
+  test("the retry poller keeps a re-dispatched async step waiting instead of routing successors", async () => {
+    const bus = new InProcessEventBus();
+    const deps: ExecutorDependencies = {
+      db,
+      eventBus: bus,
+      interpolate: (template, ctx) => interpolate(template, ctx).result,
+    };
+    const registry = new ExecutorRegistry();
+    const flaky = new FlakyAsyncExecutor(deps);
+    registry.register(flaky);
+    registry.register(new RecordExecutor(deps));
+
+    const workflow = makeWorkflow({
+      nodes: [
+        {
+          id: "dispatch",
+          type: "flaky-async",
+          config: {},
+          retry: { maxRetries: 1, strategy: "static", baseDelayMs: 1, maxDelayMs: 10 },
+          next: "after",
+        },
+        { id: "after", type: "record", config: { message: "routed" } },
+      ],
+    });
+
+    const runId = await startWorkflowExecution(workflow, {}, registry);
+    expect(flaky.attempts).toBe(1);
+
+    try {
+      startRetryPoller(registry, 10);
+      await waitFor(() => flaky.attempts === 2);
+      await waitFor(() => getWorkflowRun(runId)?.status === "waiting");
+    } finally {
+      stopRetryPoller();
+    }
+
+    // The second attempt returned the async marker — the step is waiting on task
+    // events again, and the successor must not have run off the marker object.
+    expect(stepByNodeId(runId, "dispatch")?.status).toBe("waiting");
+    expect(stepByNodeId(runId, "after")).toBeUndefined();
+    expect(getWorkflowRun(runId)?.status).toBe("waiting");
+  });
+
+  test("definition validation rejects node-level outputSchema and validation on foreach", () => {
+    const base = {
+      id: "reflect",
+      type: "foreach",
+      config: {
+        over: [],
+        itemKey: "id",
+        body: { type: "agent-task", config: { template: "Reflect" } },
+      },
+    };
+    const withOutputSchema = validateDefinition({
+      nodes: [{ ...base, outputSchema: { type: "object" } }],
+    });
+    expect(withOutputSchema.valid).toBe(false);
+    expect(
+      withOutputSchema.errors.some((error) =>
+        error.includes("node-level outputSchema/validation is not supported in v1"),
+      ),
+    ).toBe(true);
+
+    const withValidation = validateDefinition({
+      nodes: [{ ...base, validation: { rules: [] } }],
+    });
+    expect(withValidation.valid).toBe(false);
+    expect(
+      withValidation.errors.some((error) =>
+        error.includes("node-level outputSchema/validation is not supported in v1"),
+      ),
+    ).toBe(true);
   });
 
   test("definition validation rejects reserved hashes and foreach concurrency", () => {

--- a/src/tests/workflow-foreach.test.ts
+++ b/src/tests/workflow-foreach.test.ts
@@ -696,6 +696,31 @@ describe("workflow foreach", () => {
     expect(hashResult.valid).toBe(false);
     expect(hashResult.errors.some((error) => error.includes('reserved character "#"'))).toBe(true);
 
+    // A workflow stored BEFORE the reserved-# rule stays editable: update/patch
+    // paths pass the stored definition's ids as legacyNodeIds, which exempts the
+    // pre-existing id while a NEW hash id in the same definition is still rejected.
+    const legacy = new Set(["legacy#node"]);
+    const grandfathered = validateDefinition(
+      { nodes: [{ id: "legacy#node", type: "record", config: { message: "old" } }] },
+      undefined,
+      { legacyNodeIds: legacy },
+    );
+    expect(grandfathered.valid).toBe(true);
+    const newHashId = validateDefinition(
+      {
+        nodes: [
+          { id: "legacy#node", type: "record", config: { message: "old" }, next: "fresh#node" },
+          { id: "fresh#node", type: "record", config: { message: "new" } },
+        ],
+      },
+      undefined,
+      { legacyNodeIds: legacy },
+    );
+    expect(newHashId.valid).toBe(false);
+    expect(
+      newHashId.errors.some((error) => error.includes('Node "fresh#node" contains reserved')),
+    ).toBe(true);
+
     const concurrencyResult = validateDefinition({
       nodes: [
         {

--- a/src/tests/workflow-foreach.test.ts
+++ b/src/tests/workflow-foreach.test.ts
@@ -177,7 +177,144 @@ describe("workflow foreach", () => {
     expect(aggregate.failedCount).toBe(1);
     expect(aggregate.results[1]?.status).toBe("failed");
     expect(aggregate.results[1]?.output.taskOutput).toStartWith("[FAILED: reflection broke]");
+    // The failure is explicit metadata on the completed child, not just output text.
+    expect(stepById(runId, children[1]!.id)?.error).toBe("reflection broke");
     expect(stepByNodeId(runId, "after")?.status).toBe("completed");
+  });
+
+  test("a successful child whose output text starts with [FAILED: is not misclassified", async () => {
+    const { bus, registry } = createRegistry(true);
+    const workflow = makeWorkflow(foreachDefinition());
+    const runId = await startWorkflowExecution(
+      workflow,
+      { items: agentItems.slice(0, 1) },
+      registry,
+    );
+    const child = foreachChildren(runId)[0]!;
+
+    // A legitimate completion quoting a log line — user-controlled text, not the
+    // continue-on-failure marker. Only step.error may mark a completed child failed.
+    await completeChild(
+      runId,
+      child.id,
+      "[FAILED: 3 assertions] was the CI summary I analyzed",
+      bus,
+    );
+    await waitFor(() => getWorkflowRun(runId)?.status === "completed");
+
+    const aggregate = getContext(runId).reflect as {
+      results: Array<{ status: string }>;
+      okCount: number;
+      failedCount: number;
+    };
+    expect(aggregate.okCount).toBe(1);
+    expect(aggregate.failedCount).toBe(0);
+    expect(aggregate.results[0]?.status).toBe("completed");
+  });
+
+  test("foreach body config cannot read undeclared upstream outputs", async () => {
+    const { registry } = createRegistry(false);
+    const definition: WorkflowDefinition = {
+      nodes: [
+        {
+          id: "seed",
+          type: "record",
+          config: { message: "classified" },
+          next: "reflect",
+        },
+        {
+          id: "reflect",
+          type: "foreach",
+          // `seed` is deliberately NOT declared in inputs — the deferred body pass
+          // must obey the same explicit-dataflow boundary as normal node config.
+          config: {
+            over: "{{trigger.items}}",
+            itemKey: "id",
+            body: {
+              type: "agent-task",
+              config: {
+                agentId: "{{item.id}}",
+                template: "leak:{{seed.message}} name:{{item.name}}",
+              },
+            },
+          },
+        },
+      ],
+    };
+    const workflow = makeWorkflow(definition);
+    const runId = await startWorkflowExecution(
+      workflow,
+      { items: agentItems.slice(0, 1) },
+      registry,
+    );
+
+    const child = foreachChildren(runId)[0]!;
+    const task = getTaskByWorkflowRunStepId(child.id)!;
+    expect(task.task.split("\n").at(-1)).toBe(`leak: name:${agentItems[0]!.name}`);
+    expect(child.diagnostics).toContain("seed.message");
+  });
+
+  test("the retry poller rebuilds declared input aliases for a retried foreach", async () => {
+    const { registry } = createRegistry(false);
+    const definition: WorkflowDefinition = {
+      nodes: [
+        {
+          id: "reflect",
+          type: "foreach",
+          inputs: { items: "trigger.items" },
+          config: {
+            over: "{{items}}",
+            itemKey: "id",
+            body: {
+              type: "agent-task",
+              config: { agentId: "{{item.id}}", template: "Retry reflect {{item.name}}" },
+            },
+          },
+          retry: { maxRetries: 2, strategy: "static", baseDelayMs: 1, maxDelayMs: 10 },
+          next: "after",
+        },
+        {
+          id: "after",
+          type: "record",
+          inputs: { aggregate: "reflect" },
+          config: { message: "ok" },
+        },
+      ],
+    };
+    const workflow = makeWorkflow(definition);
+    const runId = await startWorkflowExecution(
+      workflow,
+      { items: agentItems.slice(0, 2) },
+      registry,
+    );
+    expect(foreachChildren(runId)).toHaveLength(2);
+
+    // Simulate a transient fan-out failure recorded for the retry poller: the
+    // parent step failed before any child survived, run is failed, retry due.
+    for (const child of foreachChildren(runId)) {
+      db.getDb().prepare("DELETE FROM agent_tasks WHERE workflowRunStepId = ?").run(child.id);
+      db.getDb().prepare("DELETE FROM workflow_run_steps WHERE id = ?").run(child.id);
+    }
+    const parent = stepByNodeId(runId, "reflect")!;
+    db.updateWorkflowRunStep(parent.id, {
+      status: "failed",
+      error: "transient dispatch failure",
+      nextRetryAt: new Date(Date.now() - 1000).toISOString(),
+    });
+    db.updateWorkflowRun(runId, { status: "failed" });
+
+    try {
+      startRetryPoller(registry, 10);
+      // Without buildNodeInterpolationCtx on the retry path, {{items}} resolves to
+      // "" from raw run.context, the config schema rejects it, and no child is
+      // ever re-dispatched.
+      await waitFor(() => foreachChildren(runId).length === 2);
+      await waitFor(() => getWorkflowRun(runId)?.status === "waiting");
+    } finally {
+      stopRetryPoller();
+    }
+    expect(stepByNodeId(runId, "reflect")?.status).toBe("waiting");
+    expect(taskCountForForeachChildren(runId)).toBe(2);
   });
 
   test("re-walk after partial completion does not duplicate children or tasks", async () => {

--- a/src/tests/workflow-foreach.test.ts
+++ b/src/tests/workflow-foreach.test.ts
@@ -576,6 +576,144 @@ describe("workflow foreach", () => {
     }
   });
 
+  test("a terminal foreach (no successors) may land exactly on the step cap", async () => {
+    // With no post-join walk to reserve headroom for, 1 parent + 3 children == cap 4
+    // is legal: the last child closes the join and the run finalizes.
+    const originalLimit = process.env.WORKFLOW_MAX_STEPS_PER_RUN;
+    process.env.WORKFLOW_MAX_STEPS_PER_RUN = "4";
+    try {
+      const { registry } = createRegistry(false);
+      const definition: WorkflowDefinition = {
+        nodes: [
+          {
+            id: "reflect",
+            type: "foreach",
+            config: {
+              over: "{{trigger.items}}",
+              itemKey: "id",
+              body: {
+                type: "agent-task",
+                config: { agentId: "{{item.id}}", template: "Terminal {{item.name}}" },
+              },
+            },
+          },
+        ],
+      };
+      const workflow = makeWorkflow(definition);
+      const runId = await startWorkflowExecution(workflow, { items: agentItems }, registry);
+
+      expect(getWorkflowRun(runId)?.status).toBe("waiting");
+      expect(stepByNodeId(runId, "reflect")?.status).toBe("waiting");
+      expect(foreachChildren(runId)).toHaveLength(3);
+
+      // One item beyond the cap must still be refused.
+      process.env.WORKFLOW_MAX_STEPS_PER_RUN = "3";
+      const secondRun = await startWorkflowExecution(workflow, { items: agentItems }, registry);
+      expect(getWorkflowRun(secondRun)?.status).toBe("failed");
+      expect(stepByNodeId(secondRun, "reflect")?.error).toContain("WORKFLOW_MAX_STEPS_PER_RUN");
+    } finally {
+      if (originalLimit === undefined) {
+        delete process.env.WORKFLOW_MAX_STEPS_PER_RUN;
+      } else {
+        process.env.WORKFLOW_MAX_STEPS_PER_RUN = originalLimit;
+      }
+    }
+  });
+
+  test("the retry poller rehydrates the run.id builtin for a never-checkpointed run", async () => {
+    const { registry } = createRegistry(false);
+    const definition: WorkflowDefinition = {
+      nodes: [
+        {
+          id: "reflect",
+          type: "foreach",
+          inputs: { items: "trigger.items", runId: "run.id" },
+          config: {
+            over: "{{items}}",
+            itemKey: "id",
+            body: {
+              type: "agent-task",
+              config: { agentId: "{{item.id}}", template: "RetryRun {{runId}} {{item.name}}" },
+            },
+          },
+          retry: { maxRetries: 2, strategy: "static", baseDelayMs: 1, maxDelayMs: 10 },
+        },
+      ],
+    };
+    const workflow = makeWorkflow(definition);
+    const runId = await startWorkflowExecution(
+      workflow,
+      { items: agentItems.slice(0, 2) },
+      registry,
+    );
+    expect(foreachChildren(runId)).toHaveLength(2);
+
+    // Reset to a pre-checkpoint world: no children, parent failed and retry-due,
+    // and a persisted context WITHOUT the walkGraph-hydrated `run` key.
+    for (const child of foreachChildren(runId)) {
+      db.getDb().prepare("DELETE FROM agent_tasks WHERE workflowRunStepId = ?").run(child.id);
+      db.getDb().prepare("DELETE FROM workflow_run_steps WHERE id = ?").run(child.id);
+    }
+    const parent = stepByNodeId(runId, "reflect")!;
+    db.updateWorkflowRunStep(parent.id, {
+      status: "failed",
+      error: "transient dispatch failure",
+      nextRetryAt: new Date(Date.now() - 1000).toISOString(),
+    });
+    db.updateWorkflowRun(runId, {
+      status: "failed",
+      context: { trigger: { items: agentItems.slice(0, 2) } },
+    });
+
+    try {
+      startRetryPoller(registry, 10);
+      await waitFor(() => foreachChildren(runId).length === 2);
+    } finally {
+      stopRetryPoller();
+    }
+    const redispatched = db
+      .getDb()
+      .prepare(
+        "SELECT t.task FROM agent_tasks t JOIN workflow_run_steps s ON s.id = t.workflowRunStepId WHERE s.runId = ?",
+      )
+      .all(runId) as Array<{ task: string }>;
+    expect(redispatched).toHaveLength(2);
+    for (const row of redispatched) {
+      expect(row.task).toContain(`RetryRun ${runId}`);
+    }
+  });
+
+  test("a grandfathered hash id can stay a normal node but never become a foreach parent", () => {
+    const foreachWithHashId = {
+      nodes: [
+        {
+          id: "legacy#fan",
+          type: "foreach",
+          config: {
+            over: [],
+            itemKey: "id",
+            body: { type: "agent-task", config: { template: "Reflect" } },
+          },
+        },
+      ],
+    };
+    const asForeach = validateDefinition(foreachWithHashId, undefined, {
+      legacyNodeIds: new Set(["legacy#fan"]),
+    });
+    expect(asForeach.valid).toBe(false);
+    expect(
+      asForeach.errors.some((error) => error.includes('cannot be a foreach: its id contains "#"')),
+    ).toBe(true);
+
+    // The same grandfathered id stays editable as a NORMAL node.
+    const asRecord = validateDefinition(
+      { nodes: [{ id: "legacy#fan", type: "record", config: { message: "ok" } }] },
+      undefined,
+      { legacyNodeIds: new Set(["legacy#fan"]) },
+    );
+    expect(asRecord.valid).toBe(true);
+  });
+
   test("all child rows are materialized before any child task is dispatched", async () => {
     // A real agent can complete an early child while later children are still
     // being set up; the join must never observe a partial child set. The

--- a/src/tests/workflow-foreach.test.ts
+++ b/src/tests/workflow-foreach.test.ts
@@ -1,0 +1,511 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { unlink } from "node:fs/promises";
+import { z } from "zod";
+import * as db from "../be/db";
+import {
+  closeDb,
+  completeTask,
+  createAgent,
+  createWorkflow,
+  failTask,
+  getTaskByWorkflowRunStepId,
+  getWorkflowRun,
+  getWorkflowRunStepsByRunId,
+  initDb,
+} from "../be/db";
+import type { Workflow, WorkflowDefinition } from "../types";
+import { validateDefinition } from "../workflows/definition";
+import { startWorkflowExecution, walkGraph } from "../workflows/engine";
+import { InProcessEventBus } from "../workflows/event-bus";
+import { AgentTaskExecutor } from "../workflows/executors/agent-task";
+import {
+  BaseExecutor,
+  type ExecutorDependencies,
+  type ExecutorResult,
+} from "../workflows/executors/base";
+import { ForeachExecutor } from "../workflows/executors/foreach";
+import { ExecutorRegistry } from "../workflows/executors/registry";
+import { recoverIncompleteRuns } from "../workflows/recovery";
+import {
+  cancelWorkflowRun,
+  retryFailedRun,
+  setupWorkflowResumeListener,
+} from "../workflows/resume";
+import { interpolate } from "../workflows/template";
+
+const TEST_DB_PATH = "./test-workflow-foreach.sqlite";
+
+class RecordExecutor extends BaseExecutor<
+  typeof RecordExecutor.configSchema,
+  typeof RecordExecutor.outputSchema
+> {
+  static readonly configSchema = z.object({ message: z.string() });
+  static readonly outputSchema = z.object({ message: z.string() });
+
+  readonly type = "record";
+  readonly mode = "instant" as const;
+  readonly configSchema = RecordExecutor.configSchema;
+  readonly outputSchema = RecordExecutor.outputSchema;
+
+  protected async execute(
+    config: z.infer<typeof RecordExecutor.configSchema>,
+  ): Promise<ExecutorResult<z.infer<typeof RecordExecutor.outputSchema>>> {
+    return { status: "success", output: { message: config.message } };
+  }
+}
+
+let agentItems: Array<{ id: string; name: string }>;
+
+beforeAll(async () => {
+  await removeDbFiles();
+  initDb(TEST_DB_PATH);
+  agentItems = ["Ada", "Babbage", "Curie"].map((name) => {
+    const agent = createAgent({ name, status: "idle" });
+    return { id: agent.id, name };
+  });
+});
+
+afterAll(async () => {
+  closeDb();
+  await removeDbFiles();
+});
+
+describe("workflow foreach", () => {
+  test("waits for all children, preserves item order, and runs the successor", async () => {
+    const { bus, registry } = createRegistry(true);
+    const workflow = makeWorkflow(foreachDefinition());
+    const runId = await startWorkflowExecution(workflow, { items: agentItems }, registry);
+
+    const childSteps = foreachChildren(runId);
+    expect(childSteps).toHaveLength(3);
+    expect(
+      childSteps.map((step) => getTaskByWorkflowRunStepId(step.id)?.task.split("\n").at(-1)),
+    ).toEqual(["Reflect Ada at 0", "Reflect Babbage at 1", "Reflect Curie at 2"]);
+
+    await completeChild(runId, childSteps[0]!.id, "first", bus);
+    expect(getWorkflowRun(runId)?.status).not.toBe("completed");
+    expect(stepByNodeId(runId, "after")).toBeUndefined();
+
+    await completeChild(runId, childSteps[1]!.id, "second", bus);
+    expect(getWorkflowRun(runId)?.status).not.toBe("completed");
+    expect(stepByNodeId(runId, "after")).toBeUndefined();
+
+    await completeChild(runId, childSteps[2]!.id, "third", bus);
+    await waitFor(() => getWorkflowRun(runId)?.status === "completed");
+
+    expect(stepByNodeId(runId, "after")?.status).toBe("completed");
+    const aggregate = getContext(runId).reflect as {
+      results: Array<{ itemKey: string; output: { taskOutput: string } }>;
+      okCount: number;
+      failedCount: number;
+    };
+    expect(aggregate.results.map((result) => result.itemKey)).toEqual(
+      agentItems.map((item) => item.id),
+    );
+    expect(aggregate.results.map((result) => result.output.taskOutput)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+    expect(aggregate.okCount).toBe(3);
+    expect(aggregate.failedCount).toBe(0);
+    expect(Object.keys(getContext(runId)).some((key) => key.startsWith("reflect#"))).toBe(false);
+  });
+
+  test("empty over completes synchronously and still runs the successor", async () => {
+    const { registry } = createRegistry(false);
+    const workflow = makeWorkflow(foreachDefinition());
+    const runId = await startWorkflowExecution(workflow, { items: [] }, registry);
+
+    expect(getWorkflowRun(runId)?.status).toBe("completed");
+    expect(foreachChildren(runId)).toHaveLength(0);
+    expect(stepByNodeId(runId, "after")?.status).toBe("completed");
+    expect(getContext(runId).reflect).toEqual({ results: [], okCount: 0, failedCount: 0 });
+  });
+
+  test("onNodeFailure continue aggregates a failed child and completes", async () => {
+    const { bus, registry } = createRegistry(true);
+    const items = agentItems.slice(0, 2);
+    const workflow = makeWorkflow({
+      ...foreachDefinition(),
+      onNodeFailure: "continue",
+    });
+    const runId = await startWorkflowExecution(workflow, { items }, registry);
+    const children = foreachChildren(runId);
+
+    await completeChild(runId, children[0]!.id, "ok", bus);
+    await failChild(runId, children[1]!.id, "reflection broke", bus);
+    await waitFor(() => getWorkflowRun(runId)?.status === "completed");
+
+    const aggregate = getContext(runId).reflect as {
+      results: Array<{ status: string; output: { taskOutput: string } }>;
+      okCount: number;
+      failedCount: number;
+    };
+    expect(aggregate.okCount).toBe(1);
+    expect(aggregate.failedCount).toBe(1);
+    expect(aggregate.results[1]?.status).toBe("failed");
+    expect(aggregate.results[1]?.output.taskOutput).toStartWith("[FAILED: reflection broke]");
+    expect(stepByNodeId(runId, "after")?.status).toBe("completed");
+  });
+
+  test("re-walk after partial completion does not duplicate children or tasks", async () => {
+    const { bus, registry } = createRegistry(true);
+    const definition = foreachDefinition();
+    const workflow = makeWorkflow(definition);
+    const runId = await startWorkflowExecution(workflow, { items: agentItems }, registry);
+    const children = foreachChildren(runId);
+
+    await completeChild(runId, children[0]!.id, "done", bus);
+    const completedBefore = stepById(runId, children[0]!.id)!;
+    const parentBefore = stepByNodeId(runId, "reflect")!;
+    db.updateWorkflowRunStep(parentBefore.id, { status: "running" });
+    const ctx = getContext(runId);
+    await walkGraph(definition, runId, ctx, [definition.nodes[0]!], registry, workflow.id);
+
+    const childrenAfterRewalk = foreachChildren(runId);
+    expect(childrenAfterRewalk).toHaveLength(3);
+    expect(childrenAfterRewalk.map((step) => step.id)).toEqual(children.map((step) => step.id));
+    expect(taskCountForForeachChildren(runId)).toBe(3);
+    const completedAfter = stepById(runId, children[0]!.id)!;
+    expect(completedAfter.output).toEqual(completedBefore.output);
+    expect(completedAfter.finishedAt).toBe(completedBefore.finishedAt);
+    expect(
+      getWorkflowRunStepsByRunId(runId).filter((step) => step.nodeId === "reflect"),
+    ).toHaveLength(1);
+  });
+
+  test("recovery closes a join when tasks completed while listeners were down", async () => {
+    const { registry } = createRegistry(false);
+    const workflow = makeWorkflow(foreachDefinition());
+    const runId = await startWorkflowExecution(workflow, { items: agentItems }, registry);
+
+    const taskIds: string[] = [];
+    for (const [index, step] of foreachChildren(runId).entries()) {
+      const task = getTaskByWorkflowRunStepId(step.id)!;
+      taskIds.push(task.id);
+      completeTask(task.id, JSON.stringify({ recovered: index }));
+    }
+
+    const recovered = await recoverIncompleteRuns(registry);
+    expect(recovered).toBe(3);
+    expect(getWorkflowRun(runId)?.status).toBe("completed");
+    expect(stepByNodeId(runId, "after")?.status).toBe("completed");
+    const aggregate = getContext(runId).reflect as {
+      results: Array<{ output: { taskId: string } }>;
+    };
+    expect(aggregate.results).toHaveLength(3);
+    expect(aggregate.results.map((result) => result.output.taskId)).toEqual(taskIds);
+  });
+
+  test("retryFailedRun resolves a failed synthetic child to its foreach parent", async () => {
+    const { bus, registry } = createRegistry(true);
+    const items = agentItems.slice(0, 1);
+    const workflow = makeWorkflow(foreachDefinition());
+    const runId = await startWorkflowExecution(workflow, { items }, registry);
+    const child = foreachChildren(runId)[0]!;
+    const originalTask = getTaskByWorkflowRunStepId(child.id)!;
+
+    await failChild(runId, child.id, "retry me", bus);
+    await waitFor(() => getWorkflowRun(runId)?.status === "failed");
+
+    await expect(retryFailedRun(runId, registry)).resolves.toBeUndefined();
+    const replacementTask = getTaskByWorkflowRunStepId(child.id);
+    expect(replacementTask).not.toBeNull();
+    expect(replacementTask?.id).not.toBe(originalTask.id);
+    expect(getWorkflowRun(runId)?.status).toBe("waiting");
+
+    await completeChild(runId, child.id, "retried", bus);
+    await waitFor(() => getWorkflowRun(runId)?.status === "completed");
+    expect(stepByNodeId(runId, "after")?.status).toBe("completed");
+    expect((getContext(runId).reflect as { okCount: number }).okCount).toBe(1);
+    expect(stepById(runId, child.id)?.error).toBeUndefined();
+    expect(getWorkflowRun(runId)?.error).toBeUndefined();
+  });
+
+  test("late task cancellation cannot resurrect a cancelled run", async () => {
+    const { bus, registry } = createRegistry(true);
+    const workflow = makeWorkflow({ ...foreachDefinition(), onNodeFailure: "continue" });
+    const runId = await startWorkflowExecution(
+      workflow,
+      { items: agentItems.slice(0, 1) },
+      registry,
+    );
+    const child = foreachChildren(runId)[0]!;
+    const task = getTaskByWorkflowRunStepId(child.id)!;
+
+    cancelWorkflowRun(runId, "stop now");
+    bus.emit("task.cancelled", {
+      taskId: task.id,
+      workflowRunId: runId,
+      workflowRunStepId: child.id,
+    });
+    await Bun.sleep(10);
+
+    expect(getWorkflowRun(runId)?.status).toBe("cancelled");
+    expect(stepById(runId, child.id)?.status).toBe("cancelled");
+    expect(stepByNodeId(runId, "after")).toBeUndefined();
+  });
+
+  test("recovery continues an offline failed child and closes the foreach join", async () => {
+    const { registry } = createRegistry(false);
+    const workflow = makeWorkflow({ ...foreachDefinition(), onNodeFailure: "continue" });
+    const runId = await startWorkflowExecution(workflow, { items: agentItems }, registry);
+    const children = foreachChildren(runId);
+
+    const failedTask = getTaskByWorkflowRunStepId(children[0]!.id)!;
+    failTask(failedTask.id, "offline failure");
+    for (const [index, child] of children.slice(1).entries()) {
+      const task = getTaskByWorkflowRunStepId(child.id)!;
+      completeTask(task.id, `offline-${index}`);
+    }
+
+    const recovered = await recoverIncompleteRuns(registry);
+    expect(recovered).toBe(3);
+    expect(getWorkflowRun(runId)?.status).toBe("completed");
+    expect(stepByNodeId(runId, "after")?.status).toBe("completed");
+    const aggregate = getContext(runId).reflect as {
+      results: Array<{ status: string; output: { taskOutput: string } }>;
+      okCount: number;
+      failedCount: number;
+    };
+    expect(aggregate.okCount).toBe(2);
+    expect(aggregate.failedCount).toBe(1);
+    expect(aggregate.results[0]?.status).toBe("failed");
+    expect(aggregate.results[0]?.output.taskOutput).toStartWith(
+      "[FAILED: Task failed (recovered)]",
+    );
+  });
+
+  test("failed recovery rows prevent completed siblings from resurrecting a fail-fast run", async () => {
+    const { registry } = createRegistry(false);
+    const workflow = makeWorkflow(foreachDefinition());
+    const runId = await startWorkflowExecution(
+      workflow,
+      { items: agentItems.slice(0, 2) },
+      registry,
+    );
+    const children = foreachChildren(runId);
+    failTask(getTaskByWorkflowRunStepId(children[0]!.id)!.id, "offline failure");
+    completeTask(getTaskByWorkflowRunStepId(children[1]!.id)!.id, "offline success");
+
+    const recovered = await recoverIncompleteRuns(registry);
+    expect(recovered).toBe(1);
+    expect(getWorkflowRun(runId)?.status).toBe("failed");
+    expect(stepById(runId, children[0]!.id)?.status).toBe("failed");
+    expect(stepById(runId, children[1]!.id)?.status).toBe("waiting");
+    expect(stepByNodeId(runId, "after")).toBeUndefined();
+  });
+
+  test("foreach fails before dispatch when its children exceed the run step limit", async () => {
+    const originalLimit = process.env.WORKFLOW_MAX_STEPS_PER_RUN;
+    process.env.WORKFLOW_MAX_STEPS_PER_RUN = "3";
+    try {
+      const { registry } = createRegistry(false);
+      const workflow = makeWorkflow(foreachDefinition());
+      const runId = await startWorkflowExecution(workflow, { items: agentItems }, registry);
+
+      expect(getWorkflowRun(runId)?.status).toBe("failed");
+      expect(stepByNodeId(runId, "reflect")?.status).toBe("failed");
+      expect(stepByNodeId(runId, "reflect")?.error).toContain("WORKFLOW_MAX_STEPS_PER_RUN");
+      expect(foreachChildren(runId)).toHaveLength(0);
+      expect(taskCountForForeachChildren(runId)).toBe(0);
+    } finally {
+      if (originalLimit === undefined) {
+        delete process.env.WORKFLOW_MAX_STEPS_PER_RUN;
+      } else {
+        process.env.WORKFLOW_MAX_STEPS_PER_RUN = originalLimit;
+      }
+    }
+  });
+
+  test("definition validation rejects reserved hashes and foreach concurrency", () => {
+    const hashResult = validateDefinition({
+      nodes: [{ id: "reflect#bad", type: "record", config: { message: "bad" } }],
+    });
+    expect(hashResult.valid).toBe(false);
+    expect(hashResult.errors.some((error) => error.includes('reserved character "#"'))).toBe(true);
+
+    const concurrencyResult = validateDefinition({
+      nodes: [
+        {
+          id: "reflect",
+          type: "foreach",
+          config: {
+            over: [],
+            itemKey: "id",
+            concurrency: 2,
+            body: { type: "agent-task", config: { template: "Reflect" } },
+          },
+        },
+      ],
+    });
+    expect(concurrencyResult.valid).toBe(false);
+    expect(concurrencyResult.errors.some((error) => error.includes("not supported in v1"))).toBe(
+      true,
+    );
+  });
+
+  test("definition validation rejects foreach inside a cycle through a port edge", () => {
+    const result = validateDefinition({
+      nodes: [
+        { id: "start", type: "record", config: { message: "start" }, next: "reflect" },
+        {
+          id: "reflect",
+          type: "foreach",
+          config: {
+            over: [],
+            itemKey: "id",
+            body: { type: "agent-task", config: { template: "Reflect" } },
+          },
+          next: "loop",
+        },
+        {
+          id: "loop",
+          type: "record",
+          config: { message: "loop" },
+          next: { again: "reflect" },
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("foreach inside a loop is not supported in v1");
+  });
+});
+
+function createRegistry(withListener: boolean): {
+  bus: InProcessEventBus;
+  registry: ExecutorRegistry;
+} {
+  const bus = new InProcessEventBus();
+  const deps: ExecutorDependencies = {
+    db,
+    eventBus: bus,
+    interpolate: (template, ctx) => interpolate(template, ctx).result,
+  };
+  const registry = new ExecutorRegistry();
+  registry.register(new ForeachExecutor(deps));
+  registry.register(new AgentTaskExecutor(deps));
+  registry.register(new RecordExecutor(deps));
+  if (withListener) setupWorkflowResumeListener(bus, registry);
+  return { bus, registry };
+}
+
+function foreachDefinition(): WorkflowDefinition {
+  return {
+    nodes: [
+      {
+        id: "reflect",
+        type: "foreach",
+        config: {
+          over: "{{trigger.items}}",
+          itemKey: "id",
+          body: {
+            type: "agent-task",
+            config: {
+              agentId: "{{item.id}}",
+              template: "Reflect {{item.name}} at {{index}}",
+            },
+          },
+        },
+        next: "after",
+      },
+      {
+        id: "after",
+        type: "record",
+        inputs: { aggregate: "reflect" },
+        config: { message: "joined {{aggregate.okCount}}" },
+      },
+    ],
+  };
+}
+
+function makeWorkflow(definition: WorkflowDefinition): Workflow {
+  return createWorkflow({
+    name: `foreach-${crypto.randomUUID()}`,
+    definition,
+  });
+}
+
+function foreachChildren(runId: string) {
+  return getWorkflowRunStepsByRunId(runId).filter((step) => step.nodeId.startsWith("reflect#"));
+}
+
+function stepByNodeId(runId: string, nodeId: string) {
+  return getWorkflowRunStepsByRunId(runId).find((step) => step.nodeId === nodeId);
+}
+
+function taskCountForForeachChildren(runId: string): number {
+  return (
+    db
+      .getDb()
+      .prepare<{ count: number }, [string]>(
+        `SELECT COUNT(*) AS count
+         FROM agent_tasks at
+         JOIN workflow_run_steps wrs ON wrs.id = at.workflowRunStepId
+         WHERE wrs.runId = ? AND wrs.nodeId LIKE 'reflect#%'`,
+      )
+      .get(runId)?.count ?? 0
+  );
+}
+
+function getContext(runId: string): Record<string, unknown> {
+  return (getWorkflowRun(runId)?.context ?? {}) as Record<string, unknown>;
+}
+
+async function completeChild(
+  runId: string,
+  stepId: string,
+  output: string,
+  bus: InProcessEventBus,
+): Promise<void> {
+  const task = getTaskByWorkflowRunStepId(stepId)!;
+  completeTask(task.id, output);
+  bus.emit("task.completed", {
+    taskId: task.id,
+    output,
+    workflowRunId: runId,
+    workflowRunStepId: stepId,
+  });
+  await waitFor(() => stepById(runId, stepId)?.status === "completed");
+}
+
+async function failChild(
+  runId: string,
+  stepId: string,
+  reason: string,
+  bus: InProcessEventBus,
+): Promise<void> {
+  const task = getTaskByWorkflowRunStepId(stepId)!;
+  failTask(task.id, reason);
+  bus.emit("task.failed", {
+    taskId: task.id,
+    failureReason: reason,
+    workflowRunId: runId,
+    workflowRunStepId: stepId,
+  });
+  await waitFor(() => {
+    const status = stepById(runId, stepId)?.status;
+    return status === "completed" || status === "failed";
+  });
+}
+
+function stepById(runId: string, stepId: string) {
+  return getWorkflowRunStepsByRunId(runId).find((step) => step.id === stepId);
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await Bun.sleep(10);
+  }
+  throw new Error("Timed out waiting for workflow state");
+}
+
+async function removeDbFiles(): Promise<void> {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    await unlink(TEST_DB_PATH + suffix).catch(() => {});
+  }
+}

--- a/src/tools/workflows/create-workflow.ts
+++ b/src/tools/workflows/create-workflow.ts
@@ -35,6 +35,11 @@ export const registerCreateWorkflowTool = (server: McpServer) => {
         "- STRUCTURED OUTPUT: For agent-task nodes, put outputSchema inside 'config' to validate the agent's raw JSON output. " +
         "Node-level outputSchema validates the executor's return ({taskId, taskOutput}), which is different.\n" +
         "- Agent-task config: { template, outputSchema?, agentId?, tags?, priority?, dir?, vcsRepo?, model? }.\n" +
+        "- FOREACH NODE: type 'foreach' fans out one agent-task per item. Config: " +
+        "{ over: <array or exact {{input}} token>, itemKey: <property name>, body: { type: 'agent-task', config: {...} } }. " +
+        "The body config is interpolated once per item with {{item.*}} and {{index}}. Child steps use synthetic IDs " +
+        "'<foreachNodeId>#<itemKey>'; the parent waits for every child and exposes one aggregate result to successors. " +
+        "concurrency is not supported in v1; use definition-level onNodeFailure: 'continue' to aggregate failed children.\n" +
         "- TRIGGER SCHEMA: Optional 'triggerSchema' is a JSON-Schema object that validates incoming trigger payloads. " +
         "Supported keywords: type, required, properties, enum, const, items (recursive into arrays). " +
         "Other JSON-Schema keywords (oneOf/anyOf/$ref/pattern/format/additionalProperties) are silently ignored.\n" +

--- a/src/tools/workflows/patch-workflow-node.ts
+++ b/src/tools/workflows/patch-workflow-node.ts
@@ -11,7 +11,11 @@ import {
 } from "@/tools/utils";
 import { WorkflowNodePatchSchema } from "@/types";
 import { getExecutorRegistry } from "@/workflows";
-import { applyDefinitionPatch, validateDefinition } from "@/workflows/definition";
+import {
+  applyDefinitionPatch,
+  definitionNodeIds,
+  validateDefinition,
+} from "@/workflows/definition";
 import { snapshotWorkflow } from "@/workflows/version";
 
 export const registerPatchWorkflowNodeTool = (server: McpServer) => {
@@ -49,7 +53,9 @@ export const registerPatchWorkflowNodeTool = (server: McpServer) => {
           return toolErr(`Patch errors: ${msg}`);
         }
 
-        const validation = validateDefinition(patchResult.definition, getExecutorRegistry());
+        const validation = validateDefinition(patchResult.definition, getExecutorRegistry(), {
+          legacyNodeIds: definitionNodeIds(existing.definition),
+        });
         if (!validation.valid) {
           return toolErr(`Invalid definition: ${validation.errors.join("; ")}`);
         }

--- a/src/tools/workflows/patch-workflow.ts
+++ b/src/tools/workflows/patch-workflow.ts
@@ -13,7 +13,11 @@ import {
 import type { WorkflowPatch } from "@/types";
 import { AssetKeySchema, WorkflowNodePatchSchema } from "@/types";
 import { getExecutorRegistry } from "@/workflows";
-import { applyDefinitionPatch, validateDefinition } from "@/workflows/definition";
+import {
+  applyDefinitionPatch,
+  definitionNodeIds,
+  validateDefinition,
+} from "@/workflows/definition";
 import { snapshotWorkflow } from "@/workflows/version";
 
 export const registerPatchWorkflowTool = (server: McpServer) => {
@@ -99,7 +103,9 @@ export const registerPatchWorkflowTool = (server: McpServer) => {
           return toolErr(`Patch errors: ${msg}`);
         }
 
-        const validation = validateDefinition(patchResult.definition, getExecutorRegistry());
+        const validation = validateDefinition(patchResult.definition, getExecutorRegistry(), {
+          legacyNodeIds: definitionNodeIds(existing.definition),
+        });
         if (!validation.valid) {
           return toolErr(`Invalid definition: ${validation.errors.join("; ")}`);
         }

--- a/src/tools/workflows/update-workflow.ts
+++ b/src/tools/workflows/update-workflow.ts
@@ -18,7 +18,7 @@ import {
   WorkflowDefinitionSchema,
 } from "@/types";
 import { getExecutorRegistry } from "@/workflows";
-import { validateDefinition } from "@/workflows/definition";
+import { definitionNodeIds, validateDefinition } from "@/workflows/definition";
 import { snapshotWorkflow } from "@/workflows/version";
 
 export const registerUpdateWorkflowTool = (server: McpServer) => {
@@ -112,7 +112,9 @@ export const registerUpdateWorkflowTool = (server: McpServer) => {
 
         // Validate new definition if provided
         if (definition) {
-          const validation = validateDefinition(definition, getExecutorRegistry());
+          const validation = validateDefinition(definition, getExecutorRegistry(), {
+            legacyNodeIds: definitionNodeIds(existing.definition),
+          });
           if (!validation.valid) {
             return toolErr(`Invalid definition: ${validation.errors.join("; ")}`);
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1480,6 +1480,11 @@ export const ExecutorMetaSchema = z.object({
   workflowId: z.string().uuid(),
   dryRun: z.boolean().default(false),
   requestedByUserId: z.string().optional(),
+  // The node's declared-inputs interpolation context (aliases + builtins) as built
+  // by buildNodeInterpolationCtx. Executors that defer interpolation (foreach's
+  // per-item body pass) must use THIS — not the full run context — so deferred
+  // config obeys the same explicit-dataflow boundary as normal node config.
+  inputCtx: z.record(z.string(), z.unknown()).optional(),
 });
 export type ExecutorMeta = z.infer<typeof ExecutorMetaSchema>;
 

--- a/src/workflows/constants.ts
+++ b/src/workflows/constants.ts
@@ -1,0 +1,1 @@
+export const FAILED_TASK_OUTPUT_PREFIX = "[FAILED:";

--- a/src/workflows/definition.ts
+++ b/src/workflows/definition.ts
@@ -140,6 +140,15 @@ function containsInterpolationToken(value: unknown): boolean {
 }
 
 /**
+ * Node ids of a stored definition — passed to validateDefinition as
+ * `legacyNodeIds` by update/patch paths so ids that predate the reserved-`#`
+ * rule stay editable.
+ */
+export function definitionNodeIds(def: WorkflowDefinition): Set<string> {
+  return new Set(def.nodes.map((node) => node.id));
+}
+
+/**
  * Validate a workflow definition for structural correctness.
  *
  * Checks:
@@ -152,12 +161,17 @@ function containsInterpolationToken(value: unknown): boolean {
 export function validateDefinition(
   def: WorkflowDefinition,
   registry?: ExecutorRegistry,
+  options: { legacyNodeIds?: ReadonlySet<string> } = {},
 ): { valid: boolean; errors: string[] } {
   const errors: string[] = [];
   const nodeIds = new Set(def.nodes.map((n) => n.id));
 
   for (const node of def.nodes) {
-    if (node.id.includes("#")) {
+    // `#` is reserved for synthetic foreach child ids — but only for NEW or
+    // renamed nodes. Node ids were unrestricted before this rule, so update/patch
+    // paths pass the stored definition's ids (legacyNodeIds) to keep a workflow
+    // that already contains one editable instead of bricked.
+    if (node.id.includes("#") && !options.legacyNodeIds?.has(node.id)) {
       errors.push(`Node "${node.id}" contains reserved character "#"`);
     }
     if (node.type === "foreach") {

--- a/src/workflows/definition.ts
+++ b/src/workflows/definition.ts
@@ -156,6 +156,18 @@ export function validateDefinition(
   const errors: string[] = [];
   const nodeIds = new Set(def.nodes.map((n) => n.id));
 
+  for (const node of def.nodes) {
+    if (node.id.includes("#")) {
+      errors.push(`Node "${node.id}" contains reserved character "#"`);
+    }
+    if (node.type === "foreach") {
+      validateForeachNode(node, errors);
+      if (isUpstream(def, node.id, node.id)) {
+        errors.push("foreach inside a loop is not supported in v1");
+      }
+    }
+  }
+
   // 1. Check all next refs point to existing nodes
   for (const node of def.nodes) {
     if (!node.next) continue;
@@ -272,6 +284,47 @@ export function validateDefinition(
   }
 
   return { valid: errors.length === 0, errors };
+}
+
+function validateForeachNode(node: WorkflowNode, errors: string[]): void {
+  const config = node.config;
+  if (Object.hasOwn(config, "concurrency")) {
+    errors.push(`Node "${node.id}" foreach concurrency is not supported in v1`);
+  }
+
+  const over = config.over;
+  const isInterpolatedArray = typeof over === "string" && /^\{\{[^}]+\}\}$/.test(over.trim());
+  if (!Array.isArray(over) && !isInterpolatedArray) {
+    errors.push(
+      `Node "${node.id}" foreach config.over must be an array or one exact {{interpolation}} token`,
+    );
+  }
+
+  if (typeof config.itemKey !== "string" || config.itemKey.length === 0) {
+    errors.push(`Node "${node.id}" foreach config.itemKey must be a non-empty string`);
+  }
+
+  const body = config.body;
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    errors.push(`Node "${node.id}" foreach config.body must be an object`);
+    return;
+  }
+  const bodyRecord = body as Record<string, unknown>;
+  if (bodyRecord.type !== "agent-task") {
+    errors.push(`Node "${node.id}" foreach config.body.type must be "agent-task" in v1`);
+  }
+  if (
+    typeof bodyRecord.config !== "object" ||
+    bodyRecord.config === null ||
+    Array.isArray(bodyRecord.config)
+  ) {
+    errors.push(`Node "${node.id}" foreach config.body.config must be an object`);
+    return;
+  }
+  const bodyConfig = bodyRecord.config as Record<string, unknown>;
+  if (typeof bodyConfig.template !== "string") {
+    errors.push(`Node "${node.id}" foreach agent-task body.config.template must be a string`);
+  }
 }
 
 /**

--- a/src/workflows/definition.ts
+++ b/src/workflows/definition.ts
@@ -176,6 +176,14 @@ export function validateDefinition(
     }
     if (node.type === "foreach") {
       validateForeachNode(node, errors);
+      // A legacy `#` id may stay editable as a NORMAL node, but never as a foreach
+      // parent: its children would be `a#b#item`, and parseSyntheticNodeId splits on
+      // the FIRST `#`, so the join would resolve them to parent "a" and never close.
+      if (node.id.includes("#")) {
+        errors.push(
+          `Node "${node.id}" cannot be a foreach: its id contains "#", which is reserved for synthetic child ids`,
+        );
+      }
       if (isUpstream(def, node.id, node.id)) {
         errors.push("foreach inside a loop is not supported in v1");
       }

--- a/src/workflows/definition.ts
+++ b/src/workflows/definition.ts
@@ -264,7 +264,9 @@ export function validateDefinition(
       if (!sourceNodeId) continue;
 
       // Skip built-in context sources
-      if (sourceNodeId === "trigger" || sourceNodeId === "input") continue;
+      if (sourceNodeId === "trigger" || sourceNodeId === "input" || sourceNodeId === "run") {
+        continue;
+      }
 
       // Check source node exists
       if (!nodeIds.has(sourceNodeId)) {
@@ -290,6 +292,17 @@ function validateForeachNode(node: WorkflowNode, errors: string[]): void {
   const config = node.config;
   if (Object.hasOwn(config, "concurrency")) {
     errors.push(`Node "${node.id}" foreach concurrency is not supported in v1`);
+  }
+
+  // The asynchronous join (joinForeach) checkpoints the aggregate and routes
+  // successors without re-entering executeStep, so node-level outputSchema /
+  // validation would be silently skipped on every async completion. Reject at
+  // authoring time rather than half-enforcing. The per-child agent-task
+  // body.config.outputSchema is unaffected.
+  if (node.outputSchema !== undefined || node.validation !== undefined) {
+    errors.push(
+      `Node "${node.id}" foreach node-level outputSchema/validation is not supported in v1`,
+    );
   }
 
   const over = config.over;

--- a/src/workflows/definition.ts
+++ b/src/workflows/definition.ts
@@ -179,6 +179,19 @@ export function validateDefinition(
       if (isUpstream(def, node.id, node.id)) {
         errors.push("foreach inside a loop is not supported in v1");
       }
+      // Synthetic children are named `<foreachId>#<itemKey>`. A (legacy,
+      // grandfathered) node whose id starts with that prefix would be
+      // indistinguishable from a child — resolveForeachParent would classify
+      // both, corrupting the join and routing — so the foreach itself is
+      // rejected when such a sibling exists.
+      const collidingSibling = def.nodes.find(
+        (other) => other.id !== node.id && other.id.startsWith(`${node.id}#`),
+      );
+      if (collidingSibling) {
+        errors.push(
+          `Node "${node.id}" cannot be a foreach: node "${collidingSibling.id}" collides with its synthetic child id space ("${node.id}#…")`,
+        );
+      }
     }
   }
 
@@ -244,26 +257,25 @@ export function validateDefinition(
         continue;
       }
 
-      const configResult = registry.get(node.type).configSchema.safeParse(node.config);
-      if (!configResult.success) {
-        for (const issue of configResult.error.issues) {
-          const issuePath = issue.path.map(String);
-          const path = ["config", ...issuePath].join(".");
-          let value: unknown = node.config;
-          for (const segment of issue.path) {
-            if (value === null || typeof value !== "object") {
-              value = undefined;
-              break;
-            }
-            value = (value as Record<PropertyKey, unknown>)[segment];
-          }
-          // Exact interpolation tokens can resolve to non-string values at
-          // execution time, so defer only those dynamic fields to the same
-          // executor schema after interpolation. Static values still fail now.
-          if (containsInterpolationToken(value)) continue;
-          const renderedValue = value === undefined ? "undefined" : JSON.stringify(value);
-          errors.push(
-            `Node "${node.id}" (${node.type}) ${path} has invalid value ${renderedValue}: ${issue.message}`,
+      reportStaticConfigIssues(node, registry.get(node.type).configSchema, node.config, errors);
+
+      // A foreach body is executed by the agent-task executor per item — hold its
+      // static config to the same schema a top-level agent-task node gets, so an
+      // invalid field (priority: 101, tags: "x") fails at authoring instead of
+      // after the fan-out materialized. Interpolated fields defer as usual.
+      if (node.type === "foreach" && registry.has("agent-task")) {
+        const body = node.config.body;
+        const bodyConfig =
+          typeof body === "object" && body !== null && !Array.isArray(body)
+            ? (body as Record<string, unknown>).config
+            : undefined;
+        if (typeof bodyConfig === "object" && bodyConfig !== null && !Array.isArray(bodyConfig)) {
+          reportStaticConfigIssues(
+            node,
+            registry.get("agent-task").configSchema,
+            bodyConfig,
+            errors,
+            "config.body.config",
           );
         }
       }
@@ -300,6 +312,40 @@ export function validateDefinition(
   }
 
   return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Report schema issues for the statically-known parts of a config object.
+ * Fields containing interpolation tokens defer to the same executor schema
+ * after interpolation; static values fail at authoring time.
+ */
+function reportStaticConfigIssues(
+  node: WorkflowNode,
+  schema: { safeParse: (value: unknown) => { success: boolean; error?: { issues: unknown[] } } },
+  config: unknown,
+  errors: string[],
+  pathPrefix = "config",
+): void {
+  const result = schema.safeParse(config);
+  if (result.success) return;
+  for (const rawIssue of result.error?.issues ?? []) {
+    const issue = rawIssue as { path: PropertyKey[]; message: string };
+    const issuePath = issue.path.map(String);
+    const path = [pathPrefix, ...issuePath].join(".");
+    let value: unknown = config;
+    for (const segment of issue.path) {
+      if (value === null || typeof value !== "object") {
+        value = undefined;
+        break;
+      }
+      value = (value as Record<PropertyKey, unknown>)[segment];
+    }
+    if (containsInterpolationToken(value)) continue;
+    const renderedValue = value === undefined ? "undefined" : JSON.stringify(value);
+    errors.push(
+      `Node "${node.id}" (${node.type}) ${path} has invalid value ${renderedValue}: ${issue.message}`,
+    );
+  }
 }
 
 function validateForeachNode(node: WorkflowNode, errors: string[]): void {

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -17,8 +17,10 @@ import { shouldSkipCooldown } from "./cooldown";
 import { findEntryNodes, getNextTargets, getSuccessors } from "./definition";
 import type { AsyncExecutorResult } from "./executors/base";
 import type { ExecutorRegistry } from "./executors/registry";
+import { FOREACH_TERMINAL_STEP_STATUSES, resolveForeachParent } from "./foreach-join";
 import { getSecretInputKeys, redactSecretsForStorage, resolveInputs } from "./input";
 import { validateJsonSchema } from "./json-schema-validator";
+import { getMaxWorkflowStepsPerRun } from "./limits";
 import { deepInterpolate } from "./template";
 import { runStepValidation, type ValidationRunResult } from "./validation";
 
@@ -29,9 +31,6 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 // limits. Functions let a config reload take effect without a restart.
 function maxIterations(): number {
   return Number(process.env.WORKFLOW_MAX_ITERATIONS) || 100;
-}
-function maxStepsPerRun(): number {
-  return Number(process.env.WORKFLOW_MAX_STEPS_PER_RUN) || 500;
 }
 
 export interface WorkflowExecutionOptions {
@@ -174,6 +173,10 @@ export async function walkGraph(
   // multiple completed steps from different iterations).
   if (completedNodeIds.size > 0) {
     for (const nodeId of completedNodeIds) {
+      // Synthetic foreach children persist their own step output for the join,
+      // but only the parent aggregate belongs in workflow context or routing.
+      if (resolveForeachParent(def, nodeId)) continue;
+
       const step = getLatestStepForNode(runId, nodeId);
       if (step?.output !== undefined) {
         // Bug 5 fix: Validate stored output against executor schema on recovery
@@ -207,10 +210,10 @@ export async function walkGraph(
   // unbounded resources. Checked here so it covers initial walks AND async
   // resumes (resumeFromTaskCompletion, handleTaskFailure, retry-poller).
   const allSteps = getWorkflowRunStepsByRunId(runId);
-  if (allSteps.length >= maxStepsPerRun()) {
+  if (allSteps.length >= getMaxWorkflowStepsPerRun()) {
     updateWorkflowRun(runId, {
       status: "failed",
-      error: `Circuit breaker: run exceeded ${maxStepsPerRun()} total steps (WORKFLOW_MAX_STEPS_PER_RUN)`,
+      error: `Circuit breaker: run exceeded ${getMaxWorkflowStepsPerRun()} total steps (WORKFLOW_MAX_STEPS_PER_RUN)`,
       finishedAt: new Date().toISOString(),
     });
     return;
@@ -449,17 +452,25 @@ async function executeStep(
   // references) don't leak through `get-workflow-run` or any other reader of
   // the `workflow_run_steps` table. The live `ctx` is untouched — executors
   // still see real values.
-  const stepId = crypto.randomUUID();
-  createWorkflowRunStep({
-    id: stepId,
-    runId,
-    nodeId: node.id,
-    nodeType: node.type,
-    input: redactSecretsForStorage(ctx, secretKeys),
-  });
+  const latestForeachStep =
+    node.type === "foreach" ? getLatestStepForNode(runId, node.id) : undefined;
+  const reusableForeachStep =
+    latestForeachStep && !FOREACH_TERMINAL_STEP_STATUSES.has(latestForeachStep.status)
+      ? latestForeachStep
+      : undefined;
+  const stepId = reusableForeachStep?.id ?? crypto.randomUUID();
+  if (!reusableForeachStep) {
+    createWorkflowRunStep({
+      id: stepId,
+      runId,
+      nodeId: node.id,
+      nodeType: node.type,
+      input: redactSecretsForStorage(ctx, secretKeys),
+    });
 
-  // Set idempotency key
-  updateWorkflowRunStep(stepId, { idempotencyKey });
+    // Set idempotency key
+    updateWorkflowRunStep(stepId, { idempotencyKey });
+  }
 
   // 3. Get executor
   const executor = registry.get(node.type);
@@ -738,6 +749,23 @@ export function interpolateNodeConfig(
   node: Pick<WorkflowNode, "type" | "config">,
   interpolationCtx: Record<string, unknown>,
 ): { value: unknown; unresolved: string[] } {
+  if (node.type === "foreach" && Object.hasOwn(node.config, "over")) {
+    const { over, body, ...configWithoutOverAndBody } = node.config;
+    const configResult = deepInterpolate(configWithoutOverAndBody, interpolationCtx);
+    const overResult = deepInterpolate(over, interpolationCtx, { preserveRawTokens: true });
+
+    return {
+      value: {
+        ...(configResult.value as Record<string, unknown>),
+        over: overResult.value,
+        // {{item.*}} and {{index}} do not exist until the foreach executor
+        // materializes a child, so preserve the body for that per-item pass.
+        body,
+      },
+      unresolved: [...configResult.unresolved, ...overResult.unresolved],
+    };
+  }
+
   if (node.type !== "swarm-script" || !Object.hasOwn(node.config, "args")) {
     return deepInterpolate(node.config, interpolationCtx);
   }

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -483,35 +483,7 @@ async function executeStep(
   const executor = registry.get(node.type);
 
   // 3b. Build local interpolation context from explicit inputs mapping
-  let interpolationCtx: Record<string, unknown>;
-  if (node.inputs) {
-    interpolationCtx = {};
-    // Always include built-in sources
-    if (ctx.trigger !== undefined) interpolationCtx.trigger = ctx.trigger;
-    if (ctx.input !== undefined) interpolationCtx.input = ctx.input;
-    if (ctx.workflow !== undefined) interpolationCtx.workflow = ctx.workflow;
-    if (ctx.swarm !== undefined) interpolationCtx.swarm = ctx.swarm;
-    // Resolve declared inputs
-    for (const [localName, sourcePath] of Object.entries(node.inputs)) {
-      const keys = sourcePath.split(".");
-      let value: unknown = ctx;
-      for (const key of keys) {
-        if (value == null || typeof value !== "object") {
-          value = undefined;
-          break;
-        }
-        value = (value as Record<string, unknown>)[key];
-      }
-      interpolationCtx[localName] = value;
-    }
-  } else {
-    // No inputs declared — only built-in sources available
-    interpolationCtx = {};
-    if (ctx.trigger !== undefined) interpolationCtx.trigger = ctx.trigger;
-    if (ctx.input !== undefined) interpolationCtx.input = ctx.input;
-    if (ctx.workflow !== undefined) interpolationCtx.workflow = ctx.workflow;
-    if (ctx.swarm !== undefined) interpolationCtx.swarm = ctx.swarm;
-  }
+  const interpolationCtx = buildNodeInterpolationCtx(node, ctx);
 
   // 3c. Validate resolved inputs against inputSchema if defined
   if (node.inputSchema) {
@@ -548,6 +520,7 @@ async function executeStep(
     workflowId: workflowId || "",
     dryRun: false,
     requestedByUserId: options.requestedByUserId,
+    inputCtx: interpolationCtx,
   };
 
   // Inline script nodes historically expose their wall-clock budget as
@@ -750,6 +723,41 @@ export function findReadyNodes(
     }
     return true;
   });
+}
+
+/**
+ * Build a node's interpolation context: the built-in sources plus its declared
+ * `inputs` aliases resolved against the run context. This is THE dataflow
+ * boundary for node config — every path that interpolates a node's config
+ * (initial execution AND the retry poller) must resolve aliases through this,
+ * or `{{alias}}` tokens silently resolve to empty strings on that path.
+ */
+export function buildNodeInterpolationCtx(
+  node: Pick<WorkflowNode, "inputs">,
+  ctx: Record<string, unknown>,
+): Record<string, unknown> {
+  const interpolationCtx: Record<string, unknown> = {};
+  // Always include built-in sources
+  if (ctx.trigger !== undefined) interpolationCtx.trigger = ctx.trigger;
+  if (ctx.input !== undefined) interpolationCtx.input = ctx.input;
+  if (ctx.workflow !== undefined) interpolationCtx.workflow = ctx.workflow;
+  if (ctx.swarm !== undefined) interpolationCtx.swarm = ctx.swarm;
+  if (ctx.run !== undefined) interpolationCtx.run = ctx.run;
+  if (!node.inputs) return interpolationCtx;
+  // Resolve declared inputs
+  for (const [localName, sourcePath] of Object.entries(node.inputs)) {
+    const keys = sourcePath.split(".");
+    let value: unknown = ctx;
+    for (const key of keys) {
+      if (value == null || typeof value !== "object") {
+        value = undefined;
+        break;
+      }
+      value = (value as Record<string, unknown>)[key];
+    }
+    interpolationCtx[localName] = value;
+  }
+  return interpolationCtx;
 }
 
 export function interpolateNodeConfig(

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -161,6 +161,13 @@ export async function walkGraph(
   options: WorkflowExecutionOptions = {},
 ): Promise<void> {
   let nodeExecutionCount = 0;
+  // `run.id` is a context builtin (like `trigger` / `input`) so nodes can reference
+  // their own run — e.g. an audit/receipt node correlating its output with the run
+  // that produced it. Hydrated here so every path (initial walk, resume, retry,
+  // recovery) resolves it even when the stored context predates the builtin.
+  if (!("run" in ctx)) {
+    ctx.run = { id: runId };
+  }
   const completedNodeIds = new Set(getCompletedStepNodeIds(runId));
 
   // Track active edges: "sourceId→targetId" — only edges on actually-taken

--- a/src/workflows/executors/foreach.ts
+++ b/src/workflows/executors/foreach.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { ExecutorMeta } from "../../types";
 import { deepInterpolate } from "../../utils/template";
+import { getSuccessors } from "../definition";
 import {
   buildForeachAggregate,
   FOREACH_TERMINAL_STEP_STATUSES,
@@ -87,14 +88,22 @@ export class ForeachExecutor extends BaseExecutor<
       ({ itemKey }) => !childStepsByNodeId.has(`${meta.nodeId}#${itemKey}`),
     ).length;
     const maxSteps = getMaxWorkflowStepsPerRun();
-    // `>=` (not `>`): walkGraph's circuit breaker rejects any post-join walk once
-    // allSteps.length >= maxSteps, so a fan-out that lands exactly on the cap would
-    // spend all its child work and then fail routing the successor. Reserve that
-    // headroom here, before any child is dispatched.
-    if (childCountToCreate > 0 && runSteps.length + childCountToCreate >= maxSteps) {
+    // walkGraph's circuit breaker rejects any post-join walk once allSteps.length
+    // >= maxSteps, so a fan-out with a successor that lands exactly on the cap would
+    // spend all its child work and then fail routing. Reserve that headroom here,
+    // before any child is dispatched — but only when there IS a post-join walk: a
+    // terminal foreach (no successors) just closes the join and finalizes, so an
+    // exact-cap fan-out is allowed there.
+    const workflow = this.deps.db.getWorkflow(meta.workflowId);
+    const hasSuccessors = workflow
+      ? getSuccessors(workflow.definition, meta.nodeId).length > 0
+      : true;
+    const totalSteps = runSteps.length + childCountToCreate;
+    const capBreached = hasSuccessors ? totalSteps >= maxSteps : totalSteps > maxSteps;
+    if (childCountToCreate > 0 && capBreached) {
       return {
         status: "failed",
-        error: `foreach would reach ${maxSteps} total steps (WORKFLOW_MAX_STEPS_PER_RUN): ${runSteps.length} existing + ${childCountToCreate} children leaves no room for the post-join walk`,
+        error: `foreach would reach ${maxSteps} total steps (WORKFLOW_MAX_STEPS_PER_RUN): ${runSteps.length} existing + ${childCountToCreate} children${hasSuccessors ? " leaves no room for the post-join walk" : " exceeds the per-run cap"}`,
       };
     }
 

--- a/src/workflows/executors/foreach.ts
+++ b/src/workflows/executors/foreach.ts
@@ -1,0 +1,188 @@
+import { z } from "zod";
+import type { ExecutorMeta } from "../../types";
+import { deepInterpolate } from "../../utils/template";
+import {
+  buildForeachAggregate,
+  FOREACH_TERMINAL_STEP_STATUSES,
+  parseSyntheticNodeId,
+} from "../foreach-join";
+import { getMaxWorkflowStepsPerRun } from "../limits";
+import { AgentTaskExecutor } from "./agent-task";
+import type { AsyncExecutorResult, ExecutorResult } from "./base";
+import { BaseExecutor } from "./base";
+
+const ForeachBodySchema = z.object({
+  type: z.literal("agent-task"),
+  config: z.record(z.string(), z.unknown()),
+});
+
+export const ForeachConfigSchema = z.object({
+  over: z.array(z.record(z.string(), z.unknown())),
+  itemKey: z.string().min(1),
+  body: ForeachBodySchema,
+  concurrency: z.never().optional(),
+});
+
+const ForeachResultSchema = z.object({
+  itemKey: z.string(),
+  status: z.enum(["completed", "failed", "cancelled", "skipped"]),
+  output: z.unknown().optional(),
+});
+
+export const ForeachOutputSchema = z.object({
+  results: z.array(ForeachResultSchema),
+  okCount: z.number().int().nonnegative(),
+  failedCount: z.number().int().nonnegative(),
+});
+
+export type ForeachOutput = z.infer<typeof ForeachOutputSchema>;
+
+export class ForeachExecutor extends BaseExecutor<
+  typeof ForeachConfigSchema,
+  typeof ForeachOutputSchema
+> {
+  readonly type = "foreach";
+  readonly mode = "async" as const;
+  readonly configSchema = ForeachConfigSchema;
+  readonly outputSchema = ForeachOutputSchema;
+
+  protected async execute(
+    config: z.infer<typeof ForeachConfigSchema>,
+    context: Readonly<Record<string, unknown>>,
+    meta: ExecutorMeta,
+  ): Promise<ExecutorResult<ForeachOutput>> {
+    if (config.over.length === 0) {
+      return {
+        status: "success",
+        output: { results: [], okCount: 0, failedCount: 0 },
+      };
+    }
+
+    const items = config.over.map((item, index) => {
+      const rawItemKey = item[config.itemKey];
+      if (typeof rawItemKey !== "string" || rawItemKey.length === 0) {
+        throw new Error(
+          `foreach item at index ${index} is missing non-empty string itemKey property "${config.itemKey}"`,
+        );
+      }
+      return { item, index, itemKey: rawItemKey };
+    });
+
+    const seenItemKeys = new Set<string>();
+    for (const { itemKey } of items) {
+      if (seenItemKeys.has(itemKey)) {
+        throw new Error(`foreach itemKey "${itemKey}" is duplicated`);
+      }
+      seenItemKeys.add(itemKey);
+    }
+
+    const agentTaskExecutor = new AgentTaskExecutor(this.deps);
+    const runSteps = this.deps.db.getWorkflowRunStepsByRunId(meta.runId);
+    const childStepsByNodeId = new Map(
+      runSteps
+        .filter((step) => parseSyntheticNodeId(step.nodeId)?.parentNodeId === meta.nodeId)
+        .map((step) => [step.nodeId, step]),
+    );
+    const childCountToCreate = items.filter(
+      ({ itemKey }) => !childStepsByNodeId.has(`${meta.nodeId}#${itemKey}`),
+    ).length;
+    const maxSteps = getMaxWorkflowStepsPerRun();
+    if (runSteps.length + childCountToCreate > maxSteps) {
+      return {
+        status: "failed",
+        error: `foreach would exceed ${maxSteps} total steps (WORKFLOW_MAX_STEPS_PER_RUN): ${runSteps.length} existing + ${childCountToCreate} children`,
+      };
+    }
+
+    for (const { item, index, itemKey } of items) {
+      const childNodeId = `${meta.nodeId}#${itemKey}`;
+      let childStep = childStepsByNodeId.get(childNodeId);
+      if (!childStep) {
+        const childStepId = crypto.randomUUID();
+        childStep = this.deps.db.createWorkflowRunStep({
+          id: childStepId,
+          runId: meta.runId,
+          nodeId: childNodeId,
+          nodeType: "agent-task",
+          input: { itemKey, index },
+        });
+        this.deps.db.updateWorkflowRunStep(childStepId, {
+          idempotencyKey: `${meta.runId}:${childNodeId}:0`,
+        });
+        childStepsByNodeId.set(childNodeId, childStep);
+      }
+
+      // Re-walks must not regress terminal children or disturb their aggregate
+      // inputs. Retry resets only the failed child to pending before arriving here.
+      if (FOREACH_TERMINAL_STEP_STATUSES.has(childStep.status)) continue;
+
+      const childInterpolation = deepInterpolate(config.body.config, { ...context, item, index });
+      if (childInterpolation.unresolved.length > 0) {
+        console.warn(
+          `[workflow] Step ${childNodeId}: unresolved interpolation tokens: ${childInterpolation.unresolved.join(", ")}`,
+        );
+        this.deps.db.updateWorkflowRunStep(childStep.id, {
+          diagnostics: JSON.stringify({ unresolvedTokens: childInterpolation.unresolved }),
+        });
+      }
+
+      const linkedTask = this.deps.db.getTaskByWorkflowRunStepId(childStep.id);
+      if (linkedTask?.status === "failed" || linkedTask?.status === "cancelled") {
+        // A retry needs a fresh task. Detaching the stale terminal task keeps the
+        // executor's one-task-per-step de-duplication deterministic and scoped.
+        this.deps.db.detachTaskFromWorkflowRunStep(linkedTask.id);
+      }
+
+      const childResult = await agentTaskExecutor.run({
+        config: childInterpolation.value as Record<string, unknown>,
+        context,
+        meta: {
+          ...meta,
+          stepId: childStep.id,
+          nodeId: childNodeId,
+        },
+      });
+      if (childResult.status !== "success") {
+        throw new Error(childResult.error ?? `foreach child "${itemKey}" failed to start`);
+      }
+      if ("async" in childResult) {
+        this.deps.db.updateWorkflowRunStep(childStep.id, { status: "waiting" });
+      } else {
+        this.deps.db.updateWorkflowRunStep(childStep.id, {
+          status: "completed",
+          output: normalizeExistingTaskOutput(childResult.output),
+          finishedAt: new Date().toISOString(),
+        });
+      }
+    }
+
+    const childSteps = this.deps.db
+      .getWorkflowRunStepsByRunId(meta.runId)
+      .filter((step) => parseSyntheticNodeId(step.nodeId)?.parentNodeId === meta.nodeId);
+    if (childSteps.every((step) => FOREACH_TERMINAL_STEP_STATUSES.has(step.status))) {
+      return { status: "success", output: buildForeachAggregate(childSteps) };
+    }
+
+    return {
+      status: "success",
+      async: true,
+      waitFor: "task.completed",
+      correlationId: meta.stepId,
+    } as AsyncExecutorResult<ForeachOutput>;
+  }
+}
+
+function normalizeExistingTaskOutput(output: unknown): unknown {
+  if (typeof output !== "object" || output === null) return output;
+  const record = output as Record<string, unknown>;
+  if (typeof record.taskOutput !== "string") return output;
+  try {
+    const parsed = JSON.parse(record.taskOutput);
+    if (typeof parsed === "object" && parsed !== null) {
+      return { ...record, taskOutput: parsed };
+    }
+  } catch {
+    // Non-structured task output remains a string.
+  }
+  return output;
+}

--- a/src/workflows/executors/foreach.ts
+++ b/src/workflows/executors/foreach.ts
@@ -127,7 +127,12 @@ export class ForeachExecutor extends BaseExecutor<
       // inputs. Retry resets only the failed child to pending before arriving here.
       if (FOREACH_TERMINAL_STEP_STATUSES.has(childStep.status)) continue;
 
-      const childInterpolation = deepInterpolate(config.body.config, { ...context, item, index });
+      // The deferred per-item pass interpolates against the node's declared-inputs
+      // context (meta.inputCtx) plus item/index — NOT the full run context — so
+      // body.config obeys the same explicit-dataflow boundary as normal node
+      // config instead of silently reading undeclared upstream outputs.
+      const bodyCtx = { ...(meta.inputCtx ?? context), item, index };
+      const childInterpolation = deepInterpolate(config.body.config, bodyCtx);
       if (childInterpolation.unresolved.length > 0) {
         console.warn(
           `[workflow] Step ${childNodeId}: unresolved interpolation tokens: ${childInterpolation.unresolved.join(", ")}`,

--- a/src/workflows/executors/foreach.ts
+++ b/src/workflows/executors/foreach.ts
@@ -87,30 +87,41 @@ export class ForeachExecutor extends BaseExecutor<
       ({ itemKey }) => !childStepsByNodeId.has(`${meta.nodeId}#${itemKey}`),
     ).length;
     const maxSteps = getMaxWorkflowStepsPerRun();
-    if (runSteps.length + childCountToCreate > maxSteps) {
+    // `>=` (not `>`): walkGraph's circuit breaker rejects any post-join walk once
+    // allSteps.length >= maxSteps, so a fan-out that lands exactly on the cap would
+    // spend all its child work and then fail routing the successor. Reserve that
+    // headroom here, before any child is dispatched.
+    if (childCountToCreate > 0 && runSteps.length + childCountToCreate >= maxSteps) {
       return {
         status: "failed",
-        error: `foreach would exceed ${maxSteps} total steps (WORKFLOW_MAX_STEPS_PER_RUN): ${runSteps.length} existing + ${childCountToCreate} children`,
+        error: `foreach would reach ${maxSteps} total steps (WORKFLOW_MAX_STEPS_PER_RUN): ${runSteps.length} existing + ${childCountToCreate} children leaves no room for the post-join walk`,
       };
+    }
+
+    // Materialize EVERY child step row before dispatching ANY child task. A task
+    // dispatched for an early child can complete (and trigger joinForeach) while
+    // later children are still being set up — the join must always see the full
+    // child set, with not-yet-dispatched children in a non-terminal state.
+    for (const { index, itemKey } of items) {
+      const childNodeId = `${meta.nodeId}#${itemKey}`;
+      if (childStepsByNodeId.has(childNodeId)) continue;
+      const childStepId = crypto.randomUUID();
+      const childStep = this.deps.db.createWorkflowRunStep({
+        id: childStepId,
+        runId: meta.runId,
+        nodeId: childNodeId,
+        nodeType: "agent-task",
+        input: { itemKey, index },
+      });
+      this.deps.db.updateWorkflowRunStep(childStepId, {
+        idempotencyKey: `${meta.runId}:${childNodeId}:0`,
+      });
+      childStepsByNodeId.set(childNodeId, childStep);
     }
 
     for (const { item, index, itemKey } of items) {
       const childNodeId = `${meta.nodeId}#${itemKey}`;
-      let childStep = childStepsByNodeId.get(childNodeId);
-      if (!childStep) {
-        const childStepId = crypto.randomUUID();
-        childStep = this.deps.db.createWorkflowRunStep({
-          id: childStepId,
-          runId: meta.runId,
-          nodeId: childNodeId,
-          nodeType: "agent-task",
-          input: { itemKey, index },
-        });
-        this.deps.db.updateWorkflowRunStep(childStepId, {
-          idempotencyKey: `${meta.runId}:${childNodeId}:0`,
-        });
-        childStepsByNodeId.set(childNodeId, childStep);
-      }
+      const childStep = childStepsByNodeId.get(childNodeId)!;
 
       // Re-walks must not regress terminal children or disturb their aggregate
       // inputs. Retry resets only the failed child to pending before arriving here.

--- a/src/workflows/executors/registry.ts
+++ b/src/workflows/executors/registry.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { AgentTaskExecutor } from "./agent-task";
 import type { BaseExecutor, ExecutorDependencies } from "./base";
 import { CodeMatchExecutor } from "./code-match";
+import { ForeachExecutor } from "./foreach";
 import { HumanInTheLoopExecutor } from "./human-in-the-loop";
 import { NotifyExecutor } from "./notify";
 import { PropertyMatchExecutor } from "./property-match";
@@ -75,6 +76,7 @@ export function createExecutorRegistry(deps: ExecutorDependencies): ExecutorRegi
 
   // Async executors (Phase 4)
   registry.register(new AgentTaskExecutor(deps));
+  registry.register(new ForeachExecutor(deps));
   registry.register(new HumanInTheLoopExecutor(deps));
   registry.register(new WaitExecutor(deps));
 

--- a/src/workflows/foreach-join.ts
+++ b/src/workflows/foreach-join.ts
@@ -1,0 +1,121 @@
+import { getLatestStepForNode, getWorkflowRunStepsByRunId } from "../be/db";
+import type { WorkflowDefinition, WorkflowNode, WorkflowRunStep } from "../types";
+import { checkpointStep } from "./checkpoint";
+import { FAILED_TASK_OUTPUT_PREFIX } from "./constants";
+import { getSuccessors } from "./definition";
+import type { ForeachOutput } from "./executors/foreach";
+
+export const FOREACH_TERMINAL_STEP_STATUSES = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+  "skipped",
+]);
+
+export interface SyntheticNodeId {
+  parentNodeId: string;
+  itemKey: string;
+}
+
+export function parseSyntheticNodeId(nodeId: string): SyntheticNodeId | null {
+  // Keep this parser aligned with `apps/ui/src/lib/synthetic-step-id.ts`.
+  const separatorIndex = nodeId.indexOf("#");
+  if (separatorIndex <= 0 || separatorIndex === nodeId.length - 1) return null;
+  return {
+    parentNodeId: nodeId.slice(0, separatorIndex),
+    itemKey: nodeId.slice(separatorIndex + 1),
+  };
+}
+
+export function resolveForeachParent(def: WorkflowDefinition, nodeId: string): WorkflowNode | null {
+  const parsed = parseSyntheticNodeId(nodeId);
+  if (!parsed) return null;
+  const parent = def.nodes.find((node) => node.id === parsed.parentNodeId);
+  return parent?.type === "foreach" ? parent : null;
+}
+
+export interface ForeachJoinResult {
+  joined: boolean;
+  parentNodeId: string;
+  successors: WorkflowNode[];
+}
+
+export function joinForeach(
+  def: WorkflowDefinition,
+  runId: string,
+  childStep: WorkflowRunStep,
+  ctx: Record<string, unknown>,
+): ForeachJoinResult {
+  const parent = resolveForeachParent(def, childStep.nodeId);
+  if (!parent) {
+    throw new Error(`Step "${childStep.nodeId}" is not a foreach child`);
+  }
+
+  const children = getWorkflowRunStepsByRunId(runId)
+    .filter((step) => resolveForeachParent(def, step.nodeId)?.id === parent.id)
+    .sort((a, b) => childIndex(a) - childIndex(b));
+
+  if (children.some((step) => !FOREACH_TERMINAL_STEP_STATUSES.has(step.status))) {
+    return { joined: false, parentNodeId: parent.id, successors: [] };
+  }
+
+  const parentStep = getLatestStepForNode(runId, parent.id);
+  if (!parentStep) {
+    throw new Error(`Waiting foreach parent step "${parent.id}" was not found`);
+  }
+  if (parentStep.status === "completed") {
+    // A run re-walk reconstructs successors from completed parent steps. A
+    // second closer must not mint another successor iteration here.
+    return { joined: false, parentNodeId: parent.id, successors: [] };
+  }
+
+  const aggregate = buildForeachAggregate(children);
+
+  checkpointStep(runId, parentStep.id, parent.id, { output: aggregate }, ctx);
+  return {
+    joined: true,
+    parentNodeId: parent.id,
+    successors: getSuccessors(def, parent.id),
+  };
+}
+
+export function buildForeachAggregate(children: WorkflowRunStep[]): ForeachOutput {
+  const orderedChildren = [...children].sort((a, b) => childIndex(a) - childIndex(b));
+  const results: ForeachOutput["results"] = orderedChildren.map((step) => {
+    const parsed = parseSyntheticNodeId(step.nodeId)!;
+    const status = resultStatus(step);
+    return {
+      itemKey: parsed.itemKey,
+      status,
+      output: step.output,
+    };
+  });
+  const failedCount = results.filter((result) => result.status !== "completed").length;
+  const aggregate: ForeachOutput = {
+    results,
+    okCount: results.length - failedCount,
+    failedCount,
+  };
+  return aggregate;
+}
+
+function childIndex(step: WorkflowRunStep): number {
+  if (typeof step.input !== "object" || step.input === null) return Number.MAX_SAFE_INTEGER;
+  const index = (step.input as Record<string, unknown>).index;
+  return typeof index === "number" ? index : Number.MAX_SAFE_INTEGER;
+}
+
+function resultStatus(step: WorkflowRunStep): ForeachOutput["results"][number]["status"] {
+  if (step.status !== "completed") return step.status as "failed" | "cancelled" | "skipped";
+  if (
+    typeof step.output === "object" &&
+    step.output !== null &&
+    typeof (step.output as Record<string, unknown>).taskOutput === "string" &&
+    ((step.output as Record<string, unknown>).taskOutput as string).startsWith(
+      FAILED_TASK_OUTPUT_PREFIX,
+    )
+  ) {
+    return "failed";
+  }
+  return "completed";
+}

--- a/src/workflows/foreach-join.ts
+++ b/src/workflows/foreach-join.ts
@@ -18,7 +18,10 @@ export interface SyntheticNodeId {
 }
 
 export function parseSyntheticNodeId(nodeId: string): SyntheticNodeId | null {
-  // Keep this parser aligned with `apps/ui/src/lib/synthetic-step-id.ts`.
+  // Keep this parser aligned with `apps/ui/src/lib/synthetic-step-id.ts`. This side
+  // stays permissive because every caller verifies the parsed parent is a real
+  // `foreach` node (resolveForeachParent / the executor's meta.nodeId match); the UI
+  // variant takes the foreach-id set explicitly for the same guarantee.
   const separatorIndex = nodeId.indexOf("#");
   if (separatorIndex <= 0 || separatorIndex === nodeId.length - 1) return null;
   return {

--- a/src/workflows/foreach-join.ts
+++ b/src/workflows/foreach-join.ts
@@ -1,7 +1,6 @@
 import { getLatestStepForNode, getWorkflowRunStepsByRunId } from "../be/db";
 import type { WorkflowDefinition, WorkflowNode, WorkflowRunStep } from "../types";
 import { checkpointStep } from "./checkpoint";
-import { FAILED_TASK_OUTPUT_PREFIX } from "./constants";
 import { getSuccessors } from "./definition";
 import type { ForeachOutput } from "./executors/foreach";
 
@@ -110,15 +109,9 @@ function childIndex(step: WorkflowRunStep): number {
 
 function resultStatus(step: WorkflowRunStep): ForeachOutput["results"][number]["status"] {
   if (step.status !== "completed") return step.status as "failed" | "cancelled" | "skipped";
-  if (
-    typeof step.output === "object" &&
-    step.output !== null &&
-    typeof (step.output as Record<string, unknown>).taskOutput === "string" &&
-    ((step.output as Record<string, unknown>).taskOutput as string).startsWith(
-      FAILED_TASK_OUTPUT_PREFIX,
-    )
-  ) {
-    return "failed";
-  }
-  return "completed";
+  // An onNodeFailure:"continue" completion persists its failure reason on
+  // step.error (completeTaskStepAndResolveSuccessors). Classify on that explicit
+  // metadata — a successful child whose OUTPUT merely begins with "[FAILED:"
+  // (e.g. an agent quoting a log line) is user-controlled text, not a failure.
+  return step.error ? "failed" : "completed";
 }

--- a/src/workflows/limits.ts
+++ b/src/workflows/limits.ts
@@ -1,0 +1,8 @@
+const DEFAULT_MAX_STEPS_PER_RUN = 500;
+
+// Read dynamically, NOT captured at module load: `src/http/index.ts` imports
+// workflow modules before `loadGlobalConfigsIntoEnv()` hydrates `swarm_config`
+// into `process.env`. A function also lets config reloads take effect live.
+export function getMaxWorkflowStepsPerRun(): number {
+  return Number(process.env.WORKFLOW_MAX_STEPS_PER_RUN) || DEFAULT_MAX_STEPS_PER_RUN;
+}

--- a/src/workflows/recovery.ts
+++ b/src/workflows/recovery.ts
@@ -153,6 +153,7 @@ async function recoverWaitingRuns(registry: ExecutorRegistry): Promise<number> {
         step,
         stepOutput,
         ctx,
+        taskCompleted ? undefined : reason,
       );
       if (routing.foreachChild && !routing.joined) {
         // The parent remains waiting until another child closes the join.

--- a/src/workflows/recovery.ts
+++ b/src/workflows/recovery.ts
@@ -6,16 +6,19 @@ import {
   getStuckWorkflowRuns,
   getWorkflow,
   getWorkflowRun,
+  getWorkflowRunStep,
   resolveApprovalRequest,
   updateWorkflowRun,
   updateWorkflowRunStep,
 } from "../be/db";
 import { checkpointStep } from "./checkpoint";
+import { FAILED_TASK_OUTPUT_PREFIX } from "./constants";
 import { getSuccessors } from "./definition";
 import { findReadyNodes, walkGraph } from "./engine";
 import type { ExecutorRegistry } from "./executors/registry";
 import { getSecretInputKeys } from "./input";
 import { finalizeOrWait, resumeWaitState } from "./resume";
+import { completeTaskStepAndResolveSuccessors } from "./task-step-routing";
 
 /**
  * Recover incomplete workflow runs on server startup.
@@ -111,29 +114,11 @@ async function recoverWaitingRuns(registry: ExecutorRegistry): Promise<number> {
     try {
       const run = getWorkflowRun(stuck.runId);
       const workflow = getWorkflow(stuck.workflowId);
-      if (!run || !workflow) continue;
+      if (!run || run.status !== "waiting" || !workflow) continue;
 
-      if (stuck.taskStatus === "completed") {
-        // Task finished while we were down — checkpoint and resume
-        const ctx = (run.context ?? {}) as Record<string, unknown>;
-        const stepOutput = { taskId: stuck.stepId, taskOutput: stuck.taskOutput };
-
-        checkpointStep(stuck.runId, stuck.stepId, stuck.nodeId, { output: stepOutput }, ctx);
-        updateWorkflowRun(stuck.runId, { status: "running" });
-
-        const successors = getSuccessors(workflow.definition, stuck.nodeId, "default");
-        const secretKeys = getSecretInputKeys(workflow.input);
-        await walkGraph(
-          workflow.definition,
-          stuck.runId,
-          ctx,
-          successors,
-          registry,
-          workflow.id,
-          secretKeys,
-        );
-      } else {
-        // Task failed or cancelled — mark run failed
+      const taskCompleted = stuck.taskStatus === "completed";
+      if (!taskCompleted && (workflow.definition.onNodeFailure ?? "fail") === "fail") {
+        // Preserve the fail-fast recovery policy for failed/cancelled tasks.
         const reason =
           stuck.taskStatus === "failed" ? "Task failed (recovered)" : "Task cancelled (recovered)";
         const now = new Date().toISOString();
@@ -147,6 +132,44 @@ async function recoverWaitingRuns(registry: ExecutorRegistry): Promise<number> {
           error: reason,
           finishedAt: now,
         });
+        recovered++;
+        continue;
+      }
+
+      const ctx = (run.context ?? {}) as Record<string, unknown>;
+      const reason =
+        stuck.taskStatus === "failed" ? "Task failed (recovered)" : "Task cancelled (recovered)";
+      const stepOutput = {
+        taskId: stuck.taskId,
+        taskOutput: taskCompleted
+          ? parseRecoveredTaskOutput(stuck.taskOutput)
+          : `${FAILED_TASK_OUTPUT_PREFIX} ${reason}] This node failed or was cancelled.`,
+      };
+      const step = getWorkflowRunStep(stuck.stepId);
+      if (!step) continue;
+      const routing = completeTaskStepAndResolveSuccessors(
+        workflow.definition,
+        stuck.runId,
+        step,
+        stepOutput,
+        ctx,
+      );
+      if (routing.foreachChild && !routing.joined) {
+        // The parent remains waiting until another child closes the join.
+        finalizeOrWait(stuck.runId);
+      } else {
+        // Always walk normal-task successors, even when empty, so walkGraph's
+        // finalization tail persists context and partial/retry failure state.
+        const secretKeys = getSecretInputKeys(workflow.input);
+        await walkGraph(
+          workflow.definition,
+          stuck.runId,
+          ctx,
+          routing.successors,
+          registry,
+          workflow.id,
+          secretKeys,
+        );
       }
       recovered++;
     } catch (err) {
@@ -155,6 +178,17 @@ async function recoverWaitingRuns(registry: ExecutorRegistry): Promise<number> {
   }
 
   return recovered;
+}
+
+function parseRecoveredTaskOutput(output: string | null): unknown {
+  // Keep recovery output parsing aligned with the live task-completion path.
+  if (output === null) return null;
+  try {
+    const parsed = JSON.parse(output);
+    return typeof parsed === "object" && parsed !== null ? parsed : output;
+  } catch {
+    return output;
+  }
 }
 
 /**

--- a/src/workflows/resume.ts
+++ b/src/workflows/resume.ts
@@ -217,6 +217,7 @@ async function handleTaskFailure(
     step,
     stepOutput,
     ctx,
+    reason,
   );
 
   // Use direct successor-based routing (loop-aware).

--- a/src/workflows/resume.ts
+++ b/src/workflows/resume.ts
@@ -14,13 +14,16 @@ import {
   updateWorkflowRunStep,
 } from "../be/db";
 import { checkpointStep } from "./checkpoint";
+import { FAILED_TASK_OUTPUT_PREFIX } from "./constants";
 import { getSuccessors } from "./definition";
 import { findReadyNodes, walkGraph } from "./engine";
 import type { WorkflowEventBus } from "./event-bus";
 import { workflowEventBus } from "./event-bus";
 import type { ExecutorRegistry } from "./executors/registry";
 import { computeNextPort } from "./executors/wait";
+import { resolveForeachParent } from "./foreach-join";
 import { getSecretInputKeys } from "./input";
+import { completeTaskStepAndResolveSuccessors } from "./task-step-routing";
 import { matchesFilter } from "./wait-filter";
 
 interface TaskEvent {
@@ -126,16 +129,19 @@ async function resumeFromTaskCompletion(
   }
   const stepOutput = { taskId: event.taskId, taskOutput };
 
-  checkpointStep(run.id, step.id, step.nodeId, { output: stepOutput }, ctx);
-
-  // Set run back to running
-  updateWorkflowRun(run.id, { status: "running" });
+  const routing = completeTaskStepAndResolveSuccessors(
+    workflow.definition,
+    run.id,
+    step,
+    stepOutput,
+    ctx,
+  );
 
   // Use direct successor-based routing (same as resumeFromApprovalResolution).
   // findReadyNodes is NOT loop-aware — it excludes nodes with any completed step,
   // which breaks loop workflows where a node needs re-execution on a new iteration.
   // walkGraph handles convergence internally via activeEdges reconstruction.
-  const successors = getSuccessors(workflow.definition, step.nodeId);
+  const successors = routing.successors;
 
   if (successors.length > 0) {
     const secretKeys = getSecretInputKeys(workflow.input);
@@ -182,7 +188,10 @@ async function handleTaskFailure(
   registry: ExecutorRegistry,
 ): Promise<void> {
   const run = getWorkflowRun(event.workflowRunId!);
-  if (!run) return;
+  if (!run || (run.status !== "waiting" && run.status !== "running")) return;
+
+  const step = getWorkflowRunStep(event.workflowRunStepId!);
+  if (!step || step.status !== "waiting") return;
 
   const workflow = getWorkflow(run.workflowId);
   if (!workflow) return;
@@ -195,20 +204,21 @@ async function handleTaskFailure(
   }
 
   // "continue": treat as completed with error output
-  const step = getWorkflowRunStep(event.workflowRunStepId!);
-  if (!step) return;
-
   const ctx = (run.context ?? {}) as Record<string, unknown>;
   const stepOutput = {
     taskId: event.taskId,
-    taskOutput: `[FAILED: ${reason}] This node failed or was cancelled.`,
+    taskOutput: `${FAILED_TASK_OUTPUT_PREFIX} ${reason}] This node failed or was cancelled.`,
   };
-  checkpointStep(run.id, step.id, step.nodeId, { output: stepOutput }, ctx);
-
-  updateWorkflowRun(run.id, { status: "running" });
+  const routing = completeTaskStepAndResolveSuccessors(
+    workflow.definition,
+    run.id,
+    step,
+    stepOutput,
+    ctx,
+  );
 
   // Use direct successor-based routing (loop-aware).
-  const successors = getSuccessors(workflow.definition, step.nodeId);
+  const successors = routing.successors;
 
   if (successors.length > 0) {
     const secretKeys = getSecretInputKeys(workflow.input);
@@ -259,14 +269,16 @@ export async function retryFailedRun(runId: string, registry: ExecutorRegistry):
   if (!failedStep) throw new Error("No failed step found");
 
   // Reset step and run
-  updateWorkflowRunStep(failedStep.id, { status: "pending", error: undefined });
+  updateWorkflowRunStep(failedStep.id, { status: "pending", error: null });
   const ctx = (run.context ?? {}) as Record<string, unknown>;
-  updateWorkflowRun(runId, { status: "running", error: undefined, context: ctx });
+  updateWorkflowRun(runId, { status: "running", error: null, context: ctx });
 
   // Resume from the failed node — use findReadyNodes for convergence safety
   const completedNodeIds = new Set(getCompletedStepNodeIds(runId));
   const readyNodes = findReadyNodes(workflow.definition, completedNodeIds);
-  const failedNode = workflow.definition.nodes.find((n) => n.id === failedStep.nodeId);
+  const failedNode =
+    resolveForeachParent(workflow.definition, failedStep.nodeId) ??
+    workflow.definition.nodes.find((n) => n.id === failedStep.nodeId);
   if (!failedNode) throw new Error(`Node ${failedStep.nodeId} not found in workflow definition`);
 
   // Include the failed node if it's not already in ready nodes

--- a/src/workflows/resume.ts
+++ b/src/workflows/resume.ts
@@ -108,6 +108,7 @@ async function resumeFromTaskCompletion(
 
   const step = getWorkflowRunStep(event.workflowRunStepId!);
   if (!step || step.status !== "waiting") return;
+  if (isStaleTaskEvent(step.id, event)) return;
 
   const workflow = getWorkflow(run.workflowId);
   if (!workflow) return;
@@ -192,6 +193,7 @@ async function handleTaskFailure(
 
   const step = getWorkflowRunStep(event.workflowRunStepId!);
   if (!step || step.status !== "waiting") return;
+  if (isStaleTaskEvent(step.id, event)) return;
 
   const workflow = getWorkflow(run.workflowId);
   if (!workflow) return;
@@ -234,6 +236,19 @@ async function handleTaskFailure(
   } else {
     finalizeOrWait(run.id);
   }
+}
+
+/**
+ * A retried step has a NEW task bound to it. Task lifecycle events are emitted
+ * from several places (the db mutators' after-commit emits, test/manual emits,
+ * crash-recovery echoes) and can arrive on a later tick — after the step was
+ * reset and re-dispatched. An event whose taskId no longer matches the task
+ * currently bound to the step must not complete or fail a step it doesn't own.
+ */
+function isStaleTaskEvent(stepId: string, event: TaskEvent): boolean {
+  if (!event.taskId) return false;
+  const boundTask = getTaskByWorkflowRunStepId(stepId);
+  return boundTask != null && boundTask.id !== event.taskId;
 }
 
 /**

--- a/src/workflows/retry-poller.ts
+++ b/src/workflows/retry-poller.ts
@@ -8,7 +8,7 @@ import {
 import type { RetryPolicy } from "../types";
 import { checkpointStep, checkpointStepFailure, checkpointStepWaiting } from "./checkpoint";
 import { getSuccessors } from "./definition";
-import { interpolateNodeConfig, walkGraph } from "./engine";
+import { buildNodeInterpolationCtx, interpolateNodeConfig, walkGraph } from "./engine";
 import type { AsyncExecutorResult } from "./executors/base";
 import type { ExecutorRegistry } from "./executors/registry";
 import { runStepValidation } from "./validation";
@@ -61,8 +61,13 @@ export function startRetryPoller(registry: ExecutorRegistry, intervalMs = 5000):
 
           const ctx = (run.context ?? {}) as Record<string, unknown>;
 
-          // Deep-interpolate config
-          const { value: interpolatedValue } = interpolateNodeConfig(node, ctx);
+          // Deep-interpolate config against the node's declared-inputs context —
+          // the raw run context has no `inputs` aliases, so interpolating against
+          // it directly resolves every {{alias}} to "" and (e.g.) a retried
+          // foreach with `over: "{{items}}"` burns all its retries on schema
+          // rejections without ever re-dispatching.
+          const inputCtx = buildNodeInterpolationCtx(node, ctx);
+          const { value: interpolatedValue } = interpolateNodeConfig(node, inputCtx);
           const interpolatedConfig = interpolatedValue as Record<string, unknown>;
 
           // Get executor and re-run
@@ -73,6 +78,7 @@ export function startRetryPoller(registry: ExecutorRegistry, intervalMs = 5000):
             nodeId: step.nodeId,
             workflowId: workflow.id,
             dryRun: false,
+            inputCtx,
           };
 
           try {

--- a/src/workflows/retry-poller.ts
+++ b/src/workflows/retry-poller.ts
@@ -60,6 +60,10 @@ export function startRetryPoller(registry: ExecutorRegistry, intervalMs = 5000):
           });
 
           const ctx = (run.context ?? {}) as Record<string, unknown>;
+          // A step can fail before ANY checkpoint persisted the walkGraph-hydrated
+          // context, so `run.id` may be absent here — mirror the hydration or the
+          // builtin resolves to "" on every retry.
+          if (!("run" in ctx)) ctx.run = { id: run.id };
 
           // Deep-interpolate config against the node's declared-inputs context —
           // the raw run context has no `inputs` aliases, so interpolating against

--- a/src/workflows/retry-poller.ts
+++ b/src/workflows/retry-poller.ts
@@ -6,9 +6,10 @@ import {
   updateWorkflowRunStep,
 } from "../be/db";
 import type { RetryPolicy } from "../types";
-import { checkpointStep, checkpointStepFailure } from "./checkpoint";
+import { checkpointStep, checkpointStepFailure, checkpointStepWaiting } from "./checkpoint";
 import { getSuccessors } from "./definition";
 import { interpolateNodeConfig, walkGraph } from "./engine";
+import type { AsyncExecutorResult } from "./executors/base";
 import type { ExecutorRegistry } from "./executors/registry";
 import { runStepValidation } from "./validation";
 
@@ -93,6 +94,14 @@ export function startRetryPoller(registry: ExecutorRegistry, intervalMs = 5000):
                 step.retryCount,
                 retryPolicy,
               );
+            } else if ("async" in result && (result as AsyncExecutorResult).async) {
+              // An async executor (agent-task, foreach) re-dispatched its work —
+              // the step is waiting on task events again, exactly like the
+              // executeStep async path. Checkpointing the async marker as a
+              // completed output would route successors while the re-dispatched
+              // work is still running, and the eventual completion/join would
+              // find the parent already advanced.
+              checkpointStepWaiting(run.id, step.id, ctx);
             } else {
               // Success! Re-run validation if configured before checkpointing.
               if (node.validation) {

--- a/src/workflows/task-step-routing.ts
+++ b/src/workflows/task-step-routing.ts
@@ -20,6 +20,7 @@ export function completeTaskStepAndResolveSuccessors(
   step: WorkflowRunStep,
   output: unknown,
   ctx: Record<string, unknown>,
+  failureReason?: string,
 ): TaskStepRoutingResult {
   const txn = getDb().transaction((): TaskStepRoutingResult => {
     const foreachParent = resolveForeachParent(def, step.nodeId);
@@ -27,6 +28,10 @@ export function completeTaskStepAndResolveSuccessors(
       updateWorkflowRunStep(step.id, {
         status: "completed",
         output,
+        // onNodeFailure:"continue" completions persist the failure reason as
+        // explicit metadata — the join classifies children on THIS, not on
+        // whether user-controlled output text happens to start with "[FAILED:".
+        ...(failureReason !== undefined ? { error: failureReason } : {}),
         finishedAt: new Date().toISOString(),
       });
       const join = joinForeach(def, runId, step, ctx);

--- a/src/workflows/task-step-routing.ts
+++ b/src/workflows/task-step-routing.ts
@@ -1,0 +1,54 @@
+import { getDb, updateWorkflowRun, updateWorkflowRunStep } from "../be/db";
+import type { WorkflowDefinition, WorkflowNode, WorkflowRunStep } from "../types";
+import { checkpointStep } from "./checkpoint";
+import { getSuccessors } from "./definition";
+import { joinForeach, resolveForeachParent } from "./foreach-join";
+
+export interface TaskStepRoutingResult {
+  foreachChild: boolean;
+  joined: boolean;
+  successors: WorkflowNode[];
+}
+
+/**
+ * Persist an agent-task result and resolve its next nodes. Synthetic foreach
+ * children never checkpoint into workflow context; only their parent join does.
+ */
+export function completeTaskStepAndResolveSuccessors(
+  def: WorkflowDefinition,
+  runId: string,
+  step: WorkflowRunStep,
+  output: unknown,
+  ctx: Record<string, unknown>,
+): TaskStepRoutingResult {
+  const txn = getDb().transaction((): TaskStepRoutingResult => {
+    const foreachParent = resolveForeachParent(def, step.nodeId);
+    if (foreachParent) {
+      updateWorkflowRunStep(step.id, {
+        status: "completed",
+        output,
+        finishedAt: new Date().toISOString(),
+      });
+      const join = joinForeach(def, runId, step, ctx);
+      updateWorkflowRun(runId, { status: "running" });
+      return {
+        foreachChild: true,
+        joined: join.joined,
+        successors: join.successors,
+      };
+    }
+
+    checkpointStep(runId, step.id, step.nodeId, { output }, ctx);
+    updateWorkflowRun(runId, { status: "running" });
+    return {
+      foreachChild: false,
+      joined: true,
+      successors: getSuccessors(def, step.nodeId),
+    };
+  });
+
+  // The task step, optional foreach join checkpoint, workflow context, and
+  // running status must commit together. A crash after this transaction is
+  // recoverable through the running-run graph re-walk.
+  return txn();
+}


### PR DESCRIPTION
## What

Adds a `foreach` workflow node that fans out one `agent-task` child per array item, waits for every child to reach a terminal state, and exposes a single parent-owned aggregate (`results[] / okCount / failedCount`) to downstream nodes. Cherry-picked as a standalone slice from #1088 (Dreaming add-on) so the engine change can merge and bake independently.

## How it works

- **Definition + validation** (`src/workflows/definition.ts`, `create-workflow` tool): `config.over` must interpolate to an array (an exact token preserves the array instead of stringifying), `itemKey` names a required unique non-empty string property, `body.type` is restricted to `agent-task` in v1. `concurrency` and foreach-in-a-cycle are rejected in v1.
- **Executor + join** (`src/workflows/executors/foreach.ts`, `src/workflows/foreach-join.ts`): children get synthetic step IDs `<foreachNodeId>#<itemKey>`; each child's `body.config` is interpolated per item with `item` and zero-based `index`. Empty arrays complete synchronously and still route to the successor. The workflow-level `onNodeFailure` policy applies to children (`fail` stops on the first failed/cancelled child; `continue` records a `[FAILED: …]` result and lets the join close).
- **Child→parent resume** (`src/workflows/resume.ts`, `task-step-routing.ts`, `recovery.ts`): a completing child task routes back to its foreach parent step; crash recovery re-adopts in-flight children instead of re-fanning out.
- **UI** (`apps/ui/src/components/workflows/*`, `synthetic-step-id.ts`): run graph renders the fan-out children under the foreach node, with a fallback for synthetic step IDs the graph definition doesn't know about.
- **Docs**: `runbooks/workflows.md` § Foreach nodes.

## Tests

`src/tests/workflow-foreach.test.ts` (new, ~500 lines): validation matrix, fan-out + join, empty array, failure policy both modes, interpolation of `item`/`index`, child→parent resume, recovery paths. Plus updated `workflow-executors.test.ts`.

## Why standalone

#1088 stacks on this branch; merging the engine slice first lets the add-on PR rebase cleanly on whatever lands in between (e.g. #1083) without dragging the engine diff along.
