### PR TITLE
chore: bump agent-fs image pin to 0.13.1 (unblocks deploy)

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -219,7 +219,7 @@ COPY --from=prek /prek /usr/local/bin/prek
 ARG SKILLS_CLI_VERSION
 # agent-fs version pins BOTH the skill source tag (here) and the CLI in
 # /opt/global-deps (below) — bump the ARG to update both in lockstep.
-ARG AGENT_FS_VERSION=0.13.0
+ARG AGENT_FS_VERSION=0.13.1
 RUN npx -y skills@${SKILLS_CLI_VERSION} add desplega-ai/agent-fs@v${AGENT_FS_VERSION} --skill agent-fs -g -a claude-code -y \
     && test -e /home/worker/.claude/skills/agent-fs/SKILL.md \
     && rm -rf /home/worker/.npm

--- a/charts/agent-swarm/README.md
+++ b/charts/agent-swarm/README.md
@@ -78,7 +78,7 @@ Deploys the [agent-fs](https://github.com/desplega-ai/agent-fs) HTTP service alo
 agentFs:
   enabled: true
   image:
-    tag: 0.13.0
+    tag: 0.13.1
   bucket: my-agent-fs-bucket
   # Optional. When blank, the API boot seeder registers a service user with
   # agent-fs and stores the generated bootstrap key in encrypted swarm_config.

--- a/charts/agent-swarm/values.yaml
+++ b/charts/agent-swarm/values.yaml
@@ -227,7 +227,7 @@ agentFs:
     registry: ghcr.io
     repository: desplega-ai/agent-fs
     pullPolicy: IfNotPresent
-    tag: 0.13.0
+    tag: 0.13.1
   port: 7433
   # -- Optional API-owned bootstrap key for agent-fs. When blank, the swarm API
   # boot seeder registers a service user and persists its generated key in

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -47,7 +47,7 @@ services:
       "
 
   agent-fs:
-    image: ghcr.io/desplega-ai/agent-fs:0.13.0
+    image: ghcr.io/desplega-ai/agent-fs:0.13.1
     platform: linux/amd64
     pull_policy: always
     depends_on:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -45,7 +45,7 @@ services:
 
   agent-fs:
     container_name: swarm-agent-fs
-    image: ghcr.io/desplega-ai/agent-fs:0.13.0
+    image: ghcr.io/desplega-ai/agent-fs:0.13.1
     platform: linux/amd64
     depends_on:
       minio-init:

--- a/docker-compose.scripts-only.yml
+++ b/docker-compose.scripts-only.yml
@@ -45,7 +45,7 @@ services:
 
   agent-fs:
     container_name: so-agent-fs
-    image: ghcr.io/desplega-ai/agent-fs:0.13.0
+    image: ghcr.io/desplega-ai/agent-fs:0.13.1
     platform: linux/amd64
     depends_on:
       minio-init:


### PR DESCRIPTION
agent-fs 0.13.1 landed on GHCR after the last green deploy, and `sync-chart-version --check` fails the whole Docker Build + Publish + Deploy pipeline on a stale pin. This blocked the deploy of the #1229 merge; prod is still on the previous image.

Bumped in lockstep, as the check demands:
- `charts/agent-swarm/values.yaml` + chart README (`agentFs.image.tag`)
- all three compose files (`ghcr.io/desplega-ai/agent-fs:0.13.1`)
- `Dockerfile.worker` `ARG AGENT_FS_VERSION=0.13.1` (pins both the agent-fs skill source tag and the `@desplega.ai/agent-fs` CLI in /opt/global-deps)

Verified: `bun run sync-chart-version --check` passes against GHCR; npm has `@desplega.ai/agent-fs@0.13.1` and the `v0.13.1` tag exists, so the worker image build resolves.

Merging this re-triggers the deploy pipeline, which then ships both this pin and the already-merged #1229.

https://claude.ai/code/session_01DVtLqQPrHzrSp7mni8GvjT