### PR TITLE
fix(tool-loop): serialize checkToolLoop per session so fire-and-forget callers cannot lose updates

### DIFF
--- a/docs-site/content/docs/(documentation)/guides/harness-providers.mdx
+++ b/docs-site/content/docs/(documentation)/guides/harness-providers.mdx
@@ -794,7 +794,7 @@ The adapter is responsible for polling swarm-side signals during a run. Pattern 
 - Pi: [`src/providers/pi-mono-extension.ts`](https://github.com/desplega-ai/agent-swarm/blob/main/src/providers/pi-mono-extension.ts) — `createSwarmHooksExtension` passed into `DefaultResourceLoader({ extensionFactories: [swarmExtension] })`.
 - Claude: external hook process reads a task file (`/tmp/agent-swarm-task-<pid>.json`) written by `claude-adapter.ts` L31–43; hook logic lives under `src/hooks/` (e.g. [`tool-loop-detection.ts`](https://github.com/desplega-ai/agent-swarm/blob/main/src/hooks/tool-loop-detection.ts)).
 
-Tool-loop detection (`src/hooks/tool-loop-detection.ts::checkToolLoop`) is reusable — call it from your event translator when you see `tool_start`.
+Tool-loop detection (`src/hooks/tool-loop-detection.ts::checkToolLoop`) is reusable — call it from your event translator when you see `tool_start`. You do not need to await it: calls for the same session key run one after another in call order inside `checkToolLoop`, so a fire-and-forget caller still gets an exact repeat count.
 
 ### Step 9 — Skills and slash-commands
 

--- a/src/hooks/tool-loop-detection.test.ts
+++ b/src/hooks/tool-loop-detection.test.ts
@@ -275,4 +275,53 @@ describe("tool-loop-detection", () => {
       }
     });
   });
+
+  describe("concurrent calls for one session (fire-and-forget callers)", () => {
+    // Regression for the lost-update race: claude-managed-adapter and
+    // swarm-events-shared call checkToolLoop without awaiting, so consecutive
+    // tool_use events overlap. Each call is a read-modify-write of the history
+    // file; unserialized, every overlapping call reads the same short history,
+    // the last write wins, and no call ever reaches the threshold.
+    test("15 identical calls fired without awaiting: the 15th is blocked, in order", async () => {
+      const calls = Array.from({ length: 15 }, () =>
+        checkToolLoop(SESSION_KEY, "stuck_tool", { same: "args" }),
+      );
+      const results = await Promise.all(calls);
+      // Calls 1..14 are at most a warning; the 15th (REPEAT_CRITICAL_THRESHOLD)
+      // must be the critical block, which proves both serialization and order.
+      for (let i = 0; i < 14; i++) {
+        expect(results[i]?.blocked).toBe(false);
+      }
+      expect(results[14]?.blocked).toBe(true);
+      expect(results[14]?.severity).toBe("critical");
+      expect(results[14]?.reason).toContain("15 times");
+    });
+
+    test("two sessions do not serialize against each other", async () => {
+      const OTHER = `${SESSION_KEY}-other`;
+      await clearToolHistory(OTHER);
+      try {
+        const mixed = await Promise.all([
+          ...Array.from({ length: 8 }, () => checkToolLoop(SESSION_KEY, "Read", { a: 1 })),
+          ...Array.from({ length: 8 }, () => checkToolLoop(OTHER, "Read", { a: 1 })),
+        ]);
+        // Each session independently reaches exactly the warning threshold (8).
+        expect(mixed[7]?.severity).toBe("warning");
+        expect(mixed[15]?.severity).toBe("warning");
+        expect(mixed.every((r) => !r.blocked)).toBe(true);
+      } finally {
+        await clearToolHistory(OTHER);
+      }
+    });
+
+    test("a failed call does not wedge the session queue", async () => {
+      // A rejected link must not stop later calls for the same key.
+      // Force a rejection by passing input that JSON.stringify cannot handle.
+      const cyclic: Record<string, unknown> = {};
+      cyclic.self = cyclic;
+      await expect(checkToolLoop(SESSION_KEY, "Read", cyclic)).rejects.toThrow();
+      const next = await checkToolLoop(SESSION_KEY, "Read", { ok: true });
+      expect(next.blocked).toBe(false);
+    });
+  });
 });

--- a/src/hooks/tool-loop-detection.ts
+++ b/src/hooks/tool-loop-detection.ts
@@ -128,9 +128,44 @@ async function saveHistory(sessionKey: string, history: ToolCallRecord[]): Promi
 }
 
 /**
- * Detect if the current tool call is part of a repetitive loop.
+ * In-process queue per session key. `checkToolLoop` is a read-modify-write of
+ * the history file; two calls for the same session that overlap both read the
+ * same history and the later write drops the earlier call, so the repeat
+ * count undercounts and a real loop can slip past the threshold. The
+ * long-running callers (`claude-managed-adapter`, `swarm-events-shared`) fire
+ * it without awaiting, so the serialization has to live here, not at the
+ * call sites. Entries are removed once their chain drains so the map does not
+ * grow with every session the process has ever seen.
+ *
+ * Hook processes (`src/hooks/hook.ts`) are one call per process and run
+ * sequentially per session, so they never overlap in-process; a cross-process
+ * lock is out of scope here.
  */
-export async function checkToolLoop(
+const sessionQueues = new Map<string, Promise<unknown>>();
+
+/**
+ * Detect if the current tool call is part of a repetitive loop.
+ * Calls for the same `sessionKey` run strictly one after another, in call
+ * order, even when the caller does not await the returned promise.
+ */
+export function checkToolLoop(
+  sessionKey: string,
+  toolName: string,
+  toolInput: Record<string, unknown>,
+): Promise<LoopDetectionResult> {
+  const previous = sessionQueues.get(sessionKey) ?? Promise.resolve();
+  const run = previous
+    .catch(() => {})
+    .then(() => checkToolLoopUnserialized(sessionKey, toolName, toolInput));
+  sessionQueues.set(sessionKey, run);
+  const release = () => {
+    if (sessionQueues.get(sessionKey) === run) sessionQueues.delete(sessionKey);
+  };
+  run.then(release, release);
+  return run;
+}
+
+async function checkToolLoopUnserialized(
   sessionKey: string,
   toolName: string,
   toolInput: Record<string, unknown>,

--- a/src/providers/claude-managed-adapter.ts
+++ b/src/providers/claude-managed-adapter.ts
@@ -431,8 +431,10 @@ class ClaudeManagedSession implements ProviderSession {
    * AbortError catch path emits the cancelled `result` and settles.
    *
    * Made non-blocking so the SSE for-await loop stays synchronous in the hot
-   * path. Errors from `checkToolLoop` (file I/O on `/tmp`) are swallowed —
-   * loop detection failure must never kill a real session.
+   * path. `checkToolLoop` serializes calls per session key, so back-to-back
+   * events are counted in order even though nothing here awaits them. Errors
+   * from `checkToolLoop` (file I/O on `/tmp`) are swallowed — loop detection
+   * failure must never kill a real session.
    */
   private runToolLoopCheck(toolName: string, args: unknown): void {
     if (!this.taskId) return;

--- a/src/tests/claude-managed-adapter.test.ts
+++ b/src/tests/claude-managed-adapter.test.ts
@@ -1166,12 +1166,10 @@ describe("ClaudeManagedAdapter (Phase 5) — cancellation + tool-loop detection"
     }
   }, 10_000);
 
-  // Timing-sensitive by design: the adapter fires checkToolLoop without
-  // awaiting it, and each call is a read-modify-write of a /tmp history file
-  // behind a `mkdir -p` subprocess. Under `bun test --parallel` on a loaded
-  // runner those calls overlap and lose updates, so the repeat count can fall
-  // short of the threshold. The gap between events is wide and the test
-  // retries instead of relying on a global retry.
+  // The adapter fires checkToolLoop without awaiting it. checkToolLoop
+  // serializes calls per session key (src/hooks/tool-loop-detection.ts), so
+  // back-to-back tool_use events cannot overlap the history read-modify-write
+  // and the repeat count is exact regardless of runner load.
   test(
     "repeated identical tool_use events trigger checkToolLoop block → session aborts",
     async () => {
@@ -1190,8 +1188,8 @@ describe("ClaudeManagedAdapter (Phase 5) — cancellation + tool-loop detection"
       let abortObserved = false;
       const spy = makeFakeClient({
         streamEvents: async function* () {
-          // Yield 20 identical tool_use events with tiny gaps — well above
-          // the critical threshold.
+          // Yield 20 identical tool_use events back to back — well above the
+          // critical threshold (15).
           for (let i = 0; i < 20; i++) {
             if (abortObserved) {
               throw Object.assign(new Error("aborted"), { name: "AbortError" });
@@ -1203,10 +1201,17 @@ describe("ClaudeManagedAdapter (Phase 5) — cancellation + tool-loop detection"
               name: "stuck_tool",
               input: { same: "args" },
             };
-            // Let the async checkToolLoop finish before the next event so the
-            // history read-modify-write does not overlap (see comment above).
-            await new Promise((r) => setTimeout(r, 100));
+            await new Promise((r) => setTimeout(r, 1));
           }
+          // A real SDK stream throws AbortError when the adapter aborts. The
+          // fake has to do that itself, so hold the stream open until the test
+          // observes the block (bounded by the outer poll window) instead of
+          // racing a fixed gap against the detector's file I/O.
+          const deadline = Date.now() + 10_000;
+          while (!abortObserved && Date.now() < deadline) {
+            await new Promise((r) => setTimeout(r, 5));
+          }
+          throw Object.assign(new Error("aborted"), { name: "AbortError" });
         },
       });
 
@@ -1243,9 +1248,8 @@ describe("ClaudeManagedAdapter (Phase 5) — cancellation + tool-loop detection"
       }
 
       const result = await session.waitForCompletion();
-      // Either the loop detector aborted (errorCategory cancelled) or the
-      // stream completed all 20 events naturally — but the warning should
-      // have surfaced in the emitted events.
+      // The detector must have blocked (the stream stays open until it does),
+      // and the abort must have propagated into the session result.
       const blockedWarning = emitted.find(
         (e) =>
           e.type === "raw_stderr" &&
@@ -1256,7 +1260,7 @@ describe("ClaudeManagedAdapter (Phase 5) — cancellation + tool-loop detection"
       // After the block fires, abort propagates → cancelled result.
       expect(result.isError).toBe(true);
     },
-    { timeout: 30_000, retry: 2 },
+    { timeout: 30_000 },
   );
 });
 


### PR DESCRIPTION
## Summary

`checkToolLoop` is a read-modify-write of the per-session history file under `/tmp`. Two callers fire it without awaiting (`claude-managed-adapter.ts`, `swarm-events-shared.ts`), so back-to-back `tool_use` events overlapped: both read the same history, the last write won, and the repeat count undercounted. A real loop could slip past the critical threshold. Surfaced on the PR #1216 merge gate under `--parallel=4`, where the adapter test had to take `{ retry: 2 }` and a 100 ms event gap to stay green.

## Change

- `src/hooks/tool-loop-detection.ts`: `checkToolLoop` now queues calls per `sessionKey` on an in-process promise chain and runs them one after another in call order. The map entry is removed when a session's chain drains. A rejected call does not block the next one. The awaiting callers (`hook.ts`, `pi-mono-extension.ts`) are unaffected. Cross-process hooks run one call per process, sequentially per session, so a cross-process lock is out of scope.
- `src/hooks/tool-loop-detection.test.ts`: three new tests. 15 identical unawaited calls: the 15th is `blocked` with `critical` (this fails without the chain: 18 pass / 2 fail with the queue bypassed). Two sessions stay independent. A failed call does not wedge the queue.
- `src/tests/claude-managed-adapter.test.ts`: `{ retry: 2 }` removed, event gap 100 ms to 1 ms. The fake stream now stays open until the test observes the block and then throws `AbortError` like a real SDK stream, instead of racing a fixed gap against the detector's file I/O. That second race predates #1216 (the original 25 ms gap was covering it).
- Doc comment on `runToolLoopCheck` and one sentence in the harness-providers guide (Step 8).

## Verification

- `bun run lint`, `bun run tsc:check`, `check-db-boundary.sh`, `check-api-key-boundary.sh`: clean.
- `claude-managed-adapter.test.ts` + `tool-loop-detection.test.ts`: 52/52, five runs in a row, and under `--parallel=4` with the caller test files.
- prek pre-push hooks (lint, tsc, scoped tests, boundary) passed on push.

Closes #1220

https://claude.ai/code/session_014ynX6gLoAFVQSghbeZnphJ
