### PR TITLE
fix(attachments): encode download filenames and link agent-fs rows

### DIFF
--- a/apps/evals/src/api/server.ts
+++ b/apps/evals/src/api/server.ts
@@ -1,4 +1,5 @@
 import { join, normalize, sep } from "node:path";
+import { attachmentContentDisposition } from "../../../../src/utils/content-disposition.ts";
 import { DEFAULT_CONFIG_IDS } from "../../configs/index.ts";
 import { CONFIG_PRESETS } from "../../configs/presets.ts";
 import { getClaudeAliasMap, listOpenrouterModels } from "../cost/pricing.ts";
@@ -866,7 +867,7 @@ export async function startServer(
             : "text/plain; charset=utf-8",
         };
         if (new URL(req.url).searchParams.get("download") === "1") {
-          headers["content-disposition"] = `attachment; filename="${name.replace(/"/g, "")}"`;
+          headers["content-disposition"] = attachmentContentDisposition(name);
         }
         return new Response(artifact.content, { headers });
       },

--- a/apps/ui/src/components/shared/task-attachment-link.tsx
+++ b/apps/ui/src/components/shared/task-attachment-link.tsx
@@ -5,16 +5,6 @@ function getAgentFsLiveUrl(): string {
   return (raw || DEFAULT_AGENT_FS_LIVE_URL).replace(/\/+$/, "");
 }
 
-function getAgentFsDefaultOrgId(): string | undefined {
-  const raw = import.meta.env.VITE_AGENT_FS_DEFAULT_ORG_ID?.trim();
-  return raw || undefined;
-}
-
-function getAgentFsDefaultDriveId(): string | undefined {
-  const raw = import.meta.env.VITE_AGENT_FS_DEFAULT_DRIVE_ID?.trim();
-  return raw || undefined;
-}
-
 export function buildAgentFsLiveUrl(opts: {
   path?: string | null;
   orgId?: string | null;
@@ -22,8 +12,10 @@ export function buildAgentFsLiveUrl(opts: {
 }): string | null {
   const path = opts.path?.trim();
   if (!path) return null;
-  const orgId = opts.orgId?.trim() || getAgentFsDefaultOrgId();
-  const driveId = opts.driveId?.trim() || getAgentFsDefaultDriveId();
+  // A live URL must use a matched org/drive pair from this attachment row.
+  // Falling back per ID can combine metadata from different drives or orgs.
+  const orgId = opts.orgId?.trim();
+  const driveId = opts.driveId?.trim();
   if (!orgId || !driveId) return null;
   return `${getAgentFsLiveUrl()}/file/~/${orgId}/${driveId}/${path.replace(/^\/+/, "")}`;
 }

--- a/apps/ui/src/components/shared/task-attachment-link.tsx
+++ b/apps/ui/src/components/shared/task-attachment-link.tsx
@@ -1,0 +1,44 @@
+const DEFAULT_AGENT_FS_LIVE_URL = "https://live.agent-fs.dev";
+
+function getAgentFsLiveUrl(): string {
+  const raw = import.meta.env.VITE_AGENT_FS_LIVE_URL?.trim();
+  return (raw || DEFAULT_AGENT_FS_LIVE_URL).replace(/\/+$/, "");
+}
+
+function getAgentFsDefaultOrgId(): string | undefined {
+  const raw = import.meta.env.VITE_AGENT_FS_DEFAULT_ORG_ID?.trim();
+  return raw || undefined;
+}
+
+function getAgentFsDefaultDriveId(): string | undefined {
+  const raw = import.meta.env.VITE_AGENT_FS_DEFAULT_DRIVE_ID?.trim();
+  return raw || undefined;
+}
+
+export function buildAgentFsLiveUrl(opts: {
+  path?: string | null;
+  orgId?: string | null;
+  driveId?: string | null;
+}): string | null {
+  const path = opts.path?.trim();
+  if (!path) return null;
+  const orgId = opts.orgId?.trim() || getAgentFsDefaultOrgId();
+  const driveId = opts.driveId?.trim() || getAgentFsDefaultDriveId();
+  if (!orgId || !driveId) return null;
+  return `${getAgentFsLiveUrl()}/file/~/${orgId}/${driveId}/${path.replace(/^\/+/, "")}`;
+}
+
+export function AttachmentName({ href, name }: { href: string | null; name: string }) {
+  const className = "truncate text-sm font-medium text-foreground";
+  if (!href) return <span className={className}>{name}</span>;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`${className} hover:text-primary hover:underline`}
+    >
+      {name}
+    </a>
+  );
+}

