### PR TITLE
fix(http): route handleCore errors through the request try/catch

### DIFF
--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -298,10 +298,6 @@ const httpServer = createHttpServer(async (req, res) => {
     const handleRequest = async () => {
       setCorsHeaders(req, res);
 
-      // ── Core routes (OPTIONS, health, auth, /me, /cancelled-tasks, /ping, /close) ──
-      if (await handleCore(req, res, req.headers["x-agent-id"] as string | undefined, apiKey))
-        return;
-
       const queryParams = parseQueryParams(req.url || "");
       const myAgentId = req.headers["x-agent-id"] as string | undefined;
 
@@ -366,6 +362,13 @@ const httpServer = createHttpServer(async (req, res) => {
       ];
 
       try {
+        // ── Core routes (OPTIONS, health, auth, /me, /cancelled-tasks, /ping, /close) ──
+        // Inside the try: handleCore used to run before it, so a throw there
+        // (observed in prod: a BUSY_SNAPSHOT from updateAgentStatus) escaped
+        // the async listener as an unhandled rejection and the client got a
+        // dropped connection instead of a 500.
+        if (await handleCore(req, res, myAgentId, apiKey)) return;
+
         for (const handler of handlers) {
           if (await handler()) return;
         }


### PR DESCRIPTION
`handleCore` ran before the try/catch that guards every other route handler in `src/http/index.ts`. A throw inside a core route therefore escaped the async server listener as an **unhandled rejection**, and the client saw a dropped connection instead of a 500.

Observed in prod today after the #1204 deploy: litestream's checkpointing invalidated a deferred transaction's read snapshot, `updateAgentStatus` inside a `handleCore` transaction threw `SQLITE_BUSY_SNAPSHOT`, and the process logged `[fatal] unhandledRejection` (container stayed healthy, no restart). The SQLite trigger itself is eliminated by #1229's `BEGIN IMMEDIATE`; this PR closes the error-scope gap so any future core-route throw produces a logged 500 like every other handler.

No dedicated regression test: forcing a throw inside `handleCore` needs fault injection the module doesn't expose, and the change is a pure widening of an existing catch scope. Existing core-auth / readiness / users HTTP tests pass.

https://claude.ai/code/session_01DVtLqQPrHzrSp7mni8GvjT