### PR TITLE
fix(claude-adapter): drop malformed modelUsage breakdowns instead of zero-filling

### DIFF
--- a/docs-site/content/docs/(documentation)/guides/cost-and-context-computation.mdx
+++ b/docs-site/content/docs/(documentation)/guides/cost-and-context-computation.mdx
@@ -69,7 +69,11 @@ Claude's final `result.modelUsage` is preserved as `modelBreakdown`, including
 sidechain/subagent entries. The API prices every entry at that entry's own
 model rate, sums those totals, and stores the per-model computed `costUsd` in
 the breakdown. Top-level stored token totals are the corresponding breakdown
-sums when one exists, rather than only the main-thread usage.
+sums when one exists, rather than only the main-thread usage. Because the
+breakdown takes precedence, the adapter refuses to zero-fill it: a missing,
+non-finite, or negative token counter on any entry drops the whole breakdown
+and the session falls back to top-level usage (advisory fields like
+`webSearchRequests` and per-model `costUSD` degrade per-field instead).
 
 `web_search` is a request-priced class, not a token rate. The manual rows for
 `claude` and `claude-managed` encode Anthropic's $10 per 1,000 requests

--- a/src/providers/claude-adapter.ts
+++ b/src/providers/claude-adapter.ts
@@ -994,23 +994,54 @@ class ClaudeSession implements ProviderSession {
         const cacheWrite1hTokens = cacheCreation
           ? toFiniteNumber(cacheCreation.ephemeral_1h_input_tokens)
           : undefined;
-        const models =
+        // Token counters are load-bearing downstream: the server gives models[]
+        // precedence over top-level usage for BOTH row token totals and pricing,
+        // so a zero-filled counter would store a fabricated $0 'pricing-table'
+        // row. Negative counts would be rejected by the wire schema and void
+        // the whole cost write.
+        const toTokenCount = (value: unknown): number | undefined => {
+          const n = toFiniteNumber(value);
+          return n !== undefined && n >= 0 ? n : undefined;
+        };
+        const mappedModels =
           json.modelUsage && typeof json.modelUsage === "object" && !Array.isArray(json.modelUsage)
             ? Object.entries(json.modelUsage as Record<string, unknown>).map(([model, entry]) => {
                 const modelUsage =
-                  entry && typeof entry === "object" ? (entry as Record<string, unknown>) : {};
-                const webSearchRequests = toFiniteNumber(modelUsage.webSearchRequests);
+                  entry && typeof entry === "object" ? (entry as Record<string, unknown>) : null;
+                if (!modelUsage) return null;
+                const inputTokens = toTokenCount(modelUsage.inputTokens);
+                const outputTokens = toTokenCount(modelUsage.outputTokens);
+                const cacheReadTokens = toTokenCount(modelUsage.cacheReadInputTokens);
+                const cacheWriteTokens = toTokenCount(modelUsage.cacheCreationInputTokens);
+                if (
+                  inputTokens === undefined ||
+                  outputTokens === undefined ||
+                  cacheReadTokens === undefined ||
+                  cacheWriteTokens === undefined
+                ) {
+                  return null;
+                }
+                // Advisory fields degrade per-field: a malformed value is
+                // omitted without invalidating the entry.
+                const webSearchRequests = toTokenCount(modelUsage.webSearchRequests);
                 const harnessCostUsd = toFiniteNumber(modelUsage.costUSD);
                 return {
                   model,
-                  inputTokens: toFiniteNumber(modelUsage.inputTokens) ?? 0,
-                  outputTokens: toFiniteNumber(modelUsage.outputTokens) ?? 0,
-                  cacheReadTokens: toFiniteNumber(modelUsage.cacheReadInputTokens) ?? 0,
-                  cacheWriteTokens: toFiniteNumber(modelUsage.cacheCreationInputTokens) ?? 0,
+                  inputTokens,
+                  outputTokens,
+                  cacheReadTokens,
+                  cacheWriteTokens,
                   ...(webSearchRequests === undefined ? {} : { webSearchRequests }),
                   ...(harnessCostUsd === undefined ? {} : { harnessCostUsd }),
                 };
               })
+            : undefined;
+        // One malformed entry poisons the whole breakdown — a partial list
+        // would silently undercount the session. Fall back to top-level usage
+        // (the pre-breakdown path) instead of manufacturing zeros.
+        const models =
+          mappedModels && mappedModels.length > 0 && mappedModels.every((m) => m !== null)
+            ? (mappedModels as NonNullable<CostData["models"]>)
             : undefined;
 
         const cost: CostData = {

--- a/src/providers/pricing-sources.md
+++ b/src/providers/pricing-sources.md
@@ -102,6 +102,15 @@ session) and is documented in the cost-and-context-computation guide.
   `src/providers/codex-models.ts` is advisory only. The canonical price is the
   server-side recompute against the runtime-refreshed pricing table;
   `agentswarm.cost.drift.usd` watches for divergence between the two.
+- **Claude breakdown validity is all-or-nothing:** the claude adapter drops the
+  entire `modelUsage` breakdown when any entry carries a missing, non-finite,
+  or negative token counter — zero-filling would let the server price a
+  fabricated $0 `pricing-table` row, and a partial list would undercount.
+  Such sessions are priced from top-level usage (main-thread only) instead of
+  per-model sums; the harness total is preserved in `harnessCostUsd`, so the
+  divergence surfaces in `agentswarm.cost.drift.usd`. Advisory fields
+  (`webSearchRequests`, per-model `costUSD`) degrade per-field without
+  invalidating the entry.
 
 ## When a model is missing
 

--- a/src/tests/claude-adapter.test.ts
+++ b/src/tests/claude-adapter.test.ts
@@ -449,20 +449,54 @@ describe("ClaudeSession processStreams — ProviderResult.output capture", () =>
     // null/garbage TTL values must not become 0 (Number(null) === 0 hazard).
     expect(result.cost?.cacheWrite5mTokens).toBeUndefined();
     expect(result.cost?.cacheWrite1hTokens).toBeUndefined();
+    // A malformed token counter anywhere invalidates the whole breakdown:
+    // models[] takes precedence server-side for row totals and pricing, so
+    // zero-filling would store a fabricated $0 'pricing-table' row. The server
+    // falls back to the (valid) top-level usage instead.
+    expect(result.cost?.models).toBeUndefined();
+    expect(result.cost?.totalCostUsd).toBe(0.7);
+    expect(result.cost?.inputTokens).toBe(10);
+    expect(result.cost?.outputTokens).toBe(20);
+  });
+
+  test("malformed advisory fields degrade per-field without dropping the breakdown", async () => {
+    const lines = [
+      JSON.stringify({
+        type: "result",
+        total_cost_usd: 0.7,
+        duration_ms: 100,
+        num_turns: 1,
+        usage: {
+          input_tokens: 10,
+          output_tokens: 20,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+        modelUsage: {
+          "claude-opus-5": {
+            inputTokens: 11,
+            outputTokens: 22,
+            cacheReadInputTokens: 33,
+            cacheCreationInputTokens: 44,
+            webSearchRequests: null,
+            costUSD: "not-a-number",
+          },
+        },
+      }),
+    ];
+    spawnSpy.mockImplementation((() => makeStreamingFakeProc(lines)) as typeof Bun.spawn);
+
+    const adapter = new ClaudeAdapter();
+    const session = await adapter.createSession(makeConfig({ env: CLEAN_ENV }));
+    const result = await session.waitForCompletion();
+
     expect(result.cost?.models).toEqual([
       {
         model: "claude-opus-5",
-        inputTokens: 0,
+        inputTokens: 11,
         outputTokens: 22,
         cacheReadTokens: 33,
         cacheWriteTokens: 44,
-      },
-      {
-        model: "claude-haiku-4-5",
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheWriteTokens: 0,
       },
     ]);
     const opus = result.cost?.models?.[0];


### PR DESCRIPTION
## Summary

Follow-up to #1134: carries the final Codex-review fix that was pushed to `worktree-cost-audit` a few minutes **after** the PR was merged, so it never landed on main (the resolved review thread on #1134 references commit 11196573 — this is that change, cherry-picked onto main).

**The fix** (claude adapter): a malformed `result.modelUsage` entry used to be zero-filled via `?? 0` fallbacks. Since the server gives `models[]` precedence over top-level usage for both row token totals and per-model pricing, a malformed entry could store a fabricated **$0 `pricing-table` row** (or silently undercount) while a valid harness total existed.

New contract:
- Any entry with a missing, non-finite, or **negative** token counter invalidates the whole breakdown — `models` is omitted and the server falls back to top-level usage (the pre-breakdown path), with the harness total preserved via `harnessCostUsd`. A partial list would silently undercount, so it's all-or-nothing.
- Advisory fields (`webSearchRequests`, per-model `costUSD`) still degrade per-field without dropping the entry.
- The negative-counter check also prevents a poisoned entry from 400-ing the entire cost write against the wire's `.nonnegative()` pins.

Docs: contract noted in `cost-and-context-computation.mdx`.

## Verification

- `bun run test:root -- src/tests/claude-adapter.test.ts`: 38/38 (malformed-breakdown test now expects the fallback; new test covers advisory-only degradation).
- lint + tsc clean; full pre-push gate green.

https://claude.ai/code/session_01GcEDPoibmMBDo4UdtBbTKx
