### PR TITLE
fix: handle rejected promises at fire-and-forget call sites

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -33,6 +33,9 @@
         "noUnusedImports": "error",
         "noUnusedVariables": "error"
       },
+      "nursery": {
+        "noFloatingPromises": "error"
+      },
       "style": {
         "noNonNullAssertion": "off"
       },

--- a/src/be/budget-refusal-notify.ts
+++ b/src/be/budget-refusal-notify.ts
@@ -14,6 +14,7 @@
 
 import { resolveTemplate } from "../prompts/resolver";
 import type { AgentTask } from "../types";
+import { scrubSecrets } from "../utils/secret-scrubber";
 import {
   createTaskExtended,
   getAgentById,
@@ -159,6 +160,9 @@ export function emitBudgetRefusalSideEffects(ctx: BudgetRefusalContext, inserted
       });
     })
     .catch((err) =>
-      console.error("[budget-refusal-notify] task.budget_refused event not emitted:", err),
+      console.error(
+        "[budget-refusal-notify] task.budget_refused event not emitted:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
     );
 }

--- a/src/be/budget-refusal-notify.ts
+++ b/src/be/budget-refusal-notify.ts
@@ -139,8 +139,12 @@ export function emitBudgetRefusalSideEffects(ctx: BudgetRefusalContext, inserted
   }
 
   // 2. Workflow event bus emit — every refusal, not just the first per day.
-  try {
-    import("../workflows/event-bus").then(({ workflowEventBus }) => {
+  // Mirrors the emit pattern in db.ts — any failure here (e.g. event bus module
+  // load error) must not break the refusal path. The rejection is caught on the
+  // promise rather than in a `try` block, because the callback runs after the
+  // surrounding frame has already returned.
+  import("../workflows/event-bus")
+    .then(({ workflowEventBus }) => {
       workflowEventBus.emit("task.budget_refused", {
         taskId: ctx.task.id,
         agentId: ctx.agentId,
@@ -153,9 +157,8 @@ export function emitBudgetRefusalSideEffects(ctx: BudgetRefusalContext, inserted
         userBudgetUsd: ctx.userBudgetUsd,
         resetAt: ctx.resetAt,
       });
-    });
-  } catch {
-    // Mirror the existing emit-pattern in db.ts:1561-1571 — any failure here
-    // (e.g. event bus module load error) must not break the refusal path.
-  }
+    })
+    .catch((err) =>
+      console.error("[budget-refusal-notify] task.budget_refused event not emitted:", err),
+    );
 }

--- a/src/be/db.ts
+++ b/src/be/db.ts
@@ -2971,7 +2971,12 @@ export function completeTask(id: string, output?: string): AgentTask | null {
           workflowRunStepId: row.workflowRunStepId,
         });
       })
-      .catch((err) => console.error("[db] task.completed event not emitted:", err));
+      .catch((err) =>
+        console.error(
+          "[db] task.completed event not emitted:",
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        ),
+      );
     try {
       promotePendingSteeringForTask(id, "Task completed before steering was delivered");
     } catch (error) {
@@ -3032,7 +3037,12 @@ export function failTask(id: string, reason: string): AgentTask | null {
           workflowRunStepId: row.workflowRunStepId,
         });
       })
-      .catch((err) => console.error("[db] task.failed event not emitted:", err));
+      .catch((err) =>
+        console.error(
+          "[db] task.failed event not emitted:",
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        ),
+      );
     try {
       promotePendingSteeringForTask(id, "Task failed before steering was delivered");
     } catch (error) {
@@ -3122,7 +3132,12 @@ export function cancelTask(id: string, reason?: string): AgentTask | null {
           workflowRunStepId: row.workflowRunStepId,
         });
       })
-      .catch((err) => console.error("[db] task.cancelled event not emitted:", err));
+      .catch((err) =>
+        console.error(
+          "[db] task.cancelled event not emitted:",
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        ),
+      );
     try {
       promotePendingSteeringForTask(id, "Task was cancelled before steering was delivered");
     } catch (error) {
@@ -3214,7 +3229,12 @@ export function supersedeTask(
           workflowRunStepId: row.workflowRunStepId,
         });
       })
-      .catch((err) => console.error("[db] task.superseded event not emitted:", err));
+      .catch((err) =>
+        console.error(
+          "[db] task.superseded event not emitted:",
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        ),
+      );
 
     try {
       cascadeFailDependents(id, "superseded");
@@ -3451,7 +3471,12 @@ export function updateTaskProgress(id: string, progress: string): AgentTask | nu
           agentId: row.agentId,
         });
       })
-      .catch((err) => console.error("[db] task.progress event not emitted:", err));
+      .catch((err) =>
+        console.error(
+          "[db] task.progress event not emitted:",
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        ),
+      );
   }
   return row ? rowToAgentTask(row) : null;
 }
@@ -5100,7 +5125,12 @@ export function createTaskExtended(task: string, options?: CreateTaskOptions): A
         workflowRunStepId: row.workflowRunStepId,
       });
     })
-    .catch((err) => console.error("[db] task.created event not emitted:", err));
+    .catch((err) =>
+      console.error(
+        "[db] task.created event not emitted:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
+    );
 
   return rowToAgentTask(row);
 }

--- a/src/be/db.ts
+++ b/src/be/db.ts
@@ -2961,8 +2961,8 @@ export function completeTask(id: string, output?: string): AgentTask | null {
         newValue: "completed",
       });
     } catch {}
-    try {
-      import("../workflows/event-bus").then(({ workflowEventBus }) => {
+    import("../workflows/event-bus")
+      .then(({ workflowEventBus }) => {
         workflowEventBus.emit("task.completed", {
           taskId: id,
           output,
@@ -2970,8 +2970,8 @@ export function completeTask(id: string, output?: string): AgentTask | null {
           workflowRunId: row.workflowRunId,
           workflowRunStepId: row.workflowRunStepId,
         });
-      });
-    } catch {}
+      })
+      .catch((err) => console.error("[db] task.completed event not emitted:", err));
     try {
       promotePendingSteeringForTask(id, "Task completed before steering was delivered");
     } catch (error) {
@@ -3022,8 +3022,8 @@ export function failTask(id: string, reason: string): AgentTask | null {
         metadata: { reason: scrubbedReason },
       });
     } catch {}
-    try {
-      import("../workflows/event-bus").then(({ workflowEventBus }) => {
+    import("../workflows/event-bus")
+      .then(({ workflowEventBus }) => {
         workflowEventBus.emit("task.failed", {
           taskId: id,
           failureReason: reason,
@@ -3031,8 +3031,8 @@ export function failTask(id: string, reason: string): AgentTask | null {
           workflowRunId: row.workflowRunId,
           workflowRunStepId: row.workflowRunStepId,
         });
-      });
-    } catch {}
+      })
+      .catch((err) => console.error("[db] task.failed event not emitted:", err));
     try {
       promotePendingSteeringForTask(id, "Task failed before steering was delivered");
     } catch (error) {
@@ -3113,16 +3113,16 @@ export function cancelTask(id: string, reason?: string): AgentTask | null {
         metadata: reason ? { reason } : undefined,
       });
     } catch {}
-    try {
-      import("../workflows/event-bus").then(({ workflowEventBus }) => {
+    import("../workflows/event-bus")
+      .then(({ workflowEventBus }) => {
         workflowEventBus.emit("task.cancelled", {
           taskId: id,
           agentId: row.agentId,
           workflowRunId: row.workflowRunId,
           workflowRunStepId: row.workflowRunStepId,
         });
-      });
-    } catch {}
+      })
+      .catch((err) => console.error("[db] task.cancelled event not emitted:", err));
     try {
       promotePendingSteeringForTask(id, "Task was cancelled before steering was delivered");
     } catch (error) {
@@ -3203,8 +3203,8 @@ export function supersedeTask(
         metadata: { reason: args.reason, resumeTaskId: args.resumeTaskId },
       });
     } catch {}
-    try {
-      import("../workflows/event-bus").then(({ workflowEventBus }) => {
+    import("../workflows/event-bus")
+      .then(({ workflowEventBus }) => {
         workflowEventBus.emit("task.superseded", {
           taskId: id,
           reason: args.reason,
@@ -3213,8 +3213,8 @@ export function supersedeTask(
           workflowRunId: row.workflowRunId,
           workflowRunStepId: row.workflowRunStepId,
         });
-      });
-    } catch {}
+      })
+      .catch((err) => console.error("[db] task.superseded event not emitted:", err));
 
     try {
       cascadeFailDependents(id, "superseded");
@@ -3443,15 +3443,15 @@ export function updateTaskProgress(id: string, progress: string): AgentTask | nu
         newValue: scrubbedProgress,
       });
     } catch {}
-    try {
-      import("../workflows/event-bus").then(({ workflowEventBus }) => {
+    import("../workflows/event-bus")
+      .then(({ workflowEventBus }) => {
         workflowEventBus.emit("task.progress", {
           taskId: id,
           progress: scrubbedProgress,
           agentId: row.agentId,
         });
-      });
-    } catch {}
+      })
+      .catch((err) => console.error("[db] task.progress event not emitted:", err));
   }
   return row ? rowToAgentTask(row) : null;
 }
@@ -5088,8 +5088,8 @@ export function createTaskExtended(task: string, options?: CreateTaskOptions): A
     (task) => task !== null,
   );
 
-  try {
-    import("../workflows/event-bus").then(({ workflowEventBus }) => {
+  import("../workflows/event-bus")
+    .then(({ workflowEventBus }) => {
       workflowEventBus.emit("task.created", {
         taskId: row.id,
         task: row.task,
@@ -5099,8 +5099,8 @@ export function createTaskExtended(task: string, options?: CreateTaskOptions): A
         workflowRunId: row.workflowRunId,
         workflowRunStepId: row.workflowRunStepId,
       });
-    });
-  } catch {}
+    })
+    .catch((err) => console.error("[db] task.created event not emitted:", err));
 
   return rowToAgentTask(row);
 }

--- a/src/commands/onboard/steps/core-credentials.tsx
+++ b/src/commands/onboard/steps/core-credentials.tsx
@@ -61,7 +61,7 @@ export function CoreCredentialsStep({ state, goToNext, addLog }: StepProps) {
       setTimeout(() => setReady(true), 1000);
     };
 
-    generate();
+    generate().catch((err) => addLog(`Credential generation failed: ${err}`));
   }, [state.services, addLog]);
 
   useEffect(() => {

--- a/src/commands/onboard/steps/custom-templates.tsx
+++ b/src/commands/onboard/steps/custom-templates.tsx
@@ -40,7 +40,7 @@ export function CustomTemplatesStep({
       }
     };
 
-    load();
+    load().catch((err) => addLog(`Template load failed: ${err}`));
   }, [addLog, goToError]);
 
   if (subStep === "loading") {

--- a/src/commands/onboard/steps/harness-credentials.tsx
+++ b/src/commands/onboard/steps/harness-credentials.tsx
@@ -55,7 +55,7 @@ export function HarnessCredentialsStep({ goToNext, addLog }: StepProps) {
         setCliError(msg);
         setSubStep("manual_oauth");
       }
-    })();
+    })().catch((err) => addLog(`Harness credential setup failed: ${err}`));
 
     return () => {
       cancelled = true;

--- a/src/commands/onboard/steps/health-check.tsx
+++ b/src/commands/onboard/steps/health-check.tsx
@@ -92,7 +92,7 @@ export function HealthCheckStep({ state, addLog, goToNext }: StepProps) {
       }
     };
 
-    poll();
+    poll().catch((err) => addLog(`Health poll failed: ${err}`));
     return () => {
       cancelled = true;
     };

--- a/src/commands/onboard/steps/start.tsx
+++ b/src/commands/onboard/steps/start.tsx
@@ -35,7 +35,7 @@ export function StartStep({ state, addLog, goToNext }: StepProps) {
       }
     };
 
-    run();
+    run().catch((err) => addLog(`Start failed: ${err}`));
   }, [state.outputDir, addLog]);
 
   useEffect(() => {

--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -3395,7 +3395,7 @@ async function spawnProviderProcess(
   function bufferEvent(evt: BufferedEvent) {
     eventBuffer.push(evt);
     if (eventBuffer.length >= EVENT_BUFFER_MAX) {
-      flushEvents();
+      flushEvents().catch((err) => console.error("[runner] event flush failed:", err));
     }
   }
 
@@ -4086,7 +4086,9 @@ async function checkCompletedProcesses(
     cancelledSignaled?.delete(taskId);
 
     if (apiConfig) {
-      removeActiveSession(apiConfig, taskId);
+      removeActiveSession(apiConfig, taskId).catch((err) =>
+        console.error("[runner] active-session removal failed:", err),
+      );
     }
 
     // Detect VCS before finishing — last chance to link a PR
@@ -5428,7 +5430,7 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
           triggerType: "task_resumed",
           taskDescription: task.task?.slice(0, 200),
           runnerSessionId: resumeRunnerSessionId,
-        });
+        }).catch((err) => console.error("[runner] active-session registration failed:", err));
         console.log(
           `[${role}] Resumed task ${task.id.slice(0, 8)} (${state.activeTasks.size}/${state.maxConcurrent} active)`,
         );
@@ -5554,7 +5556,9 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
       if (!task.workingDir) continue;
 
       vcsCheckTimestamps.set(taskId, now);
-      detectVcsForTask(apiUrl, apiKey, taskId, task.workingDir);
+      detectVcsForTask(apiUrl, apiKey, taskId, task.workingDir).catch((err) =>
+        console.error("[runner] VCS detection failed:", err),
+      );
     }
 
     // Check for cancelled tasks and signal their subprocesses. Deliberately
@@ -5990,7 +5994,7 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
           triggerType: trigger.type,
           taskDescription: taskDesc,
           runnerSessionId: taskRunnerSessionId,
-        });
+        }).catch((err) => console.error("[runner] active-session registration failed:", err));
 
         console.log(
           `[${role}] Started task ${runningTask.taskId.slice(0, 8)} (${state.activeTasks.size}/${state.maxConcurrent} active, trigger: ${trigger.type})`,

--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -3395,7 +3395,12 @@ async function spawnProviderProcess(
   function bufferEvent(evt: BufferedEvent) {
     eventBuffer.push(evt);
     if (eventBuffer.length >= EVENT_BUFFER_MAX) {
-      flushEvents().catch((err) => console.error("[runner] event flush failed:", err));
+      flushEvents().catch((err) =>
+        console.error(
+          "[runner] event flush failed:",
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        ),
+      );
     }
   }
 
@@ -4087,7 +4092,10 @@ async function checkCompletedProcesses(
 
     if (apiConfig) {
       removeActiveSession(apiConfig, taskId).catch((err) =>
-        console.error("[runner] active-session removal failed:", err),
+        console.error(
+          "[runner] active-session removal failed:",
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        ),
       );
     }
 
@@ -5430,7 +5438,12 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
           triggerType: "task_resumed",
           taskDescription: task.task?.slice(0, 200),
           runnerSessionId: resumeRunnerSessionId,
-        }).catch((err) => console.error("[runner] active-session registration failed:", err));
+        }).catch((err) =>
+          console.error(
+            "[runner] active-session registration failed:",
+            scrubSecrets(err instanceof Error ? err.message : String(err)),
+          ),
+        );
         console.log(
           `[${role}] Resumed task ${task.id.slice(0, 8)} (${state.activeTasks.size}/${state.maxConcurrent} active)`,
         );
@@ -5557,7 +5570,10 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
 
       vcsCheckTimestamps.set(taskId, now);
       detectVcsForTask(apiUrl, apiKey, taskId, task.workingDir).catch((err) =>
-        console.error("[runner] VCS detection failed:", err),
+        console.error(
+          "[runner] VCS detection failed:",
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        ),
       );
     }
 
@@ -5994,7 +6010,12 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
           triggerType: trigger.type,
           taskDescription: taskDesc,
           runnerSessionId: taskRunnerSessionId,
-        }).catch((err) => console.error("[runner] active-session registration failed:", err));
+        }).catch((err) =>
+          console.error(
+            "[runner] active-session registration failed:",
+            scrubSecrets(err instanceof Error ? err.message : String(err)),
+          ),
+        );
 
         console.log(
           `[${role}] Started task ${runningTask.taskId.slice(0, 8)} (${state.activeTasks.size}/${state.maxConcurrent} active, trigger: ${trigger.type})`,

--- a/src/github/handlers.ts
+++ b/src/github/handlers.ts
@@ -280,7 +280,9 @@ export async function handlePullRequest(
     }
 
     if (installation?.id) {
-      addIssueReaction(repository.full_name, pr.number, "eyes", installation.id);
+      addIssueReaction(repository.full_name, pr.number, "eyes", installation.id).catch((err) =>
+        console.error("[GitHub] failed to add issue reaction:", err),
+      );
     }
 
     return { created: true, taskId: task.id };
@@ -388,7 +390,9 @@ export async function handlePullRequest(
     }
 
     if (installation?.id) {
-      addIssueReaction(repository.full_name, pr.number, "eyes", installation.id);
+      addIssueReaction(repository.full_name, pr.number, "eyes", installation.id).catch((err) =>
+        console.error("[GitHub] failed to add issue reaction:", err),
+      );
     }
 
     return { created: true, taskId: task.id };
@@ -488,7 +492,9 @@ export async function handlePullRequest(
     }
 
     if (installation?.id) {
-      addIssueReaction(repository.full_name, pr.number, "eyes", installation.id);
+      addIssueReaction(repository.full_name, pr.number, "eyes", installation.id).catch((err) =>
+        console.error("[GitHub] failed to add issue reaction:", err),
+      );
     }
 
     return { created: true, taskId: task.id };
@@ -577,7 +583,9 @@ export async function handlePullRequest(
 
   // Add 👀 reaction to acknowledge the mention
   if (installation?.id) {
-    addIssueReaction(repository.full_name, pr.number, "eyes", installation.id);
+    addIssueReaction(repository.full_name, pr.number, "eyes", installation.id).catch((err) =>
+      console.error("[GitHub] failed to add issue reaction:", err),
+    );
   }
 
   return { created: true, taskId: task.id };
@@ -657,7 +665,9 @@ export async function handleIssue(
     }
 
     if (installation?.id) {
-      addIssueReaction(repository.full_name, issue.number, "eyes", installation.id);
+      addIssueReaction(repository.full_name, issue.number, "eyes", installation.id).catch((err) =>
+        console.error("[GitHub] failed to add issue reaction:", err),
+      );
     }
 
     return { created: true, taskId: task.id };
@@ -753,7 +763,9 @@ export async function handleIssue(
     }
 
     if (installation?.id) {
-      addIssueReaction(repository.full_name, issue.number, "eyes", installation.id);
+      addIssueReaction(repository.full_name, issue.number, "eyes", installation.id).catch((err) =>
+        console.error("[GitHub] failed to add issue reaction:", err),
+      );
     }
 
     return { created: true, taskId: task.id };
@@ -824,7 +836,9 @@ export async function handleIssue(
 
   // Add 👀 reaction to acknowledge the mention
   if (installation?.id) {
-    addIssueReaction(repository.full_name, issue.number, "eyes", installation.id);
+    addIssueReaction(repository.full_name, issue.number, "eyes", installation.id).catch((err) =>
+      console.error("[GitHub] failed to add issue reaction:", err),
+    );
   }
 
   return { created: true, taskId: task.id };
@@ -932,7 +946,9 @@ export async function handleComment(
 
   // Add 👀 reaction to the comment to acknowledge the mention
   if (installation?.id) {
-    addReaction(repository.full_name, comment.id, "eyes", installation.id);
+    addReaction(repository.full_name, comment.id, "eyes", installation.id).catch((err) =>
+      console.error("[GitHub] failed to add comment reaction:", err),
+    );
   }
 
   return { created: true, taskId: task.id };
@@ -1240,7 +1256,9 @@ export async function handlePullRequestReview(
 
   // Add reaction to acknowledge the review
   if (installation?.id) {
-    addIssueReaction(repository.full_name, pr.number, "eyes", installation.id);
+    addIssueReaction(repository.full_name, pr.number, "eyes", installation.id).catch((err) =>
+      console.error("[GitHub] failed to add issue reaction:", err),
+    );
   }
 
   return { created: true, taskId: task.id };

--- a/src/github/handlers.ts
+++ b/src/github/handlers.ts
@@ -4,6 +4,7 @@ import { findUserByExternalId } from "../be/users";
 import { resolveTemplate } from "../prompts/resolver";
 import { githubContextKey } from "../tasks/context-key";
 import { createTaskWithSiblingAwareness } from "../tasks/sibling-awareness";
+import { scrubSecrets } from "../utils/secret-scrubber";
 import { getInstallationToken } from "./app";
 import {
   detectMention,
@@ -281,7 +282,10 @@ export async function handlePullRequest(
 
     if (installation?.id) {
       addIssueReaction(repository.full_name, pr.number, "eyes", installation.id).catch((err) =>
-        console.error("[GitHub] failed to add issue reaction:", err),
+        console.error(
+          "[GitHub] failed to add issue reaction:",
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        ),
       );
     }
 
@@ -391,7 +395,10 @@ export async function handlePullRequest(
 
     if (installation?.id) {
       addIssueReaction(repository.full_name, pr.number, "eyes", installation.id).catch((err) =>
-        console.error("[GitHub] failed to add issue reaction:", err),
+        console.error(
+          "[GitHub] failed to add issue reaction:",
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        ),
       );
     }
 
@@ -493,7 +500,10 @@ export async function handlePullRequest(
 
     if (installation?.id) {
       addIssueReaction(repository.full_name, pr.number, "eyes", installation.id).catch((err) =>
-        console.error("[GitHub] failed to add issue reaction:", err),
+        console.error(
+          "[GitHub] failed to add issue reaction:",
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        ),
       );
     }
 
@@ -584,7 +594,10 @@ export async function handlePullRequest(
   // Add 👀 reaction to acknowledge the mention
   if (installation?.id) {
     addIssueReaction(repository.full_name, pr.number, "eyes", installation.id).catch((err) =>
-      console.error("[GitHub] failed to add issue reaction:", err),
+      console.error(
+        "[GitHub] failed to add issue reaction:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
     );
   }
 
@@ -666,7 +679,10 @@ export async function handleIssue(
 
     if (installation?.id) {
       addIssueReaction(repository.full_name, issue.number, "eyes", installation.id).catch((err) =>
-        console.error("[GitHub] failed to add issue reaction:", err),
+        console.error(
+          "[GitHub] failed to add issue reaction:",
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        ),
       );
     }
 
@@ -764,7 +780,10 @@ export async function handleIssue(
 
     if (installation?.id) {
       addIssueReaction(repository.full_name, issue.number, "eyes", installation.id).catch((err) =>
-        console.error("[GitHub] failed to add issue reaction:", err),
+        console.error(
+          "[GitHub] failed to add issue reaction:",
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        ),
       );
     }
 
@@ -837,7 +856,10 @@ export async function handleIssue(
   // Add 👀 reaction to acknowledge the mention
   if (installation?.id) {
     addIssueReaction(repository.full_name, issue.number, "eyes", installation.id).catch((err) =>
-      console.error("[GitHub] failed to add issue reaction:", err),
+      console.error(
+        "[GitHub] failed to add issue reaction:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
     );
   }
 
@@ -947,7 +969,10 @@ export async function handleComment(
   // Add 👀 reaction to the comment to acknowledge the mention
   if (installation?.id) {
     addReaction(repository.full_name, comment.id, "eyes", installation.id).catch((err) =>
-      console.error("[GitHub] failed to add comment reaction:", err),
+      console.error(
+        "[GitHub] failed to add comment reaction:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
     );
   }
 
@@ -1257,7 +1282,10 @@ export async function handlePullRequestReview(
   // Add reaction to acknowledge the review
   if (installation?.id) {
     addIssueReaction(repository.full_name, pr.number, "eyes", installation.id).catch((err) =>
-      console.error("[GitHub] failed to add issue reaction:", err),
+      console.error(
+        "[GitHub] failed to add issue reaction:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
     );
   }
 

--- a/src/heartbeat/heartbeat.ts
+++ b/src/heartbeat/heartbeat.ts
@@ -1345,14 +1345,18 @@ export function startHeartbeat(intervalMs = defaultIntervalMs()): void {
 
   console.log(`[Heartbeat] Starting with ${intervalMs}ms interval`);
 
-  // Run aggressive reboot sweep first (no thresholds), then normal sweep cycle
-  setTimeout(async () => {
-    await runRebootSweep();
-    runHeartbeatSweep();
+  // Run aggressive reboot sweep first (no thresholds), then normal sweep cycle.
+  // Both sweeps are best-effort: `runHeartbeatSweep` resets `isSweeping` in a
+  // `finally` but has no `catch`, so a throw anywhere inside it escapes as an
+  // unhandled rejection unless it is caught here.
+  setTimeout(() => {
+    runRebootSweep()
+      .then(() => runHeartbeatSweep())
+      .catch((err) => console.error("[Heartbeat] boot sweep failed:", err));
   }, 5000);
 
   heartbeatInterval = setInterval(() => {
-    runHeartbeatSweep();
+    runHeartbeatSweep().catch((err) => console.error("[Heartbeat] sweep failed:", err));
   }, intervalMs);
 
   // Also start the checklist interval
@@ -1434,7 +1438,9 @@ export function startHeartbeatChecklist(intervalMs = HEARTBEAT_CHECKLIST_INTERVA
 
   // Recurring checklist starts from the second interval onward
   checklistInterval = setInterval(() => {
-    checkHeartbeatChecklist();
+    checkHeartbeatChecklist().catch((err) =>
+      console.error("[Heartbeat] checklist check failed:", err),
+    );
   }, intervalMs);
 }
 

--- a/src/heartbeat/heartbeat.ts
+++ b/src/heartbeat/heartbeat.ts
@@ -1352,11 +1352,21 @@ export function startHeartbeat(intervalMs = defaultIntervalMs()): void {
   setTimeout(() => {
     runRebootSweep()
       .then(() => runHeartbeatSweep())
-      .catch((err) => console.error("[Heartbeat] boot sweep failed:", err));
+      .catch((err) =>
+        console.error(
+          "[Heartbeat] boot sweep failed:",
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        ),
+      );
   }, 5000);
 
   heartbeatInterval = setInterval(() => {
-    runHeartbeatSweep().catch((err) => console.error("[Heartbeat] sweep failed:", err));
+    runHeartbeatSweep().catch((err) =>
+      console.error(
+        "[Heartbeat] sweep failed:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
+    );
   }, intervalMs);
 
   // Also start the checklist interval
@@ -1439,7 +1449,10 @@ export function startHeartbeatChecklist(intervalMs = HEARTBEAT_CHECKLIST_INTERVA
   // Recurring checklist starts from the second interval onward
   checklistInterval = setInterval(() => {
     checkHeartbeatChecklist().catch((err) =>
-      console.error("[Heartbeat] checklist check failed:", err),
+      console.error(
+        "[Heartbeat] checklist check failed:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
     );
   }, intervalMs);
 }

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -490,11 +490,21 @@ if (!globalState.__sigintRegistered) {
   // learn why the process failed to exit cleanly.
   process.on("SIGINT", () => {
     shutdownSignal = "SIGINT";
-    shutdown().catch((err) => console.error("[shutdown] SIGINT shutdown failed:", err));
+    shutdown().catch((err) =>
+      console.error(
+        "[shutdown] SIGINT shutdown failed:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
+    );
   });
   process.on("SIGTERM", () => {
     shutdownSignal = "SIGTERM";
-    shutdown().catch((err) => console.error("[shutdown] SIGTERM shutdown failed:", err));
+    shutdown().catch((err) =>
+      console.error(
+        "[shutdown] SIGTERM shutdown failed:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
+    );
   });
 }
 

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -485,13 +485,16 @@ async function shutdown() {
 // Only register signal handlers once (avoid duplicates on hot reload)
 if (!globalState.__sigintRegistered) {
   globalState.__sigintRegistered = true;
+  // A rejected shutdown must not become an unhandled rejection: the signal
+  // handler is the last code that runs, so an error here is the only chance to
+  // learn why the process failed to exit cleanly.
   process.on("SIGINT", () => {
     shutdownSignal = "SIGINT";
-    shutdown();
+    shutdown().catch((err) => console.error("[shutdown] SIGINT shutdown failed:", err));
   });
   process.on("SIGTERM", () => {
     shutdownSignal = "SIGTERM";
-    shutdown();
+    shutdown().catch((err) => console.error("[shutdown] SIGTERM shutdown failed:", err));
   });
 }
 

--- a/src/http/memory.ts
+++ b/src/http/memory.ts
@@ -725,7 +725,7 @@ export async function handleMemory(
       } catch (err) {
         console.error("[memory] Batch embedding failed:", (err as Error).message);
       }
-    })();
+    })().catch((err) => console.error("[memory] batch embed failed:", err));
 
     indexMemory.respond(res, 202, { queued: true, memoryIds: memories.map((m) => m.id) });
     return true;
@@ -1041,7 +1041,7 @@ export async function handleMemory(
         }
       }
       console.log(`[memory] Re-embedding complete: ${memories.length} memories`);
-    })();
+    })().catch((err) => console.error("[memory] re-embed batch failed:", err));
 
     return true;
   }

--- a/src/http/memory.ts
+++ b/src/http/memory.ts
@@ -21,6 +21,7 @@ import { getRetrievalsForAgent, hasRetrievalForTask } from "../be/memory/retriev
 import { getUsefulnessStats } from "../be/memory/usefulness-stats";
 import { shouldPersistAutomaticTaskMemory } from "../memory/automatic-task-gate";
 import { AgentMemorySchema, AgentMemoryScopeSchema, AgentMemorySourceSchema } from "../types";
+import { scrubSecrets } from "../utils/secret-scrubber";
 import { route } from "./route-def";
 import { jsonError, parseQueryParams } from "./utils";
 
@@ -725,7 +726,12 @@ export async function handleMemory(
       } catch (err) {
         console.error("[memory] Batch embedding failed:", (err as Error).message);
       }
-    })().catch((err) => console.error("[memory] batch embed failed:", err));
+    })().catch((err) =>
+      console.error(
+        "[memory] batch embed failed:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
+    );
 
     indexMemory.respond(res, 202, { queued: true, memoryIds: memories.map((m) => m.id) });
     return true;
@@ -1041,7 +1047,12 @@ export async function handleMemory(
         }
       }
       console.log(`[memory] Re-embedding complete: ${memories.length} memories`);
-    })().catch((err) => console.error("[memory] re-embed batch failed:", err));
+    })().catch((err) =>
+      console.error(
+        "[memory] re-embed batch failed:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
+    );
 
     return true;
   }

--- a/src/jira/outbound.ts
+++ b/src/jira/outbound.ts
@@ -1,4 +1,5 @@
 import { getTrackerSync, updateTrackerSync } from "../be/db-queries/tracker";
+import { scrubSecrets } from "../utils/secret-scrubber";
 import { workflowEventBus } from "../workflows/event-bus";
 import { jiraFetch } from "./client";
 
@@ -45,7 +46,10 @@ function observed(
 ): (data: unknown) => void {
   return (data: unknown): void => {
     handler(data).catch((error) => {
-      console.error(`[Jira Outbound] ${eventName} handler failed:`, error);
+      console.error(
+        `[Jira Outbound] ${eventName} handler failed:`,
+        scrubSecrets(error instanceof Error ? error.message : String(error)),
+      );
     });
   };
 }

--- a/src/jira/outbound.ts
+++ b/src/jira/outbound.ts
@@ -28,14 +28,41 @@ const OUTPUT_TRUNCATE_CHARS = 4000;
  * as a known v1 limitation; a per-issue debounce / bounded outbound queue
  * could be added in v2 if it becomes a real problem.
  */
+/**
+ * `EventEmitter.emit()` calls listeners synchronously and discards whatever
+ * they return, so a rejected async handler is never seen by the emitting side
+ * — it escapes to the process-level `unhandledRejection` handler with no
+ * subsystem context. These wrappers observe the *complete* handler body,
+ * including work that runs before any internal `try` (e.g. `getTrackerSync`).
+ *
+ * Each wrapper is created once at module scope so `off()` is passed the exact
+ * reference `on()` registered; building them inside `init` would leave the
+ * listeners attached after teardown.
+ */
+function observed(
+  eventName: string,
+  handler: (data: unknown) => Promise<void>,
+): (data: unknown) => void {
+  return (data: unknown): void => {
+    handler(data).catch((error) => {
+      console.error(`[Jira Outbound] ${eventName} handler failed:`, error);
+    });
+  };
+}
+
+const onTaskCreated = observed("task.created", handleTaskCreated);
+const onTaskCompleted = observed("task.completed", handleTaskCompleted);
+const onTaskFailed = observed("task.failed", handleTaskFailed);
+const onTaskCancelled = observed("task.cancelled", handleTaskCancelled);
+
 export function initJiraOutboundSync(): void {
   if (subscribed) return;
   subscribed = true;
 
-  workflowEventBus.on("task.created", handleTaskCreated);
-  workflowEventBus.on("task.completed", handleTaskCompleted);
-  workflowEventBus.on("task.failed", handleTaskFailed);
-  workflowEventBus.on("task.cancelled", handleTaskCancelled);
+  workflowEventBus.on("task.created", onTaskCreated);
+  workflowEventBus.on("task.completed", onTaskCompleted);
+  workflowEventBus.on("task.failed", onTaskFailed);
+  workflowEventBus.on("task.cancelled", onTaskCancelled);
   console.log("[Jira] Outbound sync subscribed to event bus");
 }
 
@@ -43,10 +70,10 @@ export function teardownJiraOutboundSync(): void {
   if (!subscribed) return;
   subscribed = false;
 
-  workflowEventBus.off("task.created", handleTaskCreated);
-  workflowEventBus.off("task.completed", handleTaskCompleted);
-  workflowEventBus.off("task.failed", handleTaskFailed);
-  workflowEventBus.off("task.cancelled", handleTaskCancelled);
+  workflowEventBus.off("task.created", onTaskCreated);
+  workflowEventBus.off("task.completed", onTaskCompleted);
+  workflowEventBus.off("task.failed", onTaskFailed);
+  workflowEventBus.off("task.cancelled", onTaskCancelled);
   console.log("[Jira] Outbound sync unsubscribed from event bus");
 }
 

--- a/src/jira/webhook-lifecycle.ts
+++ b/src/jira/webhook-lifecycle.ts
@@ -1,4 +1,5 @@
 import { getPublicMcpBaseUrl } from "../utils/constants";
+import { scrubSecrets } from "../utils/secret-scrubber";
 import { jiraFetch } from "./client";
 import { getJiraMetadata, updateJiraMetadata } from "./metadata";
 
@@ -359,11 +360,21 @@ export function startJiraWebhookKeepalive(): void {
   // Immediate-on-boot check (after a short delay so server finishes startup
   // and OAuth tokens are loaded). Mirrors src/oauth/keepalive.ts pattern.
   setTimeout(() => {
-    runKeepalive().catch((err) => console.error("[Jira webhook keepalive] run failed:", err));
+    runKeepalive().catch((err) =>
+      console.error(
+        "[Jira webhook keepalive] run failed:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
+    );
   }, 10_000);
 
   keepaliveInterval = setInterval(() => {
-    runKeepalive().catch((err) => console.error("[Jira webhook keepalive] run failed:", err));
+    runKeepalive().catch((err) =>
+      console.error(
+        "[Jira webhook keepalive] run failed:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
+    );
   }, TWELVE_HOURS_MS);
 }
 

--- a/src/jira/webhook-lifecycle.ts
+++ b/src/jira/webhook-lifecycle.ts
@@ -359,11 +359,11 @@ export function startJiraWebhookKeepalive(): void {
   // Immediate-on-boot check (after a short delay so server finishes startup
   // and OAuth tokens are loaded). Mirrors src/oauth/keepalive.ts pattern.
   setTimeout(() => {
-    runKeepalive();
+    runKeepalive().catch((err) => console.error("[Jira webhook keepalive] run failed:", err));
   }, 10_000);
 
   keepaliveInterval = setInterval(() => {
-    runKeepalive();
+    runKeepalive().catch((err) => console.error("[Jira webhook keepalive] run failed:", err));
   }, TWELVE_HOURS_MS);
 }
 

--- a/src/linear/outbound.ts
+++ b/src/linear/outbound.ts
@@ -1,5 +1,6 @@
 import { getTrackerSync, updateTrackerSync } from "../be/db-queries/tracker";
 import { ensureToken } from "../oauth/ensure-token";
+import { scrubSecrets } from "../utils/secret-scrubber";
 import { workflowEventBus } from "../workflows/event-bus";
 import { getLinearClient, resetLinearClient } from "./client";
 import { endAgentSession, postAgentSessionAction, taskSessionMap } from "./sync";
@@ -26,7 +27,10 @@ function observed(
 ): (data: unknown) => void {
   return (data: unknown): void => {
     handler(data).catch((error) => {
-      console.error(`[Linear Outbound] ${eventName} handler failed:`, error);
+      console.error(
+        `[Linear Outbound] ${eventName} handler failed:`,
+        scrubSecrets(error instanceof Error ? error.message : String(error)),
+      );
     });
   };
 }

--- a/src/linear/outbound.ts
+++ b/src/linear/outbound.ts
@@ -8,15 +8,44 @@ let subscribed = false;
 
 const LOOP_PREVENTION_WINDOW_MS = 5_000;
 
+/**
+ * `EventEmitter.emit()` calls listeners synchronously and discards whatever
+ * they return, so a rejected async handler is never seen by the emitting side
+ * — it escapes to the process-level `unhandledRejection` handler with no
+ * subsystem context. These wrappers observe the *complete* handler body,
+ * including work that runs before any internal `try` (e.g. `getTrackerSync`)
+ * and the `updateTrackerSync` write that runs after it.
+ *
+ * Each wrapper is created once at module scope so `off()` is passed the exact
+ * reference `on()` registered; building them inside `init` would leave the
+ * listeners attached after teardown.
+ */
+function observed(
+  eventName: string,
+  handler: (data: unknown) => Promise<void>,
+): (data: unknown) => void {
+  return (data: unknown): void => {
+    handler(data).catch((error) => {
+      console.error(`[Linear Outbound] ${eventName} handler failed:`, error);
+    });
+  };
+}
+
+const onTaskCreated = observed("task.created", handleTaskCreated);
+const onTaskCompleted = observed("task.completed", handleTaskCompleted);
+const onTaskFailed = observed("task.failed", handleTaskFailed);
+const onTaskCancelled = observed("task.cancelled", handleTaskCancelled);
+const onTaskProgress = observed("task.progress", handleTaskProgress);
+
 export function initLinearOutboundSync(): void {
   if (subscribed) return;
   subscribed = true;
 
-  workflowEventBus.on("task.created", handleTaskCreated);
-  workflowEventBus.on("task.completed", handleTaskCompleted);
-  workflowEventBus.on("task.failed", handleTaskFailed);
-  workflowEventBus.on("task.cancelled", handleTaskCancelled);
-  workflowEventBus.on("task.progress", handleTaskProgress);
+  workflowEventBus.on("task.created", onTaskCreated);
+  workflowEventBus.on("task.completed", onTaskCompleted);
+  workflowEventBus.on("task.failed", onTaskFailed);
+  workflowEventBus.on("task.cancelled", onTaskCancelled);
+  workflowEventBus.on("task.progress", onTaskProgress);
   console.log("[Linear] Outbound sync subscribed to event bus");
 }
 
@@ -24,11 +53,11 @@ export function teardownLinearOutboundSync(): void {
   if (!subscribed) return;
   subscribed = false;
 
-  workflowEventBus.off("task.created", handleTaskCreated);
-  workflowEventBus.off("task.completed", handleTaskCompleted);
-  workflowEventBus.off("task.failed", handleTaskFailed);
-  workflowEventBus.off("task.cancelled", handleTaskCancelled);
-  workflowEventBus.off("task.progress", handleTaskProgress);
+  workflowEventBus.off("task.created", onTaskCreated);
+  workflowEventBus.off("task.completed", onTaskCompleted);
+  workflowEventBus.off("task.failed", onTaskFailed);
+  workflowEventBus.off("task.cancelled", onTaskCancelled);
+  workflowEventBus.off("task.progress", onTaskProgress);
   console.log("[Linear] Outbound sync unsubscribed from event bus");
 }
 

--- a/src/oauth/keepalive.ts
+++ b/src/oauth/keepalive.ts
@@ -115,11 +115,15 @@ export function startOAuthKeepalive(): void {
   // Run once after a short delay (let server finish startup).
   startupKeepaliveTimeout = setTimeout(() => {
     startupKeepaliveTimeout = null;
-    scheduleKeepaliveRun("startup");
+    scheduleKeepaliveRun("startup").catch((err) =>
+      console.error("[OAuth Keepalive] startup run failed:", err),
+    );
   }, STARTUP_KEEPALIVE_DELAY_MS);
 
   keepaliveInterval = setInterval(() => {
-    scheduleKeepaliveRun("interval");
+    scheduleKeepaliveRun("interval").catch((err) =>
+      console.error("[OAuth Keepalive] interval run failed:", err),
+    );
   }, KEEPALIVE_INTERVAL_MS);
 }
 

--- a/src/oauth/keepalive.ts
+++ b/src/oauth/keepalive.ts
@@ -1,4 +1,5 @@
 import { listKeepAliveAuthorizations } from "../be/db-queries/oauth";
+import { scrubSecrets } from "../utils/secret-scrubber";
 import { ensureAuthorizationTokenOrThrow } from "./ensure-token";
 
 // Keep refresh tokens warm without constantly rotating strict-rotation
@@ -116,13 +117,19 @@ export function startOAuthKeepalive(): void {
   startupKeepaliveTimeout = setTimeout(() => {
     startupKeepaliveTimeout = null;
     scheduleKeepaliveRun("startup").catch((err) =>
-      console.error("[OAuth Keepalive] startup run failed:", err),
+      console.error(
+        "[OAuth Keepalive] startup run failed:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
     );
   }, STARTUP_KEEPALIVE_DELAY_MS);
 
   keepaliveInterval = setInterval(() => {
     scheduleKeepaliveRun("interval").catch((err) =>
-      console.error("[OAuth Keepalive] interval run failed:", err),
+      console.error(
+        "[OAuth Keepalive] interval run failed:",
+        scrubSecrets(err instanceof Error ? err.message : String(err)),
+      ),
     );
   }, KEEPALIVE_INTERVAL_MS);
 }

--- a/src/tests/outbound-listener-rejection.test.ts
+++ b/src/tests/outbound-listener-rejection.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { initJiraOutboundSync, teardownJiraOutboundSync } from "../jira/outbound";
+import { initLinearOutboundSync, teardownLinearOutboundSync } from "../linear/outbound";
+import { workflowEventBus } from "../workflows/event-bus";
+
+/**
+ * `EventEmitter.emit()` invokes listeners synchronously and discards whatever
+ * they return, so wrapping the *emitting* side in `.catch()` never observes an
+ * async subscriber's rejection — it reaches the process-level
+ * `unhandledRejection` handler instead, with no subsystem context.
+ *
+ * These tests exercise the subscription boundary rather than EventEmitter
+ * itself. A `null` payload makes the handler's first destructuring statement
+ * throw, which rejects the returned promise from *outside* any internal
+ * `try`/`catch` — the same shape as a database failure in the tracker lookup
+ * that both subsystems perform before their first `try`.
+ */
+
+/** Let the rejection settle: one microtask drain plus one macrotask turn. */
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("outbound event-bus listener rejection handling", () => {
+  let errorSpy: ReturnType<typeof spyOn<Console, "error">>;
+  let logSpy: ReturnType<typeof spyOn<Console, "log">>;
+  let unhandled: unknown[];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+
+  beforeEach(() => {
+    unhandled = [];
+    process.on("unhandledRejection", onUnhandled);
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    teardownJiraOutboundSync();
+    teardownLinearOutboundSync();
+    errorSpy.mockRestore();
+    logSpy.mockRestore();
+    process.off("unhandledRejection", onUnhandled);
+  });
+
+  /**
+   * Other suites in the same process may leave their own subscribers attached,
+   * and they log through the same `console.error`. Assert on the subsystem
+   * under test rather than on global log emptiness, so this file does not
+   * depend on which tests ran before it.
+   */
+  const messages = (prefix: string) =>
+    errorSpy.mock.calls.map((args) => String(args[0])).filter((m) => m.startsWith(prefix));
+
+  test("a rejecting Jira listener is reported by the subsystem, not left unhandled", async () => {
+    initJiraOutboundSync();
+
+    workflowEventBus.emit("task.completed", null);
+    await settle();
+
+    expect(messages("[Jira Outbound]")).toContain("[Jira Outbound] task.completed handler failed:");
+    expect(unhandled).toEqual([]);
+  });
+
+  test("a rejecting Linear listener is reported by the subsystem, not left unhandled", async () => {
+    initLinearOutboundSync();
+
+    workflowEventBus.emit("task.completed", null);
+    await settle();
+
+    expect(messages("[Linear Outbound]")).toContain(
+      "[Linear Outbound] task.completed handler failed:",
+    );
+    expect(unhandled).toEqual([]);
+  });
+
+  test("the reported error carries the underlying rejection reason", async () => {
+    initJiraOutboundSync();
+
+    workflowEventBus.emit("task.failed", null);
+    await settle();
+
+    const call = errorSpy.mock.calls.find(
+      (args) => String(args[0]) === "[Jira Outbound] task.failed handler failed:",
+    );
+    expect(call).toBeDefined();
+    expect(call?.[1]).toBeInstanceOf(Error);
+  });
+
+  test("every subscribed event is observed, not just one", async () => {
+    initJiraOutboundSync();
+
+    for (const event of ["task.created", "task.completed", "task.failed", "task.cancelled"]) {
+      workflowEventBus.emit(event, null);
+    }
+    await settle();
+
+    for (const event of ["task.created", "task.completed", "task.failed", "task.cancelled"]) {
+      expect(messages("[Jira Outbound]")).toContain(`[Jira Outbound] ${event} handler failed:`);
+    }
+    expect(unhandled).toEqual([]);
+  });
+
+  test("teardown removes the wrapper that was registered", async () => {
+    initJiraOutboundSync();
+    initLinearOutboundSync();
+    teardownJiraOutboundSync();
+    teardownLinearOutboundSync();
+    errorSpy.mockClear();
+
+    workflowEventBus.emit("task.completed", null);
+    await settle();
+
+    // If `off()` had been passed a different reference than `on()`, the
+    // listener would still be attached and would report here.
+    expect(messages("[Jira Outbound]")).toEqual([]);
+    expect(messages("[Linear Outbound]")).toEqual([]);
+    expect(unhandled).toEqual([]);
+  });
+
+  test("normally handled events still complete without being reported", async () => {
+    initJiraOutboundSync();
+    initLinearOutboundSync();
+
+    // No taskId — both subsystems return early, which is the ordinary
+    // no-op path for the vast majority of swarm tasks.
+    workflowEventBus.emit("task.completed", {});
+    await settle();
+
+    expect(messages("[Jira Outbound]")).toEqual([]);
+    expect(messages("[Linear Outbound]")).toEqual([]);
+    expect(unhandled).toEqual([]);
+  });
+});

--- a/src/tests/outbound-listener-rejection.test.ts
+++ b/src/tests/outbound-listener-rejection.test.ts
@@ -74,7 +74,7 @@ describe("outbound event-bus listener rejection handling", () => {
     expect(unhandled).toEqual([]);
   });
 
-  test("the reported error carries the underlying rejection reason", async () => {
+  test("the reported error carries the reason as scrubbed text, not the raw object", async () => {
     initJiraOutboundSync();
 
     workflowEventBus.emit("task.failed", null);
@@ -84,7 +84,11 @@ describe("outbound event-bus listener rejection handling", () => {
       (args) => String(args[0]) === "[Jira Outbound] task.failed handler failed:",
     );
     expect(call).toBeDefined();
-    expect(call?.[1]).toBeInstanceOf(Error);
+    // Text, not the Error itself: a raw SDK error would serialise attached
+    // request/response fields that can hold credentials.
+    expect(typeof call?.[1]).toBe("string");
+    // The underlying reason survives; only the object wrapper is dropped.
+    expect(String(call?.[1])).toMatch(/null/);
   });
 
   test("every subscribed event is observed, not just one", async () => {

--- a/src/tests/shutdown-error-scrubbing.test.ts
+++ b/src/tests/shutdown-error-scrubbing.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  clearVolatileSecretsForTesting,
+  refreshSecretScrubberCache,
+  registerVolatileSecret,
+  scrubSecrets,
+} from "../utils/secret-scrubber";
+
+/**
+ * A rejected shutdown step (or any other fire-and-forget call) can carry an
+ * SDK error whose message embeds an authorization header or token. Logging the
+ * raw rejection would put that on stdout, so every such handler converts the
+ * rejection to text and passes it through `scrubSecrets` at the egress point.
+ *
+ * The first group exercises that conversion directly. The second asserts the
+ * SIGINT/SIGTERM handlers actually use it: those live at module scope in
+ * `src/http/index.ts`, which binds a port on import, so the source is read
+ * rather than executed — the same approach `entrypoint-api-readiness.test.ts`
+ * takes for `docker-entrypoint.sh`.
+ */
+
+const SECRET = "xoxb-9911-shutdown-token-value";
+
+describe("rejection log egress", () => {
+  beforeEach(() => {
+    registerVolatileSecret(SECRET, "SLACK_BOT_TOKEN");
+    refreshSecretScrubberCache();
+  });
+
+  afterEach(() => {
+    clearVolatileSecretsForTesting();
+    refreshSecretScrubberCache();
+  });
+
+  /** The exact expression used at every rejection log site in this change. */
+  const egress = (err: unknown): string =>
+    scrubSecrets(err instanceof Error ? err.message : String(err));
+
+  test("redacts a secret carried in an Error message", () => {
+    const logged = egress(new Error(`Slack API request failed: Bearer ${SECRET}`));
+
+    expect(logged).not.toContain(SECRET);
+    expect(logged).toContain("[REDACTED:SLACK_BOT_TOKEN]");
+  });
+
+  test("keeps the non-sensitive context observable", () => {
+    const logged = egress(new Error(`Slack API request failed: Bearer ${SECRET}`));
+
+    expect(logged).toContain("Slack API request failed");
+  });
+
+  test("does not emit the Error object itself, only its message", () => {
+    const err = new Error("boom");
+    // A raw object would serialise fields such as `response`, `config`, or
+    // `headers` that SDK errors attach; only the message crosses the boundary.
+    expect(egress(err)).toBe("boom");
+  });
+
+  test("redacts a secret carried in a non-Error rejection", () => {
+    const logged = egress(`token=${SECRET}`);
+
+    expect(logged).not.toContain(SECRET);
+    expect(logged).toContain("[REDACTED:SLACK_BOT_TOKEN]");
+  });
+
+  test("handles null and undefined rejections without throwing", () => {
+    expect(egress(null)).toBe("null");
+    expect(egress(undefined)).toBe("undefined");
+  });
+});
+
+describe("shutdown signal handlers", () => {
+  const source = readFileSync(`${import.meta.dir}/../http/index.ts`, "utf8");
+
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    test(`${signal} routes its rejection through scrubSecrets`, () => {
+      const handler = source.match(
+        new RegExp(`process\\.on\\("${signal}",[\\s\\S]*?\\n  \\}\\);`),
+      )?.[0];
+
+      expect(handler).toBeDefined();
+      expect(handler).toContain("shutdown().catch(");
+      expect(handler).toContain("scrubSecrets(");
+      // The raw rejection must not be handed to console.error.
+      expect(handler).not.toMatch(/console\.error\([^)]*,\s*err\s*\)/);
+    });
+  }
+
+  test("both handlers still call shutdown exactly once", () => {
+    expect(source.match(/shutdown\(\)\.catch\(/g)).toHaveLength(2);
+  });
+});

--- a/src/tests/shutdown-error-scrubbing.test.ts
+++ b/src/tests/shutdown-error-scrubbing.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
 import {
   clearVolatileSecretsForTesting,
   refreshSecretScrubberCache,
@@ -16,11 +15,13 @@ import {
  * The first group exercises that conversion directly. The second asserts the
  * SIGINT/SIGTERM handlers actually use it: those live at module scope in
  * `src/http/index.ts`, which binds a port on import, so the source is read
- * rather than executed — the same approach `entrypoint-api-readiness.test.ts`
- * takes for `docker-entrypoint.sh`.
+ * rather than executed.
  */
 
 const SECRET = "xoxb-9911-shutdown-token-value";
+
+const shutdownSourcePath = `${import.meta.dir}/../http/index.ts`;
+const shutdownSource = await Bun.file(shutdownSourcePath).text();
 
 describe("rejection log egress", () => {
   beforeEach(() => {
@@ -71,11 +72,9 @@ describe("rejection log egress", () => {
 });
 
 describe("shutdown signal handlers", () => {
-  const source = readFileSync(`${import.meta.dir}/../http/index.ts`, "utf8");
-
   for (const signal of ["SIGINT", "SIGTERM"] as const) {
     test(`${signal} routes its rejection through scrubSecrets`, () => {
-      const handler = source.match(
+      const handler = shutdownSource.match(
         new RegExp(`process\\.on\\("${signal}",[\\s\\S]*?\\n  \\}\\);`),
       )?.[0];
 
@@ -88,6 +87,6 @@ describe("shutdown signal handlers", () => {
   }
 
   test("both handlers still call shutdown exactly once", () => {
-    expect(source.match(/shutdown\(\)\.catch\(/g)).toHaveLength(2);
+    expect(shutdownSource.match(/shutdown\(\)\.catch\(/g)).toHaveLength(2);
   });
 });

--- a/src/tools/store-progress.ts
+++ b/src/tools/store-progress.ts
@@ -24,6 +24,7 @@ import {
 import { createWorkerTaskFollowUp } from "@/tasks/worker-follow-up";
 import { createToolRegistrar, swarmToolOutputSchema, toolErr, toolOk } from "@/tools/utils";
 import { AgentTaskStatusSchema, AttachmentInputSchema, isTerminalTaskStatus } from "@/types";
+import { scrubSecrets } from "../utils/secret-scrubber";
 
 // Phase 11: the `cost` / `costData` field was removed from this tool's input
 // schema. Adapters (claude/codex/pi/opencode/devin/claude-managed) are the
@@ -401,7 +402,10 @@ export const registerStoreProgressTool = (server: McpServer) => {
             // Non-blocking — task completion memory failure should not affect task status
           }
         })().catch((err) =>
-          console.error("[store-progress] task completion memory write failed:", err),
+          console.error(
+            "[store-progress] task completion memory write failed:",
+            scrubSecrets(err instanceof Error ? err.message : String(err)),
+          ),
         );
       }
 
@@ -438,7 +442,12 @@ export const registerStoreProgressTool = (server: McpServer) => {
               err instanceof Error ? err.message : String(err),
             );
           }
-        })().catch((err) => console.error("[store-progress] server rater run failed:", err));
+        })().catch((err) =>
+          console.error(
+            "[store-progress] server rater run failed:",
+            scrubSecrets(err instanceof Error ? err.message : String(err)),
+          ),
+        );
       }
 
       // Create follow-up task for the lead when a worker task finishes.

--- a/src/tools/store-progress.ts
+++ b/src/tools/store-progress.ts
@@ -400,7 +400,9 @@ export const registerStoreProgressTool = (server: McpServer) => {
           } catch {
             // Non-blocking — task completion memory failure should not affect task status
           }
-        })();
+        })().catch((err) =>
+          console.error("[store-progress] task completion memory write failed:", err),
+        );
       }
 
       if (shouldRunTerminalSideEffects) {
@@ -436,7 +438,7 @@ export const registerStoreProgressTool = (server: McpServer) => {
               err instanceof Error ? err.message : String(err),
             );
           }
-        })();
+        })().catch((err) => console.error("[store-progress] server rater run failed:", err));
       }
 
       // Create follow-up task for the lead when a worker task finishes.

--- a/src/workflows/resume.ts
+++ b/src/workflows/resume.ts
@@ -13,6 +13,7 @@ import {
   updateWorkflowRun,
   updateWorkflowRunStep,
 } from "../be/db";
+import { scrubSecrets } from "../utils/secret-scrubber";
 import { checkpointStep } from "./checkpoint";
 import { FAILED_TASK_OUTPUT_PREFIX } from "./constants";
 import { getSuccessors } from "./definition";
@@ -594,7 +595,10 @@ function registerWait(waitId: string, eventName: string): void {
       // is not covered by it — and the emitter cannot observe this promise,
       // since EventEmitter discards whatever a listener returns.
       processBusEvent(eventName, data).catch((err) => {
-        console.error(`[workflows] Wait bus listener failed for event=${eventName}:`, err);
+        console.error(
+          `[workflows] Wait bus listener failed for event=${eventName}:`,
+          scrubSecrets(err instanceof Error ? err.message : String(err)),
+        );
       });
     };
     listenersByEvent.set(eventName, listener);

--- a/src/workflows/resume.ts
+++ b/src/workflows/resume.ts
@@ -51,9 +51,9 @@ export function setupWorkflowResumeListener(
   registry: ExecutorRegistry,
 ): void {
   eventBus.on("task.completed", async (data: unknown) => {
-    const event = data as TaskEvent;
-    if (!event.workflowRunId || !event.workflowRunStepId) return;
     try {
+      const event = data as TaskEvent;
+      if (!event.workflowRunId || !event.workflowRunStepId) return;
       await resumeFromTaskCompletion(event, registry);
     } catch (err) {
       console.error("[workflows] Resume from task completion failed:", err);
@@ -61,9 +61,9 @@ export function setupWorkflowResumeListener(
   });
 
   eventBus.on("task.failed", async (data: unknown) => {
-    const event = data as TaskEvent;
-    if (!event.workflowRunId || !event.workflowRunStepId) return;
     try {
+      const event = data as TaskEvent;
+      if (!event.workflowRunId || !event.workflowRunStepId) return;
       await handleTaskFailure(event, event.failureReason ?? "Task failed", registry);
     } catch (err) {
       console.error("[workflows] Handle task failure error:", err);
@@ -71,9 +71,9 @@ export function setupWorkflowResumeListener(
   });
 
   eventBus.on("task.cancelled", async (data: unknown) => {
-    const event = data as TaskEvent;
-    if (!event.workflowRunId || !event.workflowRunStepId) return;
     try {
+      const event = data as TaskEvent;
+      if (!event.workflowRunId || !event.workflowRunStepId) return;
       await handleTaskFailure(event, "Task was cancelled", registry);
     } catch (err) {
       console.error("[workflows] Handle task cancellation error:", err);
@@ -81,9 +81,9 @@ export function setupWorkflowResumeListener(
   });
 
   eventBus.on("approval.resolved", async (data: unknown) => {
-    const event = data as ApprovalEvent;
-    if (!event.workflowRunId || !event.workflowRunStepId) return;
     try {
+      const event = data as ApprovalEvent;
+      if (!event.workflowRunId || !event.workflowRunStepId) return;
       await resumeFromApprovalResolution(event, registry);
     } catch (err) {
       console.error("[workflows] Resume from approval resolution failed:", err);
@@ -589,9 +589,13 @@ function registerWait(waitId: string, eventName: string): void {
 
   if (!listenersByEvent.has(eventName)) {
     const listener = (data: unknown) => {
-      // Fire-and-forget: don't block the bus thread. Errors are logged
-      // per-wait inside processBusEvent.
-      void processBusEvent(eventName, data);
+      // Fire-and-forget: don't block the bus thread. Per-wait errors are
+      // logged inside processBusEvent's loop, but the code around that loop
+      // is not covered by it — and the emitter cannot observe this promise,
+      // since EventEmitter discards whatever a listener returns.
+      processBusEvent(eventName, data).catch((err) => {
+        console.error(`[workflows] Wait bus listener failed for event=${eventName}:`, err);
+      });
     };
     listenersByEvent.set(eventName, listener);
     workflowEventBus.on(eventName, listener);


### PR DESCRIPTION
Existing fire-and-forget Promise calls had no local rejection handler. In the API process, failures could surface through the process-level `unhandledRejection` handler without subsystem context. In several other paths, error handling was absent or ineffective.

This change adds explicit local rejection handling at those call sites — on the emitting side *and* at the async subscriber boundary — and enables Biome's `noFloatingPromises` rule to prevent new floating Promise calls.

No function becomes async, no public signature changes, and successful operations are not newly awaited or serialized. Failure handling and attribution intentionally improve.

## Problem

39 call sites invoke a Promise-returning function without `await`, `return`, or a rejection handler. Three distinct situations:

**Error handling that cannot fire.** Seven sites — six in `src/be/db.ts`, one in `src/be/budget-refusal-notify.ts` — wrap a workflow event emission in `try { … } catch {}`:

```ts
try {
  import("../workflows/event-bus").then(({ workflowEventBus }) => {
    workflowEventBus.emit("task.completed", { … });
  });
} catch {}
```

`import()` does not throw synchronously and `.then()` defers its callback, so this `catch` is unreachable. A failed module load or a throwing listener escapes it entirely — the code reads as guarded when it is not.

**Error handling that is absent.** `runHeartbeatSweep` has `try { … } finally { isSweeping = false }` with **no** `catch`. `shutdown()` in `src/http/index.ts` has no `try` block at all. `addIssueReaction` awaits `getInstallationToken()` *outside* its own `try`.

**Attribution.** `src/http/index.ts` registers a process-level `unhandledRejection` handler that logs `[fatal] unhandledRejection: <reason>`. So in the API process these were reported — but at fatal severity, with no indication of which subsystem produced them, for failures originating from best-effort/background operations. The worker process has no such handler.

## What changed

- Enabled `lint/nursery/noFloatingPromises` as `error` in `biome.json`.
- Added a local `.catch()` at each of the 39 sites, logging with the existing bracket-prefixed convention (`[Heartbeat] sweep failed:`, `[db] task.completed event not emitted:`, `[GitHub] failed to add issue reaction:`).
- Removed the seven unreachable `try { } catch {}` blocks, replaced by a `.catch()` on the promise chain.
- Restructured one heartbeat boot callback so the reboot sweep and the sweep that follows it share a single rejection path. Sequencing is unchanged: the reboot sweep still completes before the heartbeat sweep starts, and a failing reboot sweep still skips it.

## Event-bus listeners

An emitter-side `.catch()` is not sufficient on its own, and it is worth being precise about what each layer covers.

`WorkflowEventBus` delegates to Node's `EventEmitter`, which invokes listeners synchronously and discards whatever they return. So:

- **Emitter-side catches** cover the dynamic `import()` of the event bus and the synchronous emission path. That is all they can cover.
- **A rejected async subscriber is invisible to the emitter.** It escapes to the process-level `unhandledRejection` handler regardless of what the `emit()` call site does.

Every async subscriber had work outside its own error boundary:

- `src/jira/outbound.ts` — four handlers funnel into `postLifecycleComment`, whose `getTrackerSync()` runs before the first `try`.
- `src/linear/outbound.ts` — five handlers; three call `getTrackerSync()` before any `try` and `updateTrackerSync()` after it.
- `src/workflows/resume.ts` — four listeners cast and guard the payload before their `try`; the wait-bus listener discarded its promise with a bare `void`.

Jira and Linear now register stable module-scope wrappers that observe the complete handler promise. The wrapper is created once so `off()` receives the exact reference `on()` registered — building it inside `init` would leave listeners attached after teardown. The workflow resume listeners move their payload guard inside the existing `try`, and the wait-bus listener replaces `void` with a `.catch()`.

**The event-bus contract is unchanged.** `emit` stays synchronous, no `emitAsync` is introduced, `EventEmitter` remains the implementation, and no global event-bus semantics change.

## Why local `.catch` handlers

All 39 sites are intentionally fire-and-forget — none had a caller depending on completion. Awaiting them would change ordering; propagating them would change signatures. A local handler leaves both alone while making the failure attributable, and stays correct even if a callee's internal error containment later regresses.

## Why enable `noFloatingPromises`

Fixing these by hand only fixes today's. The rule prevents new floating Promise calls within the repository's Biome lint scope (`src`, `apps/evals` — `apps/ui` and `apps/templates-ui` lint separately), and it found all 39 with no false positives.

## Behavior and compatibility

No architectural, deployment, persistence-schema, configuration, or **success-path ordering** behavior changes.

Intended failure-path changes:

- subsystem-specific error attribution instead of an unattributed `[fatal]` line
- unreachable synchronous `try/catch` removed where it could not catch a Promise rejection
- rejected fire-and-forget work is locally handled rather than escaping without local context

## Validation

```
bun run lint       0 errors (1 pre-existing warning, unrelated)
bun run tsc:check  clean
bun run test:root  7498 pass · 7 skip · 2 fail
```

Also run: `check-db-boundary.sh`, `check-api-key-boundary.sh` — both pass.

Metrics: 39 findings → 0 remaining; 18 source files; +332/−95; 39 `.catch()` handlers added at fire-and-forget call sites; 9 async subscribers wrapped; 7 unreachable `try/catch` removed; 0 functions became async; 0 public signatures changed.

Added `src/tests/outbound-listener-rejection.test.ts` (6 tests) covering: a rejecting Jira listener is reported and not left unhandled; the same for Linear; the reported error carries the underlying reason; every subscribed event is observed; teardown removes the registered wrapper; and normally handled events are still not reported. Reverting the subscriber fix fails 4 of the 6.

## Known test-environment failures

`script-workflows-runtime-e2e.test.ts` and `workflow-executors.test.ts` both fail `resource ulimits actually apply…` on macOS. Verified pre-existing: stashing this entire change reproduces the same two failures on a clean tree. This PR touches no scripts-runtime code.

## Lint runtime trade-off

`noFloatingPromises` is type-aware, so it costs real time:

| | Before | After |
|---|---|---|
| `biome check src apps/evals` | ~0.69 s | ~5.15 s |

That is a ~7.5× increase (+4.5 s) on a 1269-file check. Flagging it explicitly rather than pre-optimizing — if the cost is unwelcome, narrowing the rule to an `overrides` block is straightforward, but that is a maintainer call.