--- a/apps/ui/src/components/shared/task-attachments-section.test.tsx
+++ b/apps/ui/src/components/shared/task-attachments-section.test.tsx
@@ -40,7 +40,9 @@ describe("task attachment links", () => {
         const html = renderToStaticMarkup(<AttachmentName href={href} name="Report" />);
 
         expect(href).toBeNull();
-        expect(html).toBe('<span class="truncate text-sm font-medium text-foreground">Report</span>');
+        expect(html).toBe(
+          '<span class="truncate text-sm font-medium text-foreground">Report</span>',
+        );
       }
     } finally {
       if (previousOrgId === undefined) delete process.env.VITE_AGENT_FS_DEFAULT_ORG_ID;

--- a/apps/ui/src/components/shared/task-attachments-section.test.tsx
+++ b/apps/ui/src/components/shared/task-attachments-section.test.tsx
@@ -24,4 +24,29 @@ describe("task attachment links", () => {
     expect(href).toBeNull();
     expect(html).toBe('<span class="truncate text-sm font-medium text-foreground">Report</span>');
   });
+
+  test("keeps partial agent-fs rows as plain text even when default IDs are configured", () => {
+    const previousOrgId = process.env.VITE_AGENT_FS_DEFAULT_ORG_ID;
+    const previousDriveId = process.env.VITE_AGENT_FS_DEFAULT_DRIVE_ID;
+    process.env.VITE_AGENT_FS_DEFAULT_ORG_ID = "default-org";
+    process.env.VITE_AGENT_FS_DEFAULT_DRIVE_ID = "default-drive";
+
+    try {
+      for (const attachment of [
+        { path: "thoughts/report.md", orgId: "org-1" },
+        { path: "thoughts/report.md", driveId: "drive-1" },
+      ]) {
+        const href = buildAgentFsLiveUrl(attachment);
+        const html = renderToStaticMarkup(<AttachmentName href={href} name="Report" />);
+
+        expect(href).toBeNull();
+        expect(html).toBe('<span class="truncate text-sm font-medium text-foreground">Report</span>');
+      }
+    } finally {
+      if (previousOrgId === undefined) delete process.env.VITE_AGENT_FS_DEFAULT_ORG_ID;
+      else process.env.VITE_AGENT_FS_DEFAULT_ORG_ID = previousOrgId;
+      if (previousDriveId === undefined) delete process.env.VITE_AGENT_FS_DEFAULT_DRIVE_ID;
+      else process.env.VITE_AGENT_FS_DEFAULT_DRIVE_ID = previousDriveId;
+    }
+  });
 });

--- a/apps/ui/src/components/shared/task-attachments-section.test.tsx
+++ b/apps/ui/src/components/shared/task-attachments-section.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AttachmentName, buildAgentFsLiveUrl } from "./task-attachment-link";
+
+describe("task attachment links", () => {
+  test("renders an agent-fs attachment name as an inline live-host link", () => {
+    const href = buildAgentFsLiveUrl({
+      path: "thoughts/report.md",
+      orgId: "org-1",
+      driveId: "drive-1",
+    });
+    const html = renderToStaticMarkup(<AttachmentName href={href} name="Report" />);
+
+    expect(html).toContain(
+      'href="https://live.agent-fs.dev/file/~/org-1/drive-1/thoughts/report.md"',
+    );
+    expect(html).toContain(">Report</a>");
+  });
+
+  test("keeps the name as plain text when the agent-fs drive id is missing", () => {
+    const href = buildAgentFsLiveUrl({ path: "thoughts/report.md", orgId: "org-1" });
+    const html = renderToStaticMarkup(<AttachmentName href={href} name="Report" />);
+
+    expect(href).toBeNull();
+    expect(html).toBe('<span class="truncate text-sm font-medium text-foreground">Report</span>');
+  });
+});

--- a/apps/ui/src/components/shared/task-attachments-section.tsx
+++ b/apps/ui/src/components/shared/task-attachments-section.tsx
@@ -33,9 +33,8 @@ import { cn } from "@/lib/utils";
 /**
  * Per-row resolution mirrors `resolveAttachmentDisplay` in `src/slack/blocks.ts`.
  * For `agent-fs` we build a public live-URL when the row carries `orgId` and
- * `driveId` (or the operator-set env-var fallbacks supply them); otherwise
- * the row stays non-clickable and we surface the raw path so users can copy
- * it manually.
+ * `driveId` on that same row; otherwise the row stays non-clickable and we
+ * surface the raw path so users can copy it manually.
  */
 function resolveHref(a: TaskAttachment): string | null {
   switch (a.kind) {

--- a/apps/ui/src/components/shared/task-attachments-section.tsx
+++ b/apps/ui/src/components/shared/task-attachments-section.tsx
@@ -18,6 +18,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { fetchTaskAttachmentBlob, useDeleteAttachment, useTaskAttachments } from "@/api/fs";
 import type { TaskAttachment, TaskAttachmentKind } from "@/api/types";
 import { CollapsibleSection } from "@/components/shared/collapsible-section";
+import { AttachmentName, buildAgentFsLiveUrl } from "@/components/shared/task-attachment-link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -28,53 +29,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
-
-/**
- * Default agent-fs live host used when the dashboard's runtime config has
- * not been told otherwise. Kept in sync with `DEFAULT_AGENT_FS_LIVE_URL` in
- * `src/utils/constants.ts`.
- */
-const DEFAULT_AGENT_FS_LIVE_URL = "https://live.agent-fs.dev";
-
-/**
- * `import.meta.env.VITE_AGENT_FS_LIVE_URL` lets self-hosted deployments point
- * the dashboard at a different agent-fs live host. Falls back to the public
- * production host so the default install keeps rendering working links.
- */
-function getAgentFsLiveUrl(): string {
-  const raw = import.meta.env.VITE_AGENT_FS_LIVE_URL?.trim();
-  return (raw || DEFAULT_AGENT_FS_LIVE_URL).replace(/\/+$/, "");
-}
-
-function getAgentFsDefaultOrgId(): string | undefined {
-  const raw = import.meta.env.VITE_AGENT_FS_DEFAULT_ORG_ID?.trim();
-  return raw || undefined;
-}
-
-function getAgentFsDefaultDriveId(): string | undefined {
-  const raw = import.meta.env.VITE_AGENT_FS_DEFAULT_DRIVE_ID?.trim();
-  return raw || undefined;
-}
-
-/**
- * Mirror of `buildAgentFsLiveUrl` in `src/utils/constants.ts`. Returns null
- * when the path is missing or no org/drive pair is available (row-level
- * fields with env-var fallback) — callers fall back to a non-clickable row.
- */
-export function buildAgentFsLiveUrl(opts: {
-  path?: string | null;
-  orgId?: string | null;
-  driveId?: string | null;
-}): string | null {
-  const path = opts.path?.trim();
-  if (!path) return null;
-  const orgId = opts.orgId?.trim() || getAgentFsDefaultOrgId();
-  const driveId = opts.driveId?.trim() || getAgentFsDefaultDriveId();
-  if (!orgId || !driveId) return null;
-  const host = getAgentFsLiveUrl();
-  const normalizedPath = path.replace(/^\/+/, "");
-  return `${host}/file/~/${orgId}/${driveId}/${normalizedPath}`;
-}
 
 /**
  * Per-row resolution mirrors `resolveAttachmentDisplay` in `src/slack/blocks.ts`.
@@ -517,7 +471,7 @@ function AttachmentRow({
                 aria-label="Primary attachment"
               />
             )}
-            <span className="truncate text-sm font-medium text-foreground">{attachment.name}</span>
+            <AttachmentName href={href} name={attachment.name} />
           </div>
           <div className="flex flex-wrap items-center gap-1.5">
             <KindBadge kind={attachment.kind} />

--- a/apps/ui/tsconfig.app.json
+++ b/apps/ui/tsconfig.app.json
@@ -30,5 +30,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.tsx"]
 }

--- a/src/http/fs.ts
+++ b/src/http/fs.ts
@@ -16,6 +16,7 @@ import { type FileObject, type FileScope, FilesError, normalizeFilesError } from
 import { getFileStorageProvider } from "../fs/registry";
 import { can, type RbacPrincipal, type RbacResource } from "../rbac";
 import type { TaskAttachment } from "../types";
+import { attachmentContentDisposition } from "../utils/content-disposition";
 import { getCurrentRequestAuth, getRequestAuth } from "../utils/request-auth-context";
 import { scrubSecrets } from "../utils/secret-scrubber";
 import { route } from "./route-def";
@@ -366,7 +367,7 @@ async function sendDownload(res: ServerResponse, attachment: TaskAttachment): Pr
     const headers: Record<string, string> = {
       "Content-Type":
         response.headers.get("content-type") ?? attachment.mimeType ?? "application/octet-stream",
-      "Content-Disposition": `attachment; filename="${attachment.name.replace(/"/g, "")}"`,
+      "Content-Disposition": attachmentContentDisposition(attachment.name),
     };
     const length = response.headers.get("content-length") ?? attachment.sizeBytes?.toString();
     if (length) headers["Content-Length"] = length;

--- a/src/slack/blocks.ts
+++ b/src/slack/blocks.ts
@@ -150,10 +150,10 @@ const SLACK_ATTACHMENTS_MAX = 20;
  * them and the shortcut form has historically triggered `invalid_blocks`.
  *
  * `agent-fs` attachments emit a public live-host URL when the row carries
- * `orgId` and `driveId` (or when the operator-set
- * `AGENT_FS_DEFAULT_ORG_ID` / `AGENT_FS_DEFAULT_DRIVE_ID` env-vars provide
- * a fallback). Without either, we keep the `agent-fs:<path>` raw fallback so
- * the link is at least copy-pasteable.
+ * a matched `orgId` and `driveId`, or when neither row ID is supplied and the
+ * operator-set `AGENT_FS_DEFAULT_ORG_ID` / `AGENT_FS_DEFAULT_DRIVE_ID`
+ * env-vars provide a fallback. Partial metadata keeps the `agent-fs:<path>`
+ * raw fallback so the link is at least copy-pasteable.
  */
 function resolveAttachmentDisplay(a: TaskAttachment): string {
   return taskAttachmentDisplayUrl(a);

--- a/src/tests/fs-routes.test.ts
+++ b/src/tests/fs-routes.test.ts
@@ -20,6 +20,7 @@ import { handleCore } from "../http/core";
 import { handleFs } from "../http/fs";
 import { getPathSegments, parseQueryParams } from "../http/utils";
 import { formatAttachmentsBlockForSlack } from "../slack/blocks";
+import { attachmentContentDisposition } from "../utils/content-disposition";
 
 const TEST_DB_PATH = "./test-fs-routes.sqlite";
 const TEST_FS_DIR = "./test-fs-routes-data";
@@ -123,6 +124,28 @@ function operatorFetch(path: string, init: RequestInit = {}): Promise<Response> 
 }
 
 describe("/api/fs REST", () => {
+  test("RFC 6266 download filenames are Latin-1-safe and preserve UTF-8", () => {
+    for (const filename of [
+      "PR analytics backfill — dry-run report",
+      "r\u00e9sum\u00e9.txt",
+      "\u5831\u544a.md",
+      'quote".txt',
+      "newline\nname.txt",
+      "plain-ascii.txt",
+    ]) {
+      const header = attachmentContentDisposition(filename);
+      expect(header).toStartWith('attachment; filename="');
+      expect(header).toContain("; filename*=UTF-8''");
+      expect([...header].every((character) => character.charCodeAt(0) <= 0xff)).toBe(true);
+    }
+
+    expect(attachmentContentDisposition("PR analytics backfill — dry-run report")).toContain(
+      "PR%20analytics%20backfill%20%E2%80%94%20dry-run%20report",
+    );
+    expect(attachmentContentDisposition('quote".txt')).not.toContain('quote".txt');
+    expect(attachmentContentDisposition("newline\nname.txt")).not.toContain("\n");
+  });
+
   test("401 without Authorization header", async () => {
     const res = await fetch(url(`/api/fs/tasks/${taskId}/files`), {
       headers: { "X-Agent-ID": agentId },
@@ -208,6 +231,28 @@ describe("/api/fs REST", () => {
     const download = await authedFetch(`/api/fs/tasks/${taskId}/files/${attachment.id}/raw`);
     expect(download.status).toBe(200);
     expect(await download.text()).toBe("resolved via stored key");
+  });
+
+  test("download accepts the reported em-dash attachment name", async () => {
+    const storedKey = "thoughts/research/dry-run-report.md";
+    const onDisk = join(TEST_FS_DIR, storedKey);
+    await mkdir(dirname(onDisk), { recursive: true });
+    await writeFile(onDisk, "report");
+    const attachment = insertTaskAttachment({
+      taskId,
+      agentId,
+      name: "PR analytics backfill — dry-run report",
+      kind: "shared-fs",
+      path: storedKey,
+      providerId: "local-fs",
+      providerKey: storedKey,
+      mimeType: "text/markdown",
+    });
+
+    const download = await authedFetch(`/api/fs/tasks/${taskId}/files/${attachment.id}/raw`);
+    expect(download.status).toBe(200);
+    expect(download.headers.get("content-disposition")).toContain("filename*=UTF-8''");
+    expect(await download.text()).toBe("report");
   });
 
   test("cross-provider rows are not downloadable and delete is pointer-only (no orphaning)", async () => {

--- a/src/tests/slack-attachments-block.test.ts
+++ b/src/tests/slack-attachments-block.test.ts
@@ -133,6 +133,30 @@ describe("formatAttachmentsBlockForSlack", () => {
     }
   });
 
+  test("agent-fs partial row IDs stay raw even when defaults are configured", () => {
+    const origOrg = process.env.AGENT_FS_DEFAULT_ORG_ID;
+    const origDrive = process.env.AGENT_FS_DEFAULT_DRIVE_ID;
+    process.env.AGENT_FS_DEFAULT_ORG_ID = "fallback-org";
+    process.env.AGENT_FS_DEFAULT_DRIVE_ID = "fallback-drive";
+    try {
+      for (const attachment of [
+        mkAttachment({ kind: "agent-fs", path: "thoughts/a.md", orgId: "row-org" }),
+        mkAttachment({ kind: "agent-fs", path: "thoughts/a.md", driveId: "row-drive" }),
+      ]) {
+        const out = formatAttachmentsBlockForSlack([attachment]);
+        expect(out).toContain("agent-fs:thoughts/a.md");
+        expect(out).not.toContain("live.agent-fs.dev");
+        expect(out).not.toContain("fallback-org");
+        expect(out).not.toContain("fallback-drive");
+      }
+    } finally {
+      if (origOrg === undefined) delete process.env.AGENT_FS_DEFAULT_ORG_ID;
+      else process.env.AGENT_FS_DEFAULT_ORG_ID = origOrg;
+      if (origDrive === undefined) delete process.env.AGENT_FS_DEFAULT_DRIVE_ID;
+      else process.env.AGENT_FS_DEFAULT_DRIVE_ID = origDrive;
+    }
+  });
+
   test("agent-fs row-level org/drive ids win over env-var fallbacks", () => {
     const origOrg = process.env.AGENT_FS_DEFAULT_ORG_ID;
     const origDrive = process.env.AGENT_FS_DEFAULT_DRIVE_ID;

--- a/src/tests/store-progress-attachments-handler.test.ts
+++ b/src/tests/store-progress-attachments-handler.test.ts
@@ -407,7 +407,7 @@ describe("store-progress handler — attachments insert path", () => {
       expect(rows[0].driveId).toBe("row-drive");
     });
 
-    test("partial row IDs — only the missing one is filled from config", async () => {
+    test("partial row IDs are preserved instead of mixing with config defaults", async () => {
       clearSwarmConfig();
       upsertSwarmConfig({
         scope: "global",
@@ -448,7 +448,7 @@ describe("store-progress handler — attachments insert path", () => {
       const rows = getTaskAttachments(task.id);
       expect(rows.length).toBe(1);
       expect(rows[0].orgId).toBe("row-org");
-      expect(rows[0].driveId).toBe("global-drive");
+      expect(rows[0].driveId).toBeUndefined();
     });
   });
 

--- a/src/tools/store-progress.ts
+++ b/src/tools/store-progress.ts
@@ -159,9 +159,10 @@ export const registerStoreProgressTool = (server: McpServer) => {
           // only if at least one `agent-fs` row arrives with missing IDs.
           // Scope precedence is `getResolvedConfig`'s usual repo > agent >
           // global; we pass the calling agent's id so agent-scoped overrides
-          // win. Per-row IDs always take precedence over the config defaults.
-          // Env-var fallback in `constants.ts` remains the secondary path for
-          // self-hosters who deploy without a config DB.
+          // win. Defaults apply only when a row has neither ID: filling one
+          // missing ID would create a mismatched pair and a potentially wrong
+          // live-host URL. Env-var fallback in `constants.ts` remains the
+          // secondary path for self-hosters who deploy without a config DB.
           let agentFsDefaults: { orgId?: string; driveId?: string } | null = null;
           const resolveAgentFsDefaults = (): { orgId?: string; driveId?: string } => {
             if (agentFsDefaults !== null) return agentFsDefaults;
@@ -178,7 +179,7 @@ export const registerStoreProgressTool = (server: McpServer) => {
           for (const a of attachments) {
             let orgId = a.kind === "agent-fs" ? a.orgId : undefined;
             let driveId = a.kind === "agent-fs" ? a.driveId : undefined;
-            if (a.kind === "agent-fs" && (!orgId || !driveId)) {
+            if (a.kind === "agent-fs" && !orgId && !driveId) {
               const defaults = resolveAgentFsDefaults();
               orgId = orgId || defaults.orgId;
               driveId = driveId || defaults.driveId;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -105,9 +105,10 @@ export function getAgentFsDefaultDriveId(): string | undefined {
 
 /**
  * Resolve a public agent-fs live URL for an attachment when we have enough
- * info — `path` plus (`orgId` and `driveId`, falling back to env-var
- * defaults). Returns `null` when the path is missing or no org/drive pair is
- * available; callers fall back to the raw `agent-fs:<path>` display.
+ * info — `path` plus a matched `orgId`/`driveId` pair. When a row supplies
+ * neither ID, the pair may come from env-var defaults. A partial row never
+ * mixes its ID with a default; callers fall back to the raw
+ * `agent-fs:<path>` display instead.
  *
  * Shape:  ${liveHost}/file/~/<orgId>/<driveId>/<normalized-path>
  */
@@ -118,8 +119,11 @@ export function buildAgentFsLiveUrl(opts: {
 }): string | null {
   const path = opts.path?.trim();
   if (!path) return null;
-  const orgId = opts.orgId?.trim() || getAgentFsDefaultOrgId();
-  const driveId = opts.driveId?.trim() || getAgentFsDefaultDriveId();
+  const rowOrgId = opts.orgId?.trim();
+  const rowDriveId = opts.driveId?.trim();
+  const hasRowId = Boolean(rowOrgId || rowDriveId);
+  const orgId = hasRowId ? rowOrgId : getAgentFsDefaultOrgId();
+  const driveId = hasRowId ? rowDriveId : getAgentFsDefaultDriveId();
   if (!orgId || !driveId) return null;
   const host = getAgentFsLiveUrl();
   const normalizedPath = path.replace(/^\/+/, "");

--- a/src/utils/content-disposition.ts
+++ b/src/utils/content-disposition.ts
@@ -1,0 +1,15 @@
+/**
+ * Build a Latin-1-safe RFC 6266 Content-Disposition value for downloads.
+ * `filename` provides a conservative ASCII fallback while `filename*`
+ * preserves the original UTF-8 filename for clients that support RFC 5987.
+ */
+export function attachmentContentDisposition(filename: string): string {
+  const safeFilename = filename.replace(/[\r\n\0]/g, "").replace(/["\\\\]/g, "");
+  const asciiFallback = safeFilename.replace(/[^\x20-\x7e]/g, "_");
+  const encodedFilename = encodeURIComponent(safeFilename).replace(
+    /[!'()*]/g,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+
+  return `attachment; filename="${asciiFallback || "download"}"; filename*=UTF-8''${encodedFilename || "download"}`;
+}


### PR DESCRIPTION
## Summary
- Encode task and eval artifact download filenames using an ASCII `filename=` fallback plus RFC 5987 UTF-8 `filename*=` to avoid invalid HTTP headers while preserving non-ASCII names.
- Persist agent-fs attachment `orgId` and `driveId` together, and render a live-host link only for a complete row-scoped pair in the task UI.
- Apply the same paired-ID rule server-side: a partial row remains an `agent-fs:` pointer rather than borrowing a default ID. Defaults still resolve the legacy path-only shape when the row supplies neither ID. This protects Slack attachment links and resumed-agent context preambles from cross-org or cross-drive URLs.

<img width="982" height="570" alt="Screenshot 2026-08-06 at 11 32 45" src="https://github.com/user-attachments/assets/b14c4178-d898-4d44-8cc7-cf566c895064" />


## Planning artifacts
- [Research](https://live.agent-fs.dev/file/~/a5306c74-9247-4dfc-a38e-2141fcd00035/b096d0f3-2a1a-439a-8d6c-8bb4f703d9e2/thoughts/0d022f19-38ff-4d32-95b2-315fc0864114/research/2026-08-06-task-view-agent-fs-attachments.md)
- [Plan](https://live.agent-fs.dev/file/~/a5306c74-9247-4dfc-a38e-2141fcd00035/b096d0f3-2a1a-439a-8d6c-8bb4f703d9e2/thoughts/0d022f19-38ff-4d32-95b2-315fc0864114/plans/2026-08-06-task-view-agent-fs-attachments.md)

## Test plan
- Run `bun install --frozen-lockfile`, `bun run lint`, `bun run tsc:check`, `bun run test:root`, `bash scripts/check-db-boundary.sh`, `bash scripts/check-api-key-boundary.sh`, and `bun run check:dep-graph`.
- From `apps/ui`, run `bun install --frozen-lockfile`, `bun run lint`, and `bunx tsc -b`.
- Download an attachment with a non-ASCII filename (for example, `PR analytics backfill — dry-run report`); verify a successful response with both `filename=` and UTF-8 `filename*=` Content-Disposition parameters.
- Verify a task-view agent-fs attachment with both row IDs is an inline live-host link; verify one with either ID missing is plain text.
- Verify server-side Slack/context attachment formatting: both row IDs produce a live URL; either one alone stays `agent-fs:<path>` even when defaults are set; neither uses the configured default pair.