### PR TITLE
feat: add nightly main checkout sync primitive

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -380,6 +380,7 @@ COPY --from=builder --chmod=755 /build/agent-swarm /usr/local/bin/agent-swarm
 COPY --chmod=755 scripts/init-local-postgres.sh /usr/local/bin/init-local-postgres.sh
 COPY --chmod=755 scripts/init-local-redis.sh /usr/local/bin/init-local-redis.sh
 COPY --chmod=755 scripts/install-repo-hooks.sh /usr/local/bin/install-repo-hooks.sh
+COPY --chmod=755 scripts/sync-main-checkouts.sh /usr/local/bin/sync-main-checkouts.sh
 
 # Copy commands / agents
 COPY --chown=worker:worker plugin/commands/* /home/worker/.claude/commands/
@@ -597,6 +598,7 @@ COPY --from=builder --chmod=755 /build/agent-swarm /usr/local/bin/agent-swarm
 COPY --chmod=755 scripts/init-local-postgres.sh /usr/local/bin/init-local-postgres.sh
 COPY --chmod=755 scripts/init-local-redis.sh /usr/local/bin/init-local-redis.sh
 COPY --chmod=755 scripts/install-repo-hooks.sh /usr/local/bin/install-repo-hooks.sh
+COPY --chmod=755 scripts/sync-main-checkouts.sh /usr/local/bin/sync-main-checkouts.sh
 
 # Copy commands / agents
 COPY --chown=worker:worker plugin/commands/* /home/worker/.claude/commands/

--- a/scripts/sync-main-checkouts.sh
+++ b/scripts/sync-main-checkouts.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Safely bring local main refs under caller-supplied roots up to origin/main.
+# This intentionally never checks out, resets, stashes, cleans, or writes a
+# non-main branch. One JSON document is written to stdout for every root.
+set -uo pipefail
+
+json_string() {
+  python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
+}
+
+receipt() {
+  local root=$1 status=$2 repos=$3
+  printf '{"root":%s,"status":%s,"repos":[%s]}\n' \
+    "$(printf '%s' "$root" | json_string)" \
+    "$(printf '%s' "$status" | json_string)" "$repos"
+}
+
+repo_receipt() {
+  local path=$1 status=$2 reason=$3 local_main=${4:-null} origin_main=${5:-null}
+  printf '{"path":%s,"status":%s,"reason":%s,"localMain":%s,"originMain":%s}' \
+    "$(printf '%s' "$path" | json_string)" \
+    "$(printf '%s' "$status" | json_string)" \
+    "$(printf '%s' "$reason" | json_string)" "$local_main" "$origin_main"
+}
+
+if (( $# == 0 )); then
+  echo 'usage: sync-main-checkouts.sh ROOT [ROOT...]' >&2
+  exit 64
+fi
+
+aggregate=0
+for requested_root in "$@"; do
+  repos=()
+  root_status=green
+
+  if [[ ! -d "$requested_root" || -L "$requested_root" ]]; then
+    receipt "$requested_root" error "$(repo_receipt "$requested_root" error "root-missing-or-symlink")"
+    aggregate=1
+    continue
+  fi
+
+  # A root-local atomic mkdir lock prevents two coordinators from manipulating
+  # the same refs concurrently. It is deliberately not a git lock because one
+  # run covers many independent repositories.
+  lock="$requested_root/.nightly-main-sync.lock"
+  if ! mkdir "$lock" 2>/dev/null; then
+    receipt "$requested_root" unsafe "$(repo_receipt "$requested_root" unsafe "overlap-lock-held")"
+    aggregate=1
+    continue
+  fi
+
+  while IFS= read -r -d '' entry; do
+    [[ "$entry" == "$lock" ]] && continue
+    if [[ -L "$entry" ]]; then
+      repos+=("$(repo_receipt "$entry" skipped "symlink-not-followed")")
+      continue
+    fi
+    if ! git -C "$entry" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      repos+=("$(repo_receipt "$entry" skipped "not-a-git-worktree")")
+      continue
+    fi
+    top=$(git -C "$entry" rev-parse --show-toplevel 2>/dev/null || true)
+    # Do not let a nested directory point the command at a repository outside
+    # the requested root's immediate child boundary.
+    if [[ -z "$top" || "$(readlink -f "$top")" != "$(readlink -f "$entry")" ]]; then
+      repos+=("$(repo_receipt "$entry" skipped "not-a-checkout-root")")
+      continue
+    fi
+    if ! git -C "$entry" config --get remote.origin.url >/dev/null 2>&1; then
+      repos+=("$(repo_receipt "$entry" unsafe "missing-origin")")
+      root_status=unsafe; aggregate=1
+      continue
+    fi
+    if ! git -C "$entry" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main >/dev/null 2>&1; then
+      repos+=("$(repo_receipt "$entry" failed "fetch-origin-main-failed")")
+      root_status=failed; aggregate=1
+      continue
+    fi
+    if ! origin=$(git -C "$entry" rev-parse --verify refs/remotes/origin/main 2>/dev/null); then
+      repos+=("$(repo_receipt "$entry" unsafe "missing-origin-main")")
+      root_status=unsafe; aggregate=1
+      continue
+    fi
+    if ! local_main=$(git -C "$entry" rev-parse --verify refs/heads/main 2>/dev/null); then
+      repos+=("$(repo_receipt "$entry" unsafe "missing-local-main" null "\"$origin\"")")
+      root_status=unsafe; aggregate=1
+      continue
+    fi
+    if ! git -C "$entry" merge-base --is-ancestor "$local_main" "$origin" >/dev/null 2>&1; then
+      repos+=("$(repo_receipt "$entry" unsafe "local-main-diverged" "\"$local_main\"" "\"$origin\"")")
+      root_status=unsafe; aggregate=1
+      continue
+    fi
+
+    branch=$(git -C "$entry" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+    if [[ "$branch" == main ]]; then
+      if [[ -n $(git -C "$entry" status --porcelain) ]]; then
+        repos+=("$(repo_receipt "$entry" unsafe "checked-out-main-dirty" "\"$local_main\"" "\"$origin\"")")
+        root_status=unsafe; aggregate=1
+        continue
+      fi
+      if ! git -C "$entry" merge --ff-only refs/remotes/origin/main >/dev/null 2>&1; then
+        repos+=("$(repo_receipt "$entry" failed "fast-forward-main-failed" "\"$local_main\"" "\"$origin\"")")
+        root_status=failed; aggregate=1
+        continue
+      fi
+      repos+=("$(repo_receipt "$entry" green "checked-out-main-fast-forwarded" "\"$(git -C "$entry" rev-parse refs/heads/main)\"" "\"$origin\"")")
+    else
+      # update-ref's expected-old argument makes the ref write atomic. The
+      # preceding ancestry check means this can only be a fast-forward.
+      if ! git -C "$entry" update-ref refs/heads/main "$origin" "$local_main"; then
+        repos+=("$(repo_receipt "$entry" failed "main-ref-changed-during-sync" "\"$local_main\"" "\"$origin\"")")
+        root_status=failed; aggregate=1
+        continue
+      fi
+      repos+=("$(repo_receipt "$entry" green "main-ref-fast-forwarded-off-branch" "\"$origin\"" "\"$origin\"")")
+    fi
+  done < <(find -P "$requested_root" -mindepth 1 -maxdepth 1 -print0)
+
+  joined=$(IFS=,; printf '%s' "${repos[*]:-}")
+  receipt "$requested_root" "$root_status" "$joined"
+  rmdir "$lock" 2>/dev/null || { echo "failed to remove overlap lock: $lock" >&2; aggregate=1; }
+done
+
+exit "$aggregate"

--- a/src/tests/sync-main-checkouts.test.ts
+++ b/src/tests/sync-main-checkouts.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const exec = promisify(execFile);
+const script = join(import.meta.dir, "../../scripts/sync-main-checkouts.sh");
+let root = "";
+
+async function run(command: string, args: string[], cwd?: string) {
+  return exec(command, args, { cwd, env: { ...process.env, GIT_TERMINAL_PROMPT: "0" } });
+}
+async function git(cwd: string, ...args: string[]) {
+  return (await run("git", ["-C", cwd, ...args])).stdout.trim();
+}
+async function commit(cwd: string, message: string) {
+  await git(cwd, "add", ".");
+  await git(cwd, "commit", "-m", message);
+}
+
+async function setup() {
+  const remote = join(root, "remote.git");
+  const upstream = join(root, "upstream");
+  const checkouts = join(root, "checkouts");
+  await run("git", ["init", "--bare", remote]);
+  await mkdir(upstream);
+  await git(upstream, "init", "-b", "main");
+  await git(upstream, "config", "user.email", "test@example.com");
+  await git(upstream, "config", "user.name", "Test");
+  await writeFile(join(upstream, "README"), "one\n");
+  await commit(upstream, "initial");
+  await git(upstream, "remote", "add", "origin", remote);
+  await git(upstream, "push", "-u", "origin", "main");
+  await mkdir(checkouts);
+  return { remote, upstream, checkouts };
+}
+async function clone(remote: string, checkouts: string, name: string) {
+  const path = join(checkouts, name);
+  await run("git", ["clone", "--branch", "main", remote, path]);
+  return path;
+}
+async function advance(upstream: string) {
+  await writeFile(join(upstream, "next"), "next\n");
+  await commit(upstream, "next");
+  await git(upstream, "push", "origin", "main");
+  return git(upstream, "rev-parse", "HEAD");
+}
+async function sync(checkouts: string) {
+  try {
+    const result = await run(script, [checkouts]);
+    return { code: 0, stdout: result.stdout };
+  } catch (error: any) {
+    return { code: error.code ?? 1, stdout: error.stdout ?? "" };
+  }
+}
+
+describe("sync-main-checkouts", () => {
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "swarm-main-sync-"));
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("fast-forwards a clean checked-out main and emits a green receipt", async () => {
+    const { remote, upstream, checkouts } = await setup();
+    const checkout = await clone(remote, checkouts, "main");
+    const expected = await advance(upstream);
+    const result = await sync(checkouts);
+    expect(result.code).toBe(0);
+    expect(await git(checkout, "rev-parse", "HEAD")).toBe(expected);
+    expect(JSON.parse(result.stdout).status).toBe("green");
+  });
+
+  test("only advances main when a feature branch has dirty work", async () => {
+    const { remote, upstream, checkouts } = await setup();
+    const checkout = await clone(remote, checkouts, "feature");
+    await git(checkout, "checkout", "-b", "feature");
+    await writeFile(join(checkout, "README"), "dirty feature\n");
+    const beforeHead = await git(checkout, "rev-parse", "HEAD");
+    const beforeStatus = await git(checkout, "status", "--porcelain");
+    const expected = await advance(upstream);
+    const result = await sync(checkouts);
+    expect(result.code).toBe(0);
+    expect(await git(checkout, "rev-parse", "HEAD")).toBe(beforeHead);
+    expect(await git(checkout, "rev-parse", "main")).toBe(expected);
+    expect(await git(checkout, "status", "--porcelain")).toBe(beforeStatus);
+    expect(await readFile(join(checkout, "README"), "utf8")).toBe("dirty feature\n");
+  });
+
+  test("fails closed for dirty checked-out main, symlinks, and non-git entries", async () => {
+    const { remote, upstream, checkouts } = await setup();
+    const checkout = await clone(remote, checkouts, "dirty-main");
+    const outside = await clone(remote, root, "outside");
+    await advance(upstream);
+    await writeFile(join(checkout, "README"), "dirty main\n");
+    await mkdir(join(checkouts, "not-git"));
+    await symlink(outside, join(checkouts, "linked"));
+    const result = await sync(checkouts);
+    expect(result.code).toBe(1);
+    expect(await git(checkout, "rev-parse", "HEAD")).not.toBe(
+      await git(upstream, "rev-parse", "HEAD"),
+    );
+    expect(result.stdout).toContain("checked-out-main-dirty");
+    expect(result.stdout).toContain("symlink-not-followed");
+    expect(result.stdout).toContain("not-a-git-worktree");
+  });
+
+  test("rejects a divergent local main without changing it", async () => {
+    const { remote, upstream, checkouts } = await setup();
+    const checkout = await clone(remote, checkouts, "diverged");
+    await git(checkout, "config", "user.email", "test@example.com");
+    await git(checkout, "config", "user.name", "Test");
+    await writeFile(join(checkout, "local"), "local\n");
+    await commit(checkout, "local");
+    const before = await git(checkout, "rev-parse", "main");
+    await advance(upstream);
+    const result = await sync(checkouts);
+    expect(result.code).toBe(1);
+    expect(await git(checkout, "rev-parse", "main")).toBe(before);
+    expect(result.stdout).toContain("local-main-diverged");
+  });
+});

--- a/templates/schedules/nightly-main-sync/config.json
+++ b/templates/schedules/nightly-main-sync/config.json
@@ -1,0 +1,13 @@
+{
+  "kind": "schedule",
+  "name": "nightly-main-sync",
+  "displayName": "Nightly Main Checkout Sync",
+  "slug": "nightly-main-sync",
+  "title": "Nightly Main Checkout Sync",
+  "description": "Fail-closed nightly fast-forward of only local main refs in isolated agent and Finn host checkout roots.",
+  "version": "1.0.0",
+  "category": "schedules",
+  "placeholders": ["FINN_HOST_CAPABLE_AGENT_ID"],
+  "runAllSeedersCandidate": false,
+  "tags": ["git", "maintenance", "reliability"]
+}

--- a/templates/schedules/nightly-main-sync/content.md
+++ b/templates/schedules/nightly-main-sync/content.md
@@ -1,0 +1,27 @@
+# Nightly Main Checkout Sync
+
+Install one **enabled `agent-task`** schedule named `nightly-main-sync` with cron `0 3 * * *`, timezone `UTC`, and a lead/DevOps coordinator target. Do **not** use host crontab or a `targetType=script` schedule: catalog scripts run with `fsMode: none` and agent personal volumes are isolated.
+
+## Coordinator task prompt
+
+You are the Nightly Main Checkout Sync coordinator. This is a fail-closed maintenance run. Synchronize only `main` refs using `/usr/local/bin/sync-main-checkouts.sh`; never run `checkout`, `reset`, `stash`, `clean`, or a merge on a feature/work branch.
+
+1. Obtain an overlap lock before dispatching children (for example an atomic `mkdir` lock under the coordinator's durable workspace). If already held, fail this run; do not wait or overlap.
+2. Enumerate all registered agents. Dispatch one child task to **each reachable agent**, targeted to that agent, with this exact command:
+   ```sh
+   /usr/local/bin/sync-main-checkouts.sh /workspace/personal/repos
+   ```
+   The child must return the command's complete JSON-lines receipts and exit status. A missing root, inaccessible agent, command failure, unsafe receipt, or child timeout is a failure.
+3. Separately identify the configured Finn host-capable agent (`FINN_HOST_CAPABLE_AGENT_ID`). Validate that it can see both `/usr/local/bin/sync-main-checkouts.sh` and `/home/dev/Factory` before dispatch. If either is absent, fail closed. Run this **additional** host child on that agent:
+   ```sh
+   /usr/local/bin/sync-main-checkouts.sh /home/dev/Factory
+   ```
+   Do not mount, copy, or inspect another agent's `/workspace/personal` directory from the coordinator.
+4. Poll every child until terminal. Do not complete while a child remains pending/running. Aggregate every receipt. The parent passes only when every non-skipped clone has `status: "green"`, every required root produced a receipt, and every child completed with exit status zero. Skips are allowed only for direct non-Git entries and symlinks; report them explicitly.
+5. Return JSON containing the parent task ID, every child task ID/status, each root receipt, and an overall `green`/`failed` verdict. Preserve the lock until all children are terminal, then remove it.
+
+## Operational rules
+
+- The primitive fetches `origin/main`, checks ancestry, and fast-forwards only `refs/heads/main`. It intentionally leaves checked-out work branches, index, and worktree bytes untouched.
+- Dirty checked-out `main`, divergent `main`, missing remotes, auth/fetch failures, missing roots, and overlap are unsafe/failing outcomes. Escalate rather than repairing them.
+- Enable only after validating the Finn runtime path. After installation, invoke `run-schedule-now` seven times serially and retain parent/child receipts as evidence.


### PR DESCRIPTION
## What
- add a fail-closed, root-bound main-only checkout sync primitive
- include it in slim and full worker images
- add a nightly coordinator schedule template and git-contract tests

## Safety
- never checks out, resets, stashes, cleans, or changes feature/work branches
- rejects dirty checked-out main, divergent refs, missing origin, fetch errors, symlinks, and overlapping runs

## Validation
- `bun test src/tests/sync-main-checkouts.test.ts`
- `bun run tsc:check`
- `bun run lint`
- `bun run test:root` *(timed out after 300s while still passing; full suite did not complete)*
- inspected required gate-tampering diff (empty)