### PR TITLE
feat(db): retry SQLITE_BUSY at the DbClient choke point

### DIFF
--- a/src/be/db-client.ts
+++ b/src/be/db-client.ts
@@ -23,6 +23,23 @@ export interface DbExecutor {
   run(sql: string, params?: DbParam[]): Promise<{ changes: number }>;
 }
 
+export type TransactionOptions = {
+  /**
+   * Declare the callback SELECT-only. The transaction then opens with a
+   * deferred BEGIN and never contends for the cross-process write lock, so
+   * it reads the WAL snapshot at full speed even while an external process
+   * (litestream checkpoint, CLI) holds the file's write lock. Measured cost
+   * of NOT setting this on a read-only transaction under an external locker:
+   * 2x read throughput at a mild 250ms hold, 14x at a 6s hold.
+   *
+   * A callback that writes despite `readOnly: true` still works (SQLite
+   * upgrades the deferred transaction), but it loses BUSY retry and can fail
+   * mid-callback under cross-process contention. Only set it on genuinely
+   * SELECT-only callbacks.
+   */
+  readOnly?: boolean;
+};
+
 export interface DbClient extends DbExecutor {
   /**
    * Run `fn` atomically. The callback receives an executor bound to the
@@ -30,9 +47,9 @@ export interface DbClient extends DbExecutor {
    * through helpers) while the callback runs are routed into the same
    * transaction via AsyncLocalStorage, mirroring how synchronous helpers
    * sharing one connection behaved before this seam existed. Nested
-   * `transaction` calls become SAVEPOINTs.
+   * `transaction` calls become SAVEPOINTs (opts are ignored for them).
    */
-  transaction<T>(fn: (tx: DbExecutor) => Promise<T>): Promise<T>;
+  transaction<T>(fn: (tx: DbExecutor) => Promise<T>, opts?: TransactionOptions): Promise<T>;
   /**
    * Schedule `fn` to run strictly after the currently-open transaction
    * COMMITs; if that transaction rolls back the hook is DROPPED (the write it
@@ -104,22 +121,43 @@ const txContext = new AsyncLocalStorage<TxContext>();
 
 /**
  * Cross-process SQLITE_BUSY retry posture (litestream checkpoints, CLI access
- * on the same file). bun:sqlite's own `busy_timeout` handles the wait while
- * the driver call runs; these retries kick in after it gives up, and the
- * backoff between attempts sleeps asynchronously, so the event loop breathes
- * between driver calls. Retries happen only where a repeat is exact:
- * top-level single statements, BEGIN IMMEDIATE (nothing ran yet), and COMMIT
- * (the transaction stays intact on a BUSY commit). Statements inside an open
- * transaction are never retried.
+ * on the same file). Retries happen only where a repeat is exact: top-level
+ * single statements, BEGIN IMMEDIATE (nothing ran yet), and COMMIT (the
+ * transaction stays intact on a BUSY commit). Statements inside an open
+ * transaction are never retried, and `readOnly` transactions opt out
+ * entirely (deferred BEGIN never contends for the write lock).
+ *
+ * Two properties keep a retrying operation from starving the rest of the
+ * process, both measured (see PR #1229's read-heavy probe):
+ * - each retryable driver attempt runs under a SHORT `busy_timeout`
+ *   (`attemptSpinMs`), so the driver's synchronous busy wait blocks the
+ *   event loop for at most that long per attempt; the real waiting happens
+ *   in the async backoff sleeps,
+ * - the FIFO lock is RELEASED during those sleeps (except after COMMIT
+ *   failures, where the open transaction pins the connection), so queued
+ *   reads flow while a writer waits out an external lock holder.
  */
 export type BusyRetryOptions = {
-  /** Ceiling on the summed async backoff (driver-level busy_timeout spins are extra). */
+  /** Ceiling on the summed async backoff across attempts. */
   maxWaitMs: number;
   /** Per-retry sleep; the attempt count is bounded by this array's length + 1. */
   backoffMs: number[];
+  /** `busy_timeout` applied for the duration of each retryable driver attempt. */
+  attemptSpinMs: number;
 };
 
-const DEFAULT_BUSY_RETRY: BusyRetryOptions = { maxWaitMs: 10_000, backoffMs: [50, 100, 250] };
+// The backoff sum (~6.9s) plus per-attempt spins must outlast a realistic
+// external hold (litestream checkpoint stalls measured in seconds) so writes
+// land in the holder's release gaps instead of failing at the driver cliff.
+const DEFAULT_BUSY_RETRY: BusyRetryOptions = {
+  maxWaitMs: 10_000,
+  backoffMs: [25, 50, 100, 250, 500, 1000, 1000, 1000, 1000, 1000, 1000],
+  attemptSpinMs: 100,
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 function isSqliteBusy(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
@@ -130,6 +168,8 @@ function isSqliteBusy(err: unknown): boolean {
 class BunSqliteClient implements DbClient {
   private readonly lock = new FifoLock();
   private savepointSeq = 0;
+  /** Lazily captured ambient busy_timeout, restored after each short-spin attempt. */
+  private restoreBusyTimeoutMs: number | null = null;
 
   constructor(
     private readonly getDatabase: () => Database,
@@ -151,29 +191,74 @@ class BunSqliteClient implements DbClient {
     });
   }
 
-  async transaction<T>(fn: (tx: DbExecutor) => Promise<T>): Promise<T> {
+  async transaction<T>(fn: (tx: DbExecutor) => Promise<T>, opts?: TransactionOptions): Promise<T> {
     const existing = txContext.getStore();
     if (existing && !existing.closed) {
       return this.savepoint(existing, fn);
     }
 
+    const readOnly = opts?.readOnly === true;
+    let sleptMs = 0;
+    for (let attemptIndex = 0; ; attemptIndex++) {
+      const attempt = await this.runTransactionAttempt(fn, readOnly);
+      if (attempt.ok) return attempt.value;
+      const backoff = this.busyRetry.backoffMs[attemptIndex];
+      if (backoff === undefined || sleptMs + backoff > this.busyRetry.maxWaitMs) {
+        throw attempt.busyBegin;
+      }
+      sleptMs += backoff;
+      // The FIFO lock is NOT held here: nothing began, so other DB work
+      // (reads especially) proceeds while this writer waits out the external
+      // lock holder.
+      await sleep(backoff);
+    }
+  }
+
+  /**
+   * One BEGIN..COMMIT attempt under the FIFO lock. Returns `busyBegin`
+   * instead of throwing when BEGIN IMMEDIATE hits a cross-process BUSY, so
+   * the caller can back off with the lock released.
+   */
+  private async runTransactionAttempt<T>(
+    fn: (tx: DbExecutor) => Promise<T>,
+    readOnly: boolean,
+  ): Promise<{ ok: true; value: T } | { ok: false; busyBegin: unknown }> {
     const release = await this.lock.acquire();
     const ctx: TxContext = { closed: false, afterCommit: [] };
     let began = false;
     try {
       const db = this.getDatabase();
       const tx = this.boundExecutor(ctx);
-      // IMMEDIATE takes the write lock at BEGIN: a cross-process BUSY then
-      // surfaces here, where a retry is exact (nothing ran yet), instead of
-      // on an arbitrary statement mid-callback where it is not.
-      await this.withBusyRetry(() => db.run("BEGIN IMMEDIATE"));
+      if (readOnly) {
+        // Deferred BEGIN executes no locking work, cannot BUSY, and keeps the
+        // whole transaction off the cross-process write lock.
+        db.run("BEGIN");
+      } else {
+        try {
+          // IMMEDIATE takes the write lock at BEGIN: a cross-process BUSY
+          // then surfaces here, where a retry is exact (nothing ran yet),
+          // instead of on an arbitrary statement mid-callback where it is
+          // not. The short spin keeps the driver's synchronous busy wait off
+          // the event loop; the real waiting is the caller's async backoff.
+          this.shortSpin(db, () => db.run("BEGIN IMMEDIATE"));
+        } catch (err) {
+          if (isSqliteBusy(err)) return { ok: false, busyBegin: err };
+          throw err;
+        }
+      }
       began = true;
       const result = await txContext.run(ctx, () => fn(tx));
-      // A BUSY COMMIT leaves the transaction open and intact, so a repeat is
-      // exact here too.
-      await this.withBusyRetry(() => db.run("COMMIT"));
+      if (readOnly) {
+        db.run("COMMIT");
+      } else {
+        // A BUSY COMMIT leaves the transaction open and intact, so a repeat
+        // is exact. The open transaction pins the connection, so these
+        // retries hold the FIFO lock and their sleeps block queued work;
+        // WAL-mode COMMIT BUSY is rare enough for that to be acceptable.
+        await this.retryHoldingLock(() => this.shortSpin(db, () => db.run("COMMIT")));
+      }
       for (const hook of ctx.afterCommit) this.scheduleHook(hook);
-      return result;
+      return { ok: true, value: result };
     } catch (err) {
       if (began) {
         try {
@@ -253,22 +338,52 @@ class BunSqliteClient implements DbClient {
     if (ctx && !ctx.closed) {
       return op(this.getDatabase());
     }
-    const release = await this.lock.acquire();
-    try {
-      // A top-level single statement is atomic, so a repeat on BUSY is exact.
-      return await this.withBusyRetry(() => op(this.getDatabase()));
-    } finally {
-      release();
+    let sleptMs = 0;
+    for (let attemptIndex = 0; ; attemptIndex++) {
+      const release = await this.lock.acquire();
+      let backoff = 0;
+      try {
+        // A top-level single statement is atomic, so a repeat on BUSY is exact.
+        return this.shortSpin(this.getDatabase(), () => op(this.getDatabase()));
+      } catch (err) {
+        if (!isSqliteBusy(err)) throw err;
+        const next = this.busyRetry.backoffMs[attemptIndex];
+        if (next === undefined || sleptMs + next > this.busyRetry.maxWaitMs) throw err;
+        backoff = next;
+        sleptMs += next;
+      } finally {
+        release();
+      }
+      // Lock released: queued reads flow while this statement waits out the
+      // external lock holder.
+      await sleep(backoff);
     }
   }
 
   /**
-   * Run `attempt` with async backoff on SQLITE_BUSY. The caller must ensure
-   * a repeat is exact (nothing partially applied by a failed attempt). Runs
-   * while the FIFO lock is held: queued in-process operations stay ordered
-   * behind the retrying one, and the loop stays free during the sleeps.
+   * Run a retryable driver attempt under a short `busy_timeout` so the
+   * synchronous in-driver busy wait blocks the event loop for at most
+   * `attemptSpinMs`. Only called while the FIFO lock is held, so the
+   * set/attempt/restore sequence cannot interleave with other client work.
    */
-  private async withBusyRetry<T>(attempt: () => T): Promise<T> {
+  private shortSpin<T>(db: Database, attempt: () => T): T {
+    if (this.restoreBusyTimeoutMs === null) {
+      const row = db.query<{ timeout: number }, []>("PRAGMA busy_timeout").get();
+      this.restoreBusyTimeoutMs = row?.timeout ?? 5000;
+    }
+    db.exec(`PRAGMA busy_timeout = ${this.busyRetry.attemptSpinMs}`);
+    try {
+      return attempt();
+    } finally {
+      db.exec(`PRAGMA busy_timeout = ${this.restoreBusyTimeoutMs}`);
+    }
+  }
+
+  /**
+   * COMMIT-only retry: the open transaction pins the shared connection, so
+   * the FIFO lock stays held and these sleeps block queued in-process work.
+   */
+  private async retryHoldingLock<T>(attempt: () => T): Promise<T> {
     let sleptMs = 0;
     for (let attemptIndex = 0; ; attemptIndex++) {
       try {
@@ -278,7 +393,7 @@ class BunSqliteClient implements DbClient {
         const backoff = this.busyRetry.backoffMs[attemptIndex];
         if (backoff === undefined || sleptMs + backoff > this.busyRetry.maxWaitMs) throw err;
         sleptMs += backoff;
-        await new Promise((resolve) => setTimeout(resolve, backoff));
+        await sleep(backoff);
       }
     }
   }

--- a/src/be/db-client.ts
+++ b/src/be/db-client.ts
@@ -159,6 +159,11 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** 0.5x-1.5x jitter so concurrent retriers cannot phase-lock with a periodic holder. */
+function jittered(ms: number): number {
+  return Math.max(1, Math.round(ms * (0.5 + Math.random())));
+}
+
 function isSqliteBusy(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const code = (err as { code?: unknown }).code;
@@ -200,17 +205,23 @@ class BunSqliteClient implements DbClient {
     const readOnly = opts?.readOnly === true;
     let sleptMs = 0;
     for (let attemptIndex = 0; ; attemptIndex++) {
-      const attempt = await this.runTransactionAttempt(fn, readOnly);
-      if (attempt.ok) return attempt.value;
       const backoff = this.busyRetry.backoffMs[attemptIndex];
-      if (backoff === undefined || sleptMs + backoff > this.busyRetry.maxWaitMs) {
-        throw attempt.busyBegin;
-      }
+      const canRetryAfter = backoff !== undefined && sleptMs + backoff <= this.busyRetry.maxWaitMs;
+      // The FINAL attempt camps on the ambient busy_timeout instead of the
+      // short spin: a lone writer sampling 100ms windows can stay phase-locked
+      // with a periodic external holder and miss every release gap (measured:
+      // 3 of 6 writes lost at 1 writer under a 6s/500ms locker). One long
+      // synchronous spin per request, only after every polite attempt failed,
+      // acquires the lock the instant the holder releases.
+      const attempt = await this.runTransactionAttempt(fn, readOnly, !canRetryAfter);
+      if (attempt.ok) return attempt.value;
+      if (!canRetryAfter || backoff === undefined) throw attempt.busyBegin;
       sleptMs += backoff;
       // The FIFO lock is NOT held here: nothing began, so other DB work
       // (reads especially) proceeds while this writer waits out the external
-      // lock holder.
-      await sleep(backoff);
+      // lock holder. Jitter desynchronizes concurrent retriers from each
+      // other and from periodic holders.
+      await sleep(jittered(backoff));
     }
   }
 
@@ -222,6 +233,7 @@ class BunSqliteClient implements DbClient {
   private async runTransactionAttempt<T>(
     fn: (tx: DbExecutor) => Promise<T>,
     readOnly: boolean,
+    campOnAmbientTimeout = false,
   ): Promise<{ ok: true; value: T } | { ok: false; busyBegin: unknown }> {
     const release = await this.lock.acquire();
     const ctx: TxContext = { closed: false, afterCommit: [] };
@@ -240,7 +252,13 @@ class BunSqliteClient implements DbClient {
           // instead of on an arbitrary statement mid-callback where it is
           // not. The short spin keeps the driver's synchronous busy wait off
           // the event loop; the real waiting is the caller's async backoff.
-          this.shortSpin(db, () => db.run("BEGIN IMMEDIATE"));
+          // The final attempt camps on the ambient busy_timeout instead (see
+          // transaction()).
+          if (campOnAmbientTimeout) {
+            db.run("BEGIN IMMEDIATE");
+          } else {
+            this.shortSpin(db, () => db.run("BEGIN IMMEDIATE"));
+          }
         } catch (err) {
           if (isSqliteBusy(err)) return { ok: false, busyBegin: err };
           throw err;
@@ -340,23 +358,28 @@ class BunSqliteClient implements DbClient {
     }
     let sleptMs = 0;
     for (let attemptIndex = 0; ; attemptIndex++) {
+      const next = this.busyRetry.backoffMs[attemptIndex];
+      const canRetryAfter = next !== undefined && sleptMs + next <= this.busyRetry.maxWaitMs;
       const release = await this.lock.acquire();
       let backoff = 0;
       try {
-        // A top-level single statement is atomic, so a repeat on BUSY is exact.
-        return this.shortSpin(this.getDatabase(), () => op(this.getDatabase()));
+        // A top-level single statement is atomic, so a repeat on BUSY is
+        // exact. The final attempt camps on the ambient busy_timeout so a
+        // lone writer cannot stay phase-locked with a periodic holder (see
+        // transaction()).
+        return canRetryAfter
+          ? this.shortSpin(this.getDatabase(), () => op(this.getDatabase()))
+          : op(this.getDatabase());
       } catch (err) {
-        if (!isSqliteBusy(err)) throw err;
-        const next = this.busyRetry.backoffMs[attemptIndex];
-        if (next === undefined || sleptMs + next > this.busyRetry.maxWaitMs) throw err;
+        if (!isSqliteBusy(err) || !canRetryAfter || next === undefined) throw err;
         backoff = next;
         sleptMs += next;
       } finally {
         release();
       }
       // Lock released: queued reads flow while this statement waits out the
-      // external lock holder.
-      await sleep(backoff);
+      // external lock holder. Jitter desynchronizes concurrent retriers.
+      await sleep(jittered(backoff));
     }
   }
 

--- a/src/be/db-client.ts
+++ b/src/be/db-client.ts
@@ -102,11 +102,39 @@ type TxContext = {
 
 const txContext = new AsyncLocalStorage<TxContext>();
 
+/**
+ * Cross-process SQLITE_BUSY retry posture (litestream checkpoints, CLI access
+ * on the same file). bun:sqlite's own `busy_timeout` handles the wait while
+ * the driver call runs; these retries kick in after it gives up, and the
+ * backoff between attempts sleeps asynchronously, so the event loop breathes
+ * between driver calls. Retries happen only where a repeat is exact:
+ * top-level single statements, BEGIN IMMEDIATE (nothing ran yet), and COMMIT
+ * (the transaction stays intact on a BUSY commit). Statements inside an open
+ * transaction are never retried.
+ */
+export type BusyRetryOptions = {
+  /** Ceiling on the summed async backoff (driver-level busy_timeout spins are extra). */
+  maxWaitMs: number;
+  /** Per-retry sleep; the attempt count is bounded by this array's length + 1. */
+  backoffMs: number[];
+};
+
+const DEFAULT_BUSY_RETRY: BusyRetryOptions = { maxWaitMs: 10_000, backoffMs: [50, 100, 250] };
+
+function isSqliteBusy(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === "string" && code.startsWith("SQLITE_BUSY");
+}
+
 class BunSqliteClient implements DbClient {
   private readonly lock = new FifoLock();
   private savepointSeq = 0;
 
-  constructor(private readonly getDatabase: () => Database) {}
+  constructor(
+    private readonly getDatabase: () => Database,
+    private readonly busyRetry: BusyRetryOptions = DEFAULT_BUSY_RETRY,
+  ) {}
 
   query<T>(sql: string, params: DbParam[] = []): Promise<T[]> {
     return this.execute((db) => db.query<T, DbParam[]>(sql).all(...params));
@@ -135,10 +163,15 @@ class BunSqliteClient implements DbClient {
     try {
       const db = this.getDatabase();
       const tx = this.boundExecutor(ctx);
-      db.run("BEGIN");
+      // IMMEDIATE takes the write lock at BEGIN: a cross-process BUSY then
+      // surfaces here, where a retry is exact (nothing ran yet), instead of
+      // on an arbitrary statement mid-callback where it is not.
+      await this.withBusyRetry(() => db.run("BEGIN IMMEDIATE"));
       began = true;
       const result = await txContext.run(ctx, () => fn(tx));
-      db.run("COMMIT");
+      // A BUSY COMMIT leaves the transaction open and intact, so a repeat is
+      // exact here too.
+      await this.withBusyRetry(() => db.run("COMMIT"));
       for (const hook of ctx.afterCommit) this.scheduleHook(hook);
       return result;
     } catch (err) {
@@ -222,9 +255,31 @@ class BunSqliteClient implements DbClient {
     }
     const release = await this.lock.acquire();
     try {
-      return op(this.getDatabase());
+      // A top-level single statement is atomic, so a repeat on BUSY is exact.
+      return await this.withBusyRetry(() => op(this.getDatabase()));
     } finally {
       release();
+    }
+  }
+
+  /**
+   * Run `attempt` with async backoff on SQLITE_BUSY. The caller must ensure
+   * a repeat is exact (nothing partially applied by a failed attempt). Runs
+   * while the FIFO lock is held: queued in-process operations stay ordered
+   * behind the retrying one, and the loop stays free during the sleeps.
+   */
+  private async withBusyRetry<T>(attempt: () => T): Promise<T> {
+    let sleptMs = 0;
+    for (let attemptIndex = 0; ; attemptIndex++) {
+      try {
+        return attempt();
+      } catch (err) {
+        if (!isSqliteBusy(err)) throw err;
+        const backoff = this.busyRetry.backoffMs[attemptIndex];
+        if (backoff === undefined || sleptMs + backoff > this.busyRetry.maxWaitMs) throw err;
+        sleptMs += backoff;
+        await new Promise((resolve) => setTimeout(resolve, backoff));
+      }
     }
   }
 
@@ -257,8 +312,12 @@ class BunSqliteClient implements DbClient {
 /**
  * Wrap a lazily-resolved bun:sqlite handle in the async DbClient seam.
  * `getDatabase` is invoked per operation so close/reopen cycles (tests) are
- * transparent to holders of the client.
+ * transparent to holders of the client. `busyRetry` overrides the
+ * cross-process SQLITE_BUSY retry posture (tests use tiny values).
  */
-export function createBunSqliteClient(getDatabase: () => Database): DbClient {
-  return new BunSqliteClient(getDatabase);
+export function createBunSqliteClient(
+  getDatabase: () => Database,
+  busyRetry?: BusyRetryOptions,
+): DbClient {
+  return new BunSqliteClient(getDatabase, busyRetry);
 }

--- a/src/be/db.ts
+++ b/src/be/db.ts
@@ -4165,7 +4165,9 @@ export async function moveAssetKey(input: {
   // auditAssetKeys stays sync (shared with the boot audit); run it inside a
   // client transaction so this request-path read cannot observe another
   // request's uncommitted writes on the shared connection.
-  const audit = await getDbClient().transaction(async () => auditAssetKeys(getDb()));
+  const audit = await getDbClient().transaction(async () => auditAssetKeys(getDb()), {
+    readOnly: true,
+  });
   if (!audit.ok) {
     throw new Error(
       "Asset namespace moves are blocked until structural errors, unknown personal users, or provider mapping drift are repaired.",
@@ -4571,25 +4573,31 @@ export async function hasPendingSteering(taskId: string): Promise<boolean> {
 // ============================================================================
 
 export async function getAgentWithTasks(id: string): Promise<AgentWithTasks | null> {
-  return await getDbClient().transaction(async () => {
-    const agent = await getAgentById(id);
-    if (!agent) return null;
+  return await getDbClient().transaction(
+    async () => {
+      const agent = await getAgentById(id);
+      if (!agent) return null;
 
-    const tasks = await getTasksByAgentId(id);
-    return { ...agent, tasks };
-  });
+      const tasks = await getTasksByAgentId(id);
+      return { ...agent, tasks };
+    },
+    { readOnly: true },
+  );
 }
 
 export async function getAllAgentsWithTasks(opts?: { slim?: boolean }): Promise<AgentWithTasks[]> {
-  return await getDbClient().transaction(async () => {
-    const agents = await getAllAgents({ slim: opts?.slim ?? false });
-    return await Promise.all(
-      agents.map(async (agent) => ({
-        ...agent,
-        tasks: await getTasksByAgentId(agent.id),
-      })),
-    );
-  });
+  return await getDbClient().transaction(
+    async () => {
+      const agents = await getAllAgents({ slim: opts?.slim ?? false });
+      return await Promise.all(
+        agents.map(async (agent) => ({
+          ...agent,
+          tasks: await getTasksByAgentId(agent.id),
+        })),
+      );
+    },
+    { readOnly: true },
+  );
 }
 
 // ============================================================================

--- a/src/http/assets.ts
+++ b/src/http/assets.ts
@@ -249,7 +249,9 @@ export async function handleAssets(
     // auditAssetKeys stays sync (shared with the boot audit); run it inside a
     // client transaction so the read cannot observe another request's
     // uncommitted writes on the shared connection.
-    const audit = await getDbClient().transaction(async () => auditAssetKeys(getDb()));
+    const audit = await getDbClient().transaction(async () => auditAssetKeys(getDb()), {
+      readOnly: true,
+    });
     keyAuditRoute.respond(res, 200, audit);
     return true;
   }

--- a/src/tests/db-client-busy-retry.test.ts
+++ b/src/tests/db-client-busy-retry.test.ts
@@ -22,7 +22,11 @@ beforeEach(() => {
   main.run("DELETE FROM items");
   locker = new Database(TEST_DB_PATH);
   locker.exec("PRAGMA busy_timeout = 25");
-  client = createBunSqliteClient(() => main, { maxWaitMs: 2_000, backoffMs: [25, 50, 100, 200] });
+  client = createBunSqliteClient(() => main, {
+    maxWaitMs: 2_000,
+    backoffMs: [25, 50, 100, 200],
+    attemptSpinMs: 25,
+  });
 });
 
 afterEach(async () => {
@@ -74,12 +78,61 @@ describe("db-client SQLITE_BUSY retry", () => {
   });
 
   test("gives up with SQLITE_BUSY when the lock outlives the retry budget", async () => {
-    const tightClient = createBunSqliteClient(() => main, { maxWaitMs: 60, backoffMs: [20, 20] });
+    const tightClient = createBunSqliteClient(() => main, {
+      maxWaitMs: 60,
+      backoffMs: [20, 20],
+      attemptSpinMs: 25,
+    });
     const released = holdWriteLock(600);
     await expect(tightClient.run("INSERT INTO items (name) VALUES (?)", ["never"])).rejects.toThrow(
       /database is locked/,
     );
     await released;
+  });
+
+  test("readOnly transaction proceeds at full speed under an external write lock", async () => {
+    await client.run("INSERT INTO items (name) VALUES (?)", ["seed"]);
+    const released = holdWriteLock(400);
+    const started = Date.now();
+    const names = await client.transaction(
+      async (tx) => (await tx.query<{ name: string }>("SELECT name FROM items")).map((r) => r.name),
+      { readOnly: true },
+    );
+    // Deferred BEGIN never touches the write lock: no busy spin, no retry
+    // budget, done long before the locker releases.
+    expect(Date.now() - started).toBeLessThan(200);
+    expect(names).toEqual(["seed"]);
+    await released;
+  });
+
+  test("reads flow while a write retries in backoff (FIFO lock released between attempts)", async () => {
+    await client.run("INSERT INTO items (name) VALUES (?)", ["reader-food"]);
+    const released = holdWriteLock(400);
+    const write = client.run("INSERT INTO items (name) VALUES (?)", ["late-write"]);
+    // Let the write burn its first attempt and enter async backoff.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    const started = Date.now();
+    const rows = await client.query<{ name: string }>(
+      "SELECT name FROM items WHERE name = 'reader-food'",
+    );
+    // Pre-fix, the retrying writer held the FIFO lock across its sleeps and
+    // this read queued behind the full retry span.
+    expect(Date.now() - started).toBeLessThan(150);
+    expect(rows.length).toBe(1);
+    await released;
+    await write;
+    const landed = await client.get<{ name: string }>(
+      "SELECT name FROM items WHERE name = 'late-write'",
+    );
+    expect(landed?.name).toBe("late-write");
+  });
+
+  test("short spin restores the ambient busy_timeout after a retried attempt", async () => {
+    const released = holdWriteLock(120);
+    await client.run("INSERT INTO items (name) VALUES (?)", ["spin-check"]);
+    await released;
+    const row = main.query<{ timeout: number }, []>("PRAGMA busy_timeout").get();
+    expect(row?.timeout).toBe(25);
   });
 
   test("non-BUSY errors are not retried", async () => {

--- a/src/tests/db-client-busy-retry.test.ts
+++ b/src/tests/db-client-busy-retry.test.ts
@@ -1,0 +1,102 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { unlink } from "node:fs/promises";
+import { createBunSqliteClient, type DbClient } from "../be/db-client";
+
+// Cross-process SQLITE_BUSY retry: a second connection on the same file plays
+// the external lock holder (litestream checkpoint, CLI access). The client's
+// own connection gets a tiny busy_timeout so each driver attempt fails fast
+// and the async retry path is what actually bridges the contention window.
+
+const TEST_DB_PATH = "./test-db-client-busy-retry.sqlite";
+
+let main: Database;
+let locker: Database;
+let client: DbClient;
+
+beforeEach(() => {
+  main = new Database(TEST_DB_PATH);
+  main.exec("PRAGMA journal_mode = WAL");
+  main.exec("PRAGMA busy_timeout = 25");
+  main.run("CREATE TABLE IF NOT EXISTS items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)");
+  main.run("DELETE FROM items");
+  locker = new Database(TEST_DB_PATH);
+  locker.exec("PRAGMA busy_timeout = 25");
+  client = createBunSqliteClient(() => main, { maxWaitMs: 2_000, backoffMs: [25, 50, 100, 200] });
+});
+
+afterEach(async () => {
+  try {
+    locker.run("ROLLBACK");
+  } catch {
+    // No transaction open; fine.
+  }
+  locker.close();
+  main.close();
+  await unlink(TEST_DB_PATH).catch(() => {});
+  await unlink(`${TEST_DB_PATH}-wal`).catch(() => {});
+  await unlink(`${TEST_DB_PATH}-shm`).catch(() => {});
+});
+
+/** Hold the write lock on the second connection for `ms`, then release. */
+function holdWriteLock(ms: number): Promise<void> {
+  locker.run("BEGIN IMMEDIATE");
+  locker.run("INSERT INTO items (name) VALUES ('locker')");
+  return new Promise((resolve) =>
+    setTimeout(() => {
+      locker.run("COMMIT");
+      resolve();
+    }, ms),
+  );
+}
+
+describe("db-client SQLITE_BUSY retry", () => {
+  test("top-level run bridges an external write lock instead of failing", async () => {
+    const released = holdWriteLock(150);
+    const result = await client.run("INSERT INTO items (name) VALUES (?)", ["bridged"]);
+    expect(result.changes).toBe(1);
+    await released;
+    const rows = await client.query<{ name: string }>("SELECT name FROM items ORDER BY name");
+    expect(rows.map((r) => r.name)).toEqual(["bridged", "locker"]);
+  });
+
+  test("transaction BEGIN IMMEDIATE bridges an external write lock", async () => {
+    const released = holdWriteLock(150);
+    await client.transaction(async (tx) => {
+      await tx.run("INSERT INTO items (name) VALUES (?)", ["tx-a"]);
+      await tx.run("INSERT INTO items (name) VALUES (?)", ["tx-b"]);
+    });
+    await released;
+    const rows = await client.query<{ name: string }>(
+      "SELECT name FROM items WHERE name LIKE 'tx-%' ORDER BY name",
+    );
+    expect(rows.map((r) => r.name)).toEqual(["tx-a", "tx-b"]);
+  });
+
+  test("gives up with SQLITE_BUSY when the lock outlives the retry budget", async () => {
+    const tightClient = createBunSqliteClient(() => main, { maxWaitMs: 60, backoffMs: [20, 20] });
+    const released = holdWriteLock(600);
+    await expect(tightClient.run("INSERT INTO items (name) VALUES (?)", ["never"])).rejects.toThrow(
+      /database is locked/,
+    );
+    await released;
+  });
+
+  test("non-BUSY errors are not retried", async () => {
+    const started = Date.now();
+    await expect(client.run("INSERT INTO no_such_table (name) VALUES (?)", ["x"])).rejects.toThrow(
+      /no such table/,
+    );
+    // A retried error would have slept through the backoff schedule.
+    expect(Date.now() - started).toBeLessThan(100);
+  });
+
+  test("reads proceed under an external write lock without needing the retry path", async () => {
+    await client.run("INSERT INTO items (name) VALUES (?)", ["pre-existing"]);
+    const released = holdWriteLock(150);
+    // WAL readers do not block on the write lock.
+    const rows = await client.query<{ name: string }>("SELECT name FROM items");
+    expect(rows.map((r) => r.name)).toEqual(["pre-existing"]);
+    await released;
+  });
+});


### PR DESCRIPTION
Stacked on #1204 (base: `worktree-async-db-refactor`).

## What

Handles cross-process `SQLITE_BUSY` (litestream checkpoints, CLI access on the same file) at the `DbClient` choke point, retrying only where a repeat is exact, without starving the rest of the process:

- **Top-level single statements** and **BEGIN** (upgraded to `BEGIN IMMEDIATE`, so a cross-process BUSY surfaces before anything ran) retry with async backoff (`[25, 50, 100, 250, 500, 1000 x6]` ms, jittered 0.5x-1.5x, `maxWaitMs: 10s`). **COMMIT** retries too (a BUSY commit leaves the transaction intact). Statements inside an open transaction are never retried.
- **Each retryable attempt runs under a 100ms `busy_timeout`** (`attemptSpinMs`, restored afterwards), so the driver's synchronous busy wait blocks the event loop for at most 100ms per attempt. The **final** attempt camps on the ambient 5s `busy_timeout` instead, so a lone writer cannot stay phase-locked with a periodic holder and miss every release gap.
- **The FIFO lock is released during backoff sleeps** (for BEGIN and top-level statements; COMMIT retries must hold it), so queued reads flow while a writer waits out an external holder.
- **`transaction(fn, { readOnly: true })`**: deferred BEGIN, no write-lock contention, no retry budget. Applied to the four genuinely SELECT-only transaction sites (`getAgentWithTasks`, `getAllAgentsWithTasks`, both `auditAssetKeys` wraps); the other 84 transaction sites write and keep IMMEDIATE.

## Why

A production deployment running litestream hit `SQLiteError: database is locked` in `createSessionLogs` and returned 500s after the 5s `busy_timeout` cliff. A live A/B benchmark reproduced that failure identically on the sync baseline and the #1204 seam: the seam alone does not change BUSY handling. This PR adds it, in one place.

## E2E verification (live server A/B, three rounds of probes)

**Write probe** (16 writers on `POST /api/session-logs`, external locker holding `BEGIN IMMEDIATE` 6s / sleeping 500ms, 40s, 2 rounds): control produced 6x500 (`SQLITE_BUSY` at ~5s, matching the customer's 5013ms) **plus 32-43 dropped connections per round** (socket closed during control's 5s event-loop freezes; 0 on fix). Fix: **0x500, 0 SQLITE_BUSY, 0 dropped connections**, throughput up, readers during the storm 2.7x faster with p95 down from ~12.9s to ~3.2s.

**Read-heavy probe** (0-1 writers, 16 readers incl. the read-only-transaction endpoint, same locker): an earlier iteration of this PR collapsed reads 14x here (write-lock contention from read-only transactions + FIFO-held backoff + 5s driver spins); the current design is at parity with control (worst case ~13% throughput at a 250ms-hold locker, p95 in the same 20-37ms band). The single-writer weakness that probe then exposed (phase-locking with a periodic holder, 3 of 6 writes lost) is addressed by the jitter + final-attempt camping commit.

**Known trades**, stated plainly:
- A caller that used to get a fast 500 gets a slow 201; the write tail under a pathological 6s locker roughly doubles (max ~13s). There is no per-call opt-out of the retry budget.
- ~12-13% read-throughput cost under a mild 250ms-hold external locker (zero uncontended cost).
- `SQLITE_BUSY_SNAPSHOT` disappears for seam transactions (IMMEDIATE never upgrades a read snapshot) — this also covers what upstream #1216 fixed for `applyRating` with a sync `.immediate()`, for every write transaction.

Full benchmark reports with raw data: `RESULTS-busy-retry.md`, `RESULTS-read-heavy.md`, `RESULTS-busy-retry-v2.md` (bench harness, kept out of the repo).

## Verification

- `src/tests/db-client-busy-retry.test.ts`: bridges a real external lock holder on statement + transaction paths, readOnly proceeds at full speed under a held write lock, reads flow while a writer is in backoff, ambient busy_timeout restoration, budget exhaustion, non-BUSY errors not retried.
- Full local suite at the known baseline; `tsc`, lint, seam/boundary/floating-promise/promise-sink gates green.

https://claude.ai/code/session_01DVtLqQPrHzrSp7mni8GvjT
