### PR TITLE
docs: drop incorrect re-offer wording from multi-runtime guide

### DIFF
--- a/docs-site/content/docs/(documentation)/guides/multi-runtime-agents.mdx
+++ b/docs-site/content/docs/(documentation)/guides/multi-runtime-agents.mdx
@@ -71,8 +71,8 @@ traffic from the runtime, including the polling loop, refreshes `last_seen_at`.
   task remediation uses the separate heartbeat crash-recovery paths.
 - A task still in the `offered` state when the offeree goes offline — because
   its last runtime expired or closed — is released back to `unassigned` by the
-  same heartbeat sweep, so it can be re-offered or auto-assigned to another
-  eligible agent in that same tick
+  same heartbeat sweep, so it can be auto-assigned to another eligible agent
+  in that same tick
   ([#1207](https://github.com/desplega-ai/agent-swarm/pull/1207)).
 
 ## Shared workspace state


### PR DESCRIPTION
Follow-up to the review note on #1242.

The offered-task recovery bullet said the released task "can be re-offered or auto-assigned" in the same sweep. As the review pointed out, the #1207 path releases the task to `unassigned` and pool auto-assignment then assigns it directly to an eligible idle worker — there is no in-sweep re-offer path. This drops "re-offered or" so the guide matches the actual behavior.