### PR TITLE
test(db-client): make the busy-retry suite deterministic under --parallel=4

### DIFF
--- a/src/tests/db-client-busy-retry.test.ts
+++ b/src/tests/db-client-busy-retry.test.ts
@@ -13,6 +13,8 @@ const TEST_DB_PATH = "./test-db-client-busy-retry.sqlite";
 let main: Database;
 let locker: Database;
 let client: DbClient;
+/** Outstanding holdWriteLock() timer, if any; afterEach waits for it. */
+let pendingHold: Promise<void> | null = null;
 
 beforeEach(() => {
   main = new Database(TEST_DB_PATH);
@@ -24,12 +26,26 @@ beforeEach(() => {
   locker.exec("PRAGMA busy_timeout = 25");
   client = createBunSqliteClient(() => main, {
     maxWaitMs: 2_000,
-    backoffMs: [25, 50, 100, 200],
+    // Headroom over the longest holdWriteLock() hold used with this client
+    // (400ms): 5 backoff slots sum to 775ms, so even at the minimum 0.5x
+    // jitter the writer's final non-retried attempt lands after the
+    // external lock releases instead of racing it.
+    backoffMs: [25, 50, 100, 200, 400],
     attemptSpinMs: 25,
   });
+  pendingHold = null;
 });
 
 afterEach(async () => {
+  // A test that exits early (a failed assertion, a thrown error) never
+  // awaits its own holdWriteLock() promise. Wait for it here so its
+  // setTimeout callback runs against a still-open, still-in-transaction
+  // `locker` instead of firing later against a rolled-back or already
+  // reassigned connection.
+  if (pendingHold) {
+    await pendingHold;
+    pendingHold = null;
+  }
   try {
     locker.run("ROLLBACK");
   } catch {
@@ -46,12 +62,17 @@ afterEach(async () => {
 function holdWriteLock(ms: number): Promise<void> {
   locker.run("BEGIN IMMEDIATE");
   locker.run("INSERT INTO items (name) VALUES ('locker')");
-  return new Promise((resolve) =>
+  const hold = new Promise<void>((resolve) =>
     setTimeout(() => {
-      locker.run("COMMIT");
+      // Only commit if `locker` is still the connection that opened this
+      // transaction: afterEach's ROLLBACK (or the next test's beforeEach
+      // reassigning `locker`) may already have run by the time this fires.
+      if (locker.inTransaction) locker.run("COMMIT");
       resolve();
     }, ms),
   );
+  pendingHold = hold;
+  return hold;
 }
 
 describe("db-client SQLITE_BUSY retry", () => {
@@ -84,46 +105,62 @@ describe("db-client SQLITE_BUSY retry", () => {
       attemptSpinMs: 25,
     });
     const released = holdWriteLock(600);
-    await expect(tightClient.run("INSERT INTO items (name) VALUES (?)", ["never"])).rejects.toThrow(
-      /database is locked/,
-    );
+    let caught: unknown;
+    try {
+      await tightClient.run("INSERT INTO items (name) VALUES (?)", ["never"]);
+    } catch (err) {
+      caught = err;
+    }
     await released;
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/database is locked/);
+    expect((caught as { code?: string }).code).toBe("SQLITE_BUSY");
   });
 
   test("readOnly transaction proceeds at full speed under an external write lock", async () => {
     await client.run("INSERT INTO items (name) VALUES (?)", ["seed"]);
-    const released = holdWriteLock(400);
-    const started = Date.now();
+    const order: string[] = [];
+    const released = holdWriteLock(400).then(() => {
+      order.push("released");
+    });
     const names = await client.transaction(
       async (tx) => (await tx.query<{ name: string }>("SELECT name FROM items")).map((r) => r.name),
       { readOnly: true },
     );
-    // Deferred BEGIN never touches the write lock: no busy spin, no retry
-    // budget, done long before the locker releases.
-    expect(Date.now() - started).toBeLessThan(200);
-    expect(names).toEqual(["seed"]);
+    order.push("read");
     await released;
+    // Deferred BEGIN never touches the write lock: no busy spin, no retry
+    // budget, so the read settles before the locker releases regardless of
+    // scheduler noise (an ordering check, not a wall-clock bound).
+    expect(order).toEqual(["read", "released"]);
+    expect(names).toEqual(["seed"]);
   });
 
   test("reads flow while a write retries in backoff (FIFO lock released between attempts)", async () => {
     await client.run("INSERT INTO items (name) VALUES (?)", ["reader-food"]);
-    const released = holdWriteLock(400);
+    const order: string[] = [];
+    const released = holdWriteLock(400).then(() => {
+      order.push("released");
+    });
     const write = client.run("INSERT INTO items (name) VALUES (?)", ["late-write"]);
     // Let the write burn its first attempt and enter async backoff.
     await new Promise((resolve) => setTimeout(resolve, 60));
-    const started = Date.now();
     const rows = await client.query<{ name: string }>(
       "SELECT name FROM items WHERE name = 'reader-food'",
     );
-    // Pre-fix, the retrying writer held the FIFO lock across its sleeps and
-    // this read queued behind the full retry span.
-    expect(Date.now() - started).toBeLessThan(150);
-    expect(rows.length).toBe(1);
+    order.push("read");
     await released;
     await write;
     const landed = await client.get<{ name: string }>(
       "SELECT name FROM items WHERE name = 'late-write'",
     );
+    // Pre-fix, the retrying writer held the FIFO lock across its sleeps and
+    // this read queued behind the full retry span; assert the settle order
+    // instead of a wall-clock bound so scheduler noise cannot flip the
+    // result, and only assert after every started call has been awaited so
+    // a failing expectation can never orphan `write` or `released`.
+    expect(order).toEqual(["read", "released"]);
+    expect(rows.length).toBe(1);
     expect(landed?.name).toBe("late-write");
   });
 
@@ -140,8 +177,11 @@ describe("db-client SQLITE_BUSY retry", () => {
     await expect(client.run("INSERT INTO no_such_table (name) VALUES (?)", ["x"])).rejects.toThrow(
       /no such table/,
     );
-    // A retried error would have slept through the backoff schedule.
-    expect(Date.now() - started).toBeLessThan(100);
+    // A retried error would have slept through at least the first backoff
+    // step (>=12ms jittered) plus spin overhead; widened from 100ms to
+    // absorb --parallel=4 scheduler noise without masking an accidental
+    // retry, which would need to clear the full ~775ms backoff schedule.
+    expect(Date.now() - started).toBeLessThan(500);
   });
 
   test("reads proceed under an external write lock without needing the retry path", async () => {


### PR DESCRIPTION
## Summary

`src/tests/db-client-busy-retry.test.ts` (from #1229) kicked PR #1234 out of the merge queue once with "Unhandled error between tests: SQLiteError: database is locked" plus "cannot commit - no transaction is active". This makes the suite deterministic without weakening what it proves.

## Mechanism

The shared client used `backoffMs: [25, 50, 100, 200]`: four slots, so the fifth attempt runs with no retries left whatever `maxWaitMs` says. Two tests hold the external write lock for 400 ms. At the low end of the jitter the writer's final attempt lands before the lock releases and throws `SQLITE_BUSY`. In "reads flow while a write retries in backoff" that writer (`client.run(...)`) was not awaited before the first `expect`, so a throw (its own, or the wall-clock assertion's) left the write promise and the `holdWriteLock` timer orphaned. `afterEach` then rolled back and closed both connections, the orphaned write surfaced as an unhandled error attributed to the next test, and the orphaned timer ran `COMMIT` against a connection with no transaction. Reproduced locally at 2/40 sequential runs with no CPU pressure; 0/50 after the fix.

## Change

- Wall-clock assertions (`< 150 ms`, `< 200 ms`) become settle-order assertions: the read is recorded before `released`. That still proves the #1229 property (the FIFO lock is released between retry sleeps; a readOnly transaction never contends for the write lock) and cannot flip on scheduler noise.
- Every started promise is awaited before any `expect`, so a failing assertion can no longer orphan work.
- `backoffMs` gains a fifth slot (`400`), so the retry budget outlasts the 400 ms hold at minimum jitter. The budget-exhaustion test keeps its own tight client and now also asserts `code === "SQLITE_BUSY"`.
- `holdWriteLock` only commits if `locker.inTransaction`, and `afterEach` awaits any outstanding hold before rollback/close.
- The one remaining latency bound (non-BUSY errors are not retried) is widened 100 -> 500 ms; an accidental retry would need ~775 ms, so it still discriminates.

`src/be/db-client.ts` is untouched: the mechanism is fully in the test.

## Verification

- `bun test src/tests/db-client-busy-retry.test.ts src/tests/db-client.test.ts`: 29 pass, 5 runs in a row.
- `bun test --parallel=4` with the busy-retry file next to `scripts-runtime-*`, `rbac-admission-e2e`, `memory-edges`: 61 pass, 5 runs.
- Stress loop (file alone, 50 sequential runs): 0 failures (pre-fix: 2/40).
- `bun run lint`, `bun run tsc:check`: clean.

Closes #1236

https://claude.ai/code/session_014ynX6gLoAFVQSghbeZnphJ
