### PR TITLE
fix: enforce lead-only task routing

### DIFF
--- a/docs-site/public/openapi.d.ts
+++ b/docs-site/public/openapi.d.ts
@@ -19803,6 +19803,7 @@ export interface components {
             harnessProvider?: "claude" | "codex" | "pi" | "devin" | "claude-managed" | "opencode";
             /** @default [] */
             capabilities: string[];
+            leadOnly?: boolean;
         };
         AgentCredStatus: {
             ready: boolean;
@@ -20534,7 +20535,7 @@ export interface components {
             /** Format: uuid */
             id: string;
             /** @enum {string} */
-            eventType: "agent_joined" | "agent_status_change" | "agent_left" | "task_created" | "task_status_change" | "task_progress" | "task_steering" | "task_offered" | "task_accepted" | "task_rejected" | "task_claimed" | "task_claim_rejected_affinity" | "task_released" | "channel_message" | "service_registered" | "service_unregistered" | "service_status_change" | "budget.upserted" | "budget.deleted" | "pricing.inserted" | "pricing.deleted" | "pricing.refresh" | "pricing.refresh.failed" | "task_superseded";
+            eventType: "agent_joined" | "agent_status_change" | "agent_left" | "task_created" | "task_status_change" | "task_progress" | "task_steering" | "task_offered" | "task_accepted" | "task_rejected" | "task_claimed" | "task_claim_rejected_affinity" | "task_authorization_rejected" | "task_recovery_authorization" | "task_released" | "channel_message" | "service_registered" | "service_unregistered" | "service_status_change" | "budget.upserted" | "budget.deleted" | "pricing.inserted" | "pricing.deleted" | "pricing.refresh" | "pricing.refresh.failed" | "task_superseded";
             agentId?: string;
             taskId?: string;
             oldValue?: string;

--- a/docs-site/public/openapi.d.ts
+++ b/docs-site/public/openapi.d.ts
@@ -19790,6 +19790,7 @@ export interface components {
             };
             totalCostUsd?: number;
             routingAffinity?: components["schemas"]["RoutingAffinity"];
+            routingAffinityInvalid?: boolean;
         };
         FollowUpConfig: {
             disabled?: boolean;

--- a/openapi.json
+++ b/openapi.json
@@ -481,6 +481,9 @@
               "type": "string"
             },
             "default": []
+          },
+          "leadOnly": {
+            "type": "boolean"
           }
         }
       },
@@ -3407,6 +3410,8 @@
               "task_rejected",
               "task_claimed",
               "task_claim_rejected_affinity",
+              "task_authorization_rejected",
+              "task_recovery_authorization",
               "task_released",
               "channel_message",
               "service_registered",

--- a/openapi.json
+++ b/openapi.json
@@ -426,6 +426,9 @@
           },
           "routingAffinity": {
             "$ref": "#/components/schemas/RoutingAffinity"
+          },
+          "routingAffinityInvalid": {
+            "type": "boolean"
           }
         },
         "required": [

--- a/runbooks/heartbeat-crash-recovery.md
+++ b/runbooks/heartbeat-crash-recovery.md
@@ -113,7 +113,7 @@ flowchart TD
 ```mermaid
 flowchart TD
   entry["supersedeTask(parent) → frees capacity,<br/>then createResumeFollowUp(crash_recovery<br/>or graceful_shutdown)"]
-  entry --> gate{"original agent row exists,<br/>status≠offline, hasCap?<br/>(protected reasons IGNORE the 30s fresh gate)"}
+  entry --> gate{"lead-only parent?<br/>worker source → current Lead;<br/>otherwise original row exists,<br/>status≠offline, hasCap?"}
   gate -->|"yes (recoverable / restarting)"| pin["resume = PENDING, agentId = parent<br/>(reclaimed on the agent's next poll —<br/>never enters the pool)"]
   gate -->|"no — offline / row gone / at capacity /<br/>pin kill-switch=0"| pool["resume = UNASSIGNED → pool<br/>(genuinely-gone / rollback path)"]
   pin --> reap{"reaper (every sweep, in cleanupStaleResources):<br/>still PENDING after<br/>HEARTBEAT_RESUME_PIN_GRACE_MIN?"}
@@ -122,7 +122,7 @@ flowchart TD
   esc --> lead["Lead re-delegates via send-task(agentId=…)<br/>— explicit agent, never re-pooled"]
 ```
 
-**Heuristic (current):** `crash_recovery` and `graceful_shutdown` resumes are **pinned back to their own (stable-ID) agent**. `createResumeFollowUp` sets `agentId = parent.agentId` whenever the agent row still exists, is not `offline`, and has capacity — *regardless of the 30s `WORKER_LIVENESS_WINDOW_SECONDS` freshness*. The agent ID survives both crash recovery and deploy/SIGTERM graceful shutdown, so "stale" usually means "restarting", not "gone". The resume is `pending` and reclaimed on the agent's next poll; it **never enters the role-blind pool**, so no wrong-specialization worker can grab it (DES-523). It falls back to the pool only when the agent is genuinely gone (`offline`), its row is absent, capacity is full, or the reason-specific rollback switch is `0` (`HEARTBEAT_PIN_CRASH_RESUME` for crash recovery, `HEARTBEAT_PIN_GRACEFUL_RESUME` for graceful shutdown). Other reasons (`context_limits` / `manual_supersede`) still require `fresh`.
+**Heuristic (current):** `crash_recovery` and `graceful_shutdown` resumes are **pinned back to their own (stable-ID) agent**, except a structured `routingAffinity.leadOnly: true` task may only pin to a Lead. A legacy/misrouted worker parent is rerouted to the current Lead when available; otherwise its child remains unassigned (workers cannot claim it) and emits a `task_recovery_authorization` escalation event. `createResumeFollowUp` sets `agentId = parent.agentId` whenever the agent row still exists, is not `offline`, and has capacity — *regardless of the 30s `WORKER_LIVENESS_WINDOW_SECONDS` freshness*. The agent ID survives both crash recovery and deploy/SIGTERM graceful shutdown, so "stale" usually means "restarting", not "gone". The resume is `pending` and reclaimed on the agent's next poll; it **never enters the role-blind pool**, so no wrong-specialization worker can grab it (DES-523). It falls back to the pool only when the agent is genuinely gone (`offline`), its row is absent, capacity is full, or the reason-specific rollback switch is `0` (`HEARTBEAT_PIN_CRASH_RESUME` for crash recovery, `HEARTBEAT_PIN_GRACEFUL_RESUME` for graceful shutdown). Other reasons (`context_limits` / `manual_supersede`) still require `fresh`.
 
 A pin **never reclaimed within `HEARTBEAT_RESUME_PIN_GRACE_MIN`** (the agent that looked recoverable never returned) is escalated by the **reaper** (`escalateUnreclaimedResumes`, run inside `cleanupStaleResources` on *every* sweep, including the post-reboot sweep): it atomically cancels the still-`pending` resume (skipping if the agent reclaimed it in the gap — TOCTOU-safe) and creates a Lead-owned `task.reroute.decision` follow-up. The Lead re-delegates via `send-task` with an **explicit `agentId`** — the work is never re-pooled. A resume already at the generation cap (`MAX_RESUME_GENERATIONS`) is failed instead of escalated, bounding a flapping task. Net: protected pinned reasons touch the unassigned pool **zero times** unless a fail-open guard or rollback switch sends them there.
 
@@ -169,11 +169,12 @@ escalateUnreclaimedResumes():
 
 **Goal:** a task interrupted by ANY event (crash, graceful shutdown, reboot, pool redispatch) must only ever land on an agent whose role matches the original assignee's role — and, where declared, whose capabilities cover the task's requirements. When no eligible agent exists, the task queues and is escalated to the Lead — it never falls to an arbitrary idle worker. Kill-switch: `POOL_AFFINITY_ENFORCEMENT=0` restores the pre-affinity, role-blind pool behavior verbatim; untagged tasks (no `routingAffinity`) are always unaffected.
 
-`agent_tasks.routingAffinity` (migration 113) is a nullable JSON snapshot — `{ sourceAgentId?, role?, capabilities: string[], harnessProvider? }` (`RoutingAffinitySchema`, `src/types.ts`). `harnessProvider` is informational only (native session resume is deprecated — see §3's model-inheritance note) and never enforced.
+`agent_tasks.routingAffinity` (migration 113) is a nullable JSON snapshot — `{ sourceAgentId?, role?, capabilities: string[], harnessProvider?, leadOnly: boolean }`. `leadOnly` is an explicit caller-supplied authorization constraint for merges and other privileged operations; the platform never infers it from prompt text. It is enforced for direct assignment, offers, pool claims, fallback dispatch, and recovery. (`RoutingAffinitySchema`, `src/types.ts`). `harnessProvider` is informational only (native session resume is deprecated — see §3's model-inheritance note) and never enforced.
 
 ```mermaid
 flowchart TD
   gate{"isAgentEligibleForTask(agent, task)"}
+  gate -->|"leadOnly and agent is not Lead"| no0["INELIGIBLE — authorization boundary"]
   gate -->|"enforcement off"| yes1["eligible"]
   gate -->|"task.routingAffinity is null"| yes2["eligible — untagged task"]
   gate -->|"affinity.sourceAgentId == agent.id"| yes3["eligible — own work"]

--- a/scripts/check-rbac-boundary.sh
+++ b/scripts/check-rbac-boundary.sh
@@ -50,7 +50,7 @@ ALLOWED_PATTERNS=(
   'src/tools/get-swarm.ts|a\.isLead \? ", lead" : ""'
   'src/tools/join-swarm.ts|agents\.find\(\(agent\) => agent\.isLead\)'
   'src/tools/join-swarm.ts|agent\.isLead \? "Lead" : "Worker"'
-  'src/tools/send-task.ts|if \(agent\.isLead\) \{'
+  'src/tools/send-task.ts|if \(agent\.isLead !== effectiveLeadOnly\) \{'
   'src/http/poll.ts|if \(agent\??\.isLead\) \{'
   'src/http/kv.ts|let isLead = false;'
   'src/http/kv.ts|isLead = agent\?\.isLead === true;'

--- a/scripts/check-rbac-boundary.sh
+++ b/scripts/check-rbac-boundary.sh
@@ -50,7 +50,7 @@ ALLOWED_PATTERNS=(
   'src/tools/get-swarm.ts|a\.isLead \? ", lead" : ""'
   'src/tools/join-swarm.ts|agents\.find\(\(agent\) => agent\.isLead\)'
   'src/tools/join-swarm.ts|agent\.isLead \? "Lead" : "Worker"'
-  'src/tools/send-task.ts|if \(agent\.isLead !== effectiveLeadOnly\) \{'
+  'src/tools/send-task.ts|if \(effectiveLeadOnly && !agent\.isLead\) \{'
   'src/http/poll.ts|if \(agent\??\.isLead\) \{'
   'src/http/kv.ts|let isLead = false;'
   'src/http/kv.ts|isLead = agent\?\.isLead === true;'

--- a/src/be/db.ts
+++ b/src/be/db.ts
@@ -1205,12 +1205,15 @@ export async function buildRoutingAffinityFromAgent(
  * hands it to the Lead.
  */
 export function isAgentEligibleForTask(
-  agent: Pick<Agent, "id" | "role" | "capabilities">,
+  agent: Pick<Agent, "id" | "isLead" | "role" | "capabilities">,
   task: Pick<AgentTask, "routingAffinity">,
 ): boolean {
-  if (!isPoolAffinityEnforcementEnabled()) return true;
-
   const affinity = task.routingAffinity;
+  // Lead-only is an authorization boundary, never a best-effort pool hint or
+  // a source-agent exception. It remains enforced even if the affinity
+  // kill-switch is used to roll back role/capability matching.
+  if (affinity?.leadOnly && !agent.isLead) return false;
+  if (!isPoolAffinityEnforcementEnabled()) return true;
   if (!affinity) return true; // Untagged task — unchanged behavior.
 
   if (affinity.sourceAgentId && affinity.sourceAgentId === agent.id) return true; // Own work.
@@ -1529,11 +1532,9 @@ export async function assignUnassignedTaskPending(
   taskId: string,
   agentId: string,
 ): Promise<AgentTask | null> {
-  // Eligibility pre-check (routing affinity) — defense in depth for the
-  // heartbeat's `autoAssignPoolTasks`, which already filters candidates via
-  // `isAgentEligibleForTask` before calling this, but any other caller gets
-  // the same guard for free.
-  if (isPoolAffinityEnforcementEnabled()) {
+  // This guard is always needed for lead-only tasks; the predicate itself
+  // handles the optional role/capability kill-switch.
+  {
     const task = await getTaskById(taskId);
     const agent = await getAgentById(agentId);
     if (task && agent && !isAgentEligibleForTask(agent, task)) {
@@ -1545,6 +1546,8 @@ export async function assignUnassignedTaskPending(
           metadata: {
             agentRole: agent.role ?? null,
             requiredRole: task.routingAffinity?.role ?? null,
+            leadOnly: task.routingAffinity?.leadOnly === true,
+            agentIsLead: agent.isLead,
           },
         });
       } catch {}
@@ -5015,6 +5018,26 @@ export async function createTaskExtended(
     }
   }
 
+  // Direct assignment and offers bypass the pool claim gate, so enforce the
+  // structured lead-only constraint at task creation as well. This is after
+  // parent inheritance so continuations cannot shed the parent's boundary.
+  const targetAgentId = options.agentId ?? options.offeredTo;
+  if (options.routingAffinity?.leadOnly && targetAgentId) {
+    const target = await getAgentById(targetAgentId);
+    if (!target?.isLead) {
+      try {
+        await createLogEntry({
+          eventType: "task_authorization_rejected",
+          agentId: options.creatorAgentId,
+          metadata: { leadOnly: true, targetAgentId, decision: "reject_non_lead_assignment" },
+        });
+      } catch {}
+      throw new Error(
+        `Lead-only task cannot be assigned or offered to non-Lead agent "${targetAgentId}".`,
+      );
+    }
+  }
+
   const auditUserId = getCurrentRequestUserId() ?? null;
   const assetKey = normalizeAssetKey(options?.key ?? defaultAssetKey("task", id));
   // The Linear tracker dedup guard and the INSERT commit as one unit. Two
@@ -5115,7 +5138,13 @@ export async function createTaskExtended(
       agentId: options?.creatorAgentId,
       taskId: id,
       newValue: status,
-      metadata: { source: options?.source ?? "mcp" },
+      metadata: {
+        source: options?.source ?? "mcp",
+        leadOnly: options?.routingAffinity?.leadOnly === true,
+        authorization: options?.routingAffinity?.leadOnly
+          ? { decision: "authorized", targetAgentId: options.agentId ?? options.offeredTo ?? null }
+          : undefined,
+      },
     });
   } catch {}
 
@@ -5156,10 +5185,9 @@ export async function createTaskExtended(
 }
 
 export async function claimTask(taskId: string, agentId: string): Promise<AgentTask | null> {
-  // Eligibility pre-check (routing affinity): static per (agent, task), so
-  // pre-filtering here does NOT reopen the claim race — the atomic UPDATE
-  // below still arbitrates concurrent claims by eligible agents.
-  if (isPoolAffinityEnforcementEnabled()) {
+  // Static per (agent, task), so this pre-check does not reopen the atomic
+  // claim race. It always applies to lead-only authorization.
+  {
     const task = await getTaskById(taskId);
     const agent = await getAgentById(agentId);
     if (task && agent && !isAgentEligibleForTask(agent, task)) {
@@ -5171,6 +5199,8 @@ export async function claimTask(taskId: string, agentId: string): Promise<AgentT
           metadata: {
             agentRole: agent.role ?? null,
             requiredRole: task.routingAffinity?.role ?? null,
+            leadOnly: task.routingAffinity?.leadOnly === true,
+            agentIsLead: agent.isLead,
           },
         });
       } catch {}
@@ -5240,6 +5270,22 @@ export async function releaseTask(taskId: string): Promise<AgentTask | null> {
 export async function acceptTask(taskId: string, agentId: string): Promise<AgentTask | null> {
   const task = await getTaskById(taskId);
   if (!task) return null;
+  const agent = await getAgentById(agentId);
+  if (task.routingAffinity?.leadOnly && (!agent || !isAgentEligibleForTask(agent, task))) {
+    try {
+      await createLogEntry({
+        eventType: "task_claim_rejected_affinity",
+        agentId,
+        taskId,
+        metadata: {
+          leadOnly: true,
+          agentIsLead: agent?.isLead ?? false,
+          decision: "reject_offer_accept",
+        },
+      });
+    } catch {}
+    return null;
+  }
   // Accept both 'offered' and 'reviewing' statuses
   if (!(task.status === "offered" || task.status === "reviewing") || task.offeredTo !== agentId)
     return null;
@@ -5499,6 +5545,22 @@ export async function claimOfferedTask(taskId: string, agentId: string): Promise
   const task = await getTaskById(taskId);
   if (!task) return null;
   if (task.status !== "offered" || task.offeredTo !== agentId) return null;
+  const agent = await getAgentById(agentId);
+  if (task.routingAffinity?.leadOnly && (!agent || !isAgentEligibleForTask(agent, task))) {
+    try {
+      await createLogEntry({
+        eventType: "task_claim_rejected_affinity",
+        agentId,
+        taskId,
+        metadata: {
+          leadOnly: true,
+          agentIsLead: agent?.isLead ?? false,
+          decision: "reject_offer_claim",
+        },
+      });
+    } catch {}
+    return null;
+  }
 
   const now = new Date().toISOString();
   const row = await getDbClient().get<AgentTaskRow>(

--- a/src/be/db.ts
+++ b/src/be/db.ts
@@ -4962,7 +4962,20 @@ export async function createTaskExtended(
         if (!options.routingAffinity) {
           options.routingAffinity = parent.routingAffinity;
         } else if (parent.routingAffinity.leadOnly) {
-          options.routingAffinity = { ...options.routingAffinity, leadOnly: true };
+          // Child-supplied affinity may add requirements, but never remove an
+          // authorization-affecting requirement inherited from a Lead-only
+          // parent. This includes public continuations that default their
+          // requiredCapabilities to an empty array.
+          options.routingAffinity = {
+            ...options.routingAffinity,
+            capabilities: [
+              ...new Set([
+                ...(parent.routingAffinity.capabilities ?? []),
+                ...(options.routingAffinity.capabilities ?? []),
+              ]),
+            ],
+            leadOnly: true,
+          };
         }
       }
     }

--- a/src/be/db.ts
+++ b/src/be/db.ts
@@ -1202,32 +1202,39 @@ export async function buildRoutingAffinityFromAgent(
  * either side is treated as INELIGIBLE — never fail-open to "anyone" — so a
  * capability-only requirement (no `role` set) can only ever be claimed by
  * its `sourceAgentId`, and otherwise queues until the starvation escalation
- * hands it to the Lead.
+ * hands it to the Lead. Lead-only work is different: any Lead may claim it
+ * (subject to explicitly required capabilities), because its source/role is
+ * only recovery provenance and must not turn a worker's old role into a
+ * constraint on the Lead pool.
  */
 export function isAgentEligibleForTask(
   agent: Pick<Agent, "id" | "isLead" | "role" | "capabilities">,
-  task: Pick<AgentTask, "routingAffinity">,
+  task: Pick<AgentTask, "routingAffinity" | "routingAffinityInvalid">,
 ): boolean {
   const affinity = task.routingAffinity;
-  // Lead-only is an authorization boundary, never a best-effort pool hint or
-  // a source-agent exception. It remains enforced even if the affinity
-  // kill-switch is used to roll back role/capability matching.
-  if (affinity?.leadOnly && !agent.isLead) return false;
-  if (!isPoolAffinityEnforcementEnabled()) return true;
+  // A malformed persisted blob is a security boundary failure, not an
+  // untagged task. Quarantine it from every assignment/claim path.
+  if (task.routingAffinityInvalid) return false;
   if (!affinity) return true; // Untagged task — unchanged behavior.
+
+  const requiredCapabilities = affinity.capabilities ?? [];
+  const hasRequiredCapabilities = () => {
+    const agentCapabilities = new Set(agent.capabilities ?? []);
+    return requiredCapabilities.every((cap) => agentCapabilities.has(cap));
+  };
+  // Lead-only is an authorization boundary, never a best-effort pool hint or
+  // a source-agent exception. Its explicit capability requirements remain
+  // enforced even if the role/capability affinity kill-switch is enabled.
+  // Do not require an unrelated worker role/source to match a Lead-only task.
+  if (affinity.leadOnly) return agent.isLead && hasRequiredCapabilities();
+  if (!isPoolAffinityEnforcementEnabled()) return true;
 
   if (affinity.sourceAgentId && affinity.sourceAgentId === agent.id) return true; // Own work.
 
   if (!agent.role || !affinity.role) return false; // Missing role data — no fail-open.
   if (agent.role !== affinity.role) return false;
 
-  const requiredCapabilities = affinity.capabilities ?? [];
-  if (requiredCapabilities.length > 0) {
-    const agentCapabilities = new Set(agent.capabilities ?? []);
-    if (!requiredCapabilities.every((cap) => agentCapabilities.has(cap))) return false;
-  }
-
-  return true;
+  return hasRequiredCapabilities();
 }
 
 // ============================================================================
@@ -1332,20 +1339,23 @@ function rowToAgentTask(row: AgentTaskRow): AgentTask {
   }
 
   let routingAffinity: RoutingAffinity | undefined;
+  let routingAffinityInvalid = false;
   if (row.routingAffinity) {
     try {
       const parsed = RoutingAffinitySchema.safeParse(JSON.parse(row.routingAffinity));
       if (parsed.success) {
         routingAffinity = parsed.data;
       } else {
+        routingAffinityInvalid = true;
         console.warn(
-          `[db] Ignoring invalid agent_tasks.routingAffinity for task ${row.id}:`,
+          `[db] Quarantining invalid agent_tasks.routingAffinity for task ${row.id}:`,
           parsed.error.message,
         );
       }
     } catch (error) {
+      routingAffinityInvalid = true;
       console.warn(
-        `[db] Ignoring malformed agent_tasks.routingAffinity for task ${row.id}:`,
+        `[db] Quarantining malformed agent_tasks.routingAffinity for task ${row.id}:`,
         error instanceof Error ? error.message : String(error),
       );
     }
@@ -1425,6 +1435,7 @@ function rowToAgentTask(row: AgentTaskRow): AgentTask {
     harnessVariantMeta: row.harnessVariantMeta ? JSON.parse(row.harnessVariantMeta) : undefined,
     totalCostUsd: row.totalCostUsd ?? undefined,
     routingAffinity,
+    routingAffinityInvalid: routingAffinityInvalid || undefined,
   };
 }
 
@@ -1516,13 +1527,16 @@ export async function getPendingTaskForAgent(agentId: string): Promise<AgentTask
     [agentId],
   );
 
-  // Find the first task whose dependencies are met
+  const agent = await getAgentById(agentId);
+  if (!agent) return null;
+
+  // A persisted legacy task may already be pending on an unauthorized agent.
+  // Do not dispatch it merely because it bypassed creation-time checks.
   for (const row of rows) {
     const task = rowToAgentTask(row);
+    if (!isAgentEligibleForTask(agent, task)) continue;
     const { ready } = await checkDependencies(task.id);
-    if (ready) {
-      return task;
-    }
+    if (ready) return task;
   }
 
   return null;
@@ -1537,17 +1551,17 @@ export async function assignUnassignedTaskPending(
   {
     const task = await getTaskById(taskId);
     const agent = await getAgentById(agentId);
-    if (task && agent && !isAgentEligibleForTask(agent, task)) {
+    if (task && (!agent || !isAgentEligibleForTask(agent, task))) {
       try {
         await createLogEntry({
           eventType: "task_claim_rejected_affinity",
           agentId,
           taskId,
           metadata: {
-            agentRole: agent.role ?? null,
+            agentRole: agent?.role ?? null,
             requiredRole: task.routingAffinity?.role ?? null,
             leadOnly: task.routingAffinity?.leadOnly === true,
-            agentIsLead: agent.isLead,
+            agentIsLead: agent?.isLead ?? false,
           },
         });
       } catch {}
@@ -4935,8 +4949,21 @@ export async function createTaskExtended(
       if (parent.followUpConfig && !options.followUpConfig) {
         options.followUpConfig = parent.followUpConfig;
       }
-      if (parent.routingAffinity && !options.routingAffinity) {
-        options.routingAffinity = parent.routingAffinity;
+      if (parent.routingAffinityInvalid) {
+        // Never let a corrupt parent affinity create an apparently untagged
+        // continuation. This is a fail-closed quarantine, including recovery.
+        throw new Error(`Cannot continue task ${parent.id}: routing affinity is invalid.`);
+      }
+      if (parent.routingAffinity) {
+        // Privilege cannot be shed by a continuation. A child can narrow or
+        // replace ordinary routing provenance, but a Lead-only parent always
+        // stamps Lead-only onto the child (including callers that supplied
+        // requiredCapabilities and therefore built a fresh affinity object).
+        if (!options.routingAffinity) {
+          options.routingAffinity = parent.routingAffinity;
+        } else if (parent.routingAffinity.leadOnly) {
+          options.routingAffinity = { ...options.routingAffinity, leadOnly: true };
+        }
       }
     }
   }
@@ -5019,21 +5046,27 @@ export async function createTaskExtended(
   }
 
   // Direct assignment and offers bypass the pool claim gate, so enforce the
-  // structured lead-only constraint at task creation as well. This is after
-  // parent inheritance so continuations cannot shed the parent's boundary.
+  // complete structured affinity here. This is after parent inheritance so
+  // continuations cannot shed a Lead-only boundary or its capabilities.
   const targetAgentId = options.agentId ?? options.offeredTo;
-  if (options.routingAffinity?.leadOnly && targetAgentId) {
+  if (options.routingAffinity && targetAgentId) {
     const target = await getAgentById(targetAgentId);
-    if (!target?.isLead) {
+    if (!target || !isAgentEligibleForTask(target, { routingAffinity: options.routingAffinity })) {
       try {
         await createLogEntry({
           eventType: "task_authorization_rejected",
           agentId: options.creatorAgentId,
-          metadata: { leadOnly: true, targetAgentId, decision: "reject_non_lead_assignment" },
+          metadata: {
+            leadOnly: options.routingAffinity.leadOnly === true,
+            targetAgentId,
+            decision: "reject_ineligible_assignment",
+          },
         });
       } catch {}
       throw new Error(
-        `Lead-only task cannot be assigned or offered to non-Lead agent "${targetAgentId}".`,
+        options.routingAffinity.leadOnly
+          ? `Lead-only task routing affinity does not authorize assignment or offer to agent "${targetAgentId}".`
+          : `Task routing affinity does not authorize assignment or offer to agent "${targetAgentId}".`,
       );
     }
   }
@@ -5190,17 +5223,17 @@ export async function claimTask(taskId: string, agentId: string): Promise<AgentT
   {
     const task = await getTaskById(taskId);
     const agent = await getAgentById(agentId);
-    if (task && agent && !isAgentEligibleForTask(agent, task)) {
+    if (task && (!agent || !isAgentEligibleForTask(agent, task))) {
       try {
         await createLogEntry({
           eventType: "task_claim_rejected_affinity",
           agentId,
           taskId,
           metadata: {
-            agentRole: agent.role ?? null,
+            agentRole: agent?.role ?? null,
             requiredRole: task.routingAffinity?.role ?? null,
             leadOnly: task.routingAffinity?.leadOnly === true,
-            agentIsLead: agent.isLead,
+            agentIsLead: agent?.isLead ?? false,
           },
         });
       } catch {}
@@ -5271,7 +5304,10 @@ export async function acceptTask(taskId: string, agentId: string): Promise<Agent
   const task = await getTaskById(taskId);
   if (!task) return null;
   const agent = await getAgentById(agentId);
-  if (task.routingAffinity?.leadOnly && (!agent || !isAgentEligibleForTask(agent, task))) {
+  if (
+    (task.routingAffinity?.leadOnly || task.routingAffinityInvalid) &&
+    (!agent || !isAgentEligibleForTask(agent, task))
+  ) {
     try {
       await createLogEntry({
         eventType: "task_claim_rejected_affinity",
@@ -5546,7 +5582,10 @@ export async function claimOfferedTask(taskId: string, agentId: string): Promise
   if (!task) return null;
   if (task.status !== "offered" || task.offeredTo !== agentId) return null;
   const agent = await getAgentById(agentId);
-  if (task.routingAffinity?.leadOnly && (!agent || !isAgentEligibleForTask(agent, task))) {
+  if (
+    (task.routingAffinity?.leadOnly || task.routingAffinityInvalid) &&
+    (!agent || !isAgentEligibleForTask(agent, task))
+  ) {
     try {
       await createLogEntry({
         eventType: "task_claim_rejected_affinity",

--- a/src/heartbeat/heartbeat.ts
+++ b/src/heartbeat/heartbeat.ts
@@ -3,6 +3,7 @@ import {
   backfillSupersedeTaskResumeTaskId,
   buildRoutingAffinityFromAgent,
   cleanupStaleSessions,
+  createLogEntry,
   createTaskExtended,
   deleteActiveSession,
   failPendingResumeIfUnclaimed,
@@ -53,6 +54,7 @@ import {
   getPinCandidateAgent,
   getResumeGeneration,
   REBOOT_RETRY_PIN_TAG,
+  resolveLeadOnlyRecoveryAssignment,
 } from "../tasks/worker-follow-up";
 import type { AgentTask } from "../types";
 import { isMultiRuntimeEnabled } from "../utils/multi-runtime";
@@ -673,6 +675,16 @@ export async function runRebootSweep(): Promise<void> {
       // Auto-retry: create a replacement task with parentTaskId
       let retryTaskId: string | null = null;
 
+      // A corrupt persisted affinity is never converted into an untagged
+      // retry by this independent recovery path.
+      if (task.routingAffinityInvalid) {
+        console.error(
+          `[Heartbeat] Reboot retry suppressed for ${task.id.slice(0, 8)}: invalid routing affinity`,
+        );
+        rebootAffectedTasks.push({ original: failed, retryTaskId: null });
+        continue;
+      }
+
       // Guard: only retry if parent doesn't already have a retry child
       const existingRetry = await getDbClient().get<{ id: string }>(
         `SELECT id FROM agent_tasks
@@ -693,21 +705,36 @@ export async function runRebootSweep(): Promise<void> {
           // the pool-fallback leg (agent gone/offline/at-capacity) — so that
           // leg is still role/capability-gated instead of role-blind.
           let preferredAgentId: string | undefined;
-          const candidate = await getPinCandidateAgent(task.agentId);
-          if (candidate) {
-            const activeCount = await getActiveTaskCount(candidate.id);
-            const hasCap = activeCount < (candidate.maxTasks ?? 1);
+          let sourceCandidate = await getPinCandidateAgent(task.agentId);
+          if (sourceCandidate) {
+            const activeCount = await getActiveTaskCount(sourceCandidate.id);
+            const maxTasks = sourceCandidate.maxTasks ?? 1;
+            const hasCap = activeCount < maxTasks;
             if (hasCap) {
-              preferredAgentId = candidate.id;
+              preferredAgentId = sourceCandidate.id;
             } else {
+              sourceCandidate = null;
               console.warn(
-                `[Heartbeat] Reboot retry for task ${task.id.slice(0, 8)} NOT pinned: agent ${candidate.id.slice(0, 8)} at capacity (${activeCount}/${candidate.maxTasks ?? 1}); falling back to affinity-gated pool`,
+                `[Heartbeat] Reboot retry for task ${task.id.slice(0, 8)} NOT pinned: agent ${task.agentId.slice(0, 8)} at capacity (${activeCount}/${maxTasks}); falling back to affinity-gated pool`,
               );
             }
           }
 
+          const leadOnly = task.routingAffinity?.leadOnly === true;
+          const authorization = await resolveLeadOnlyRecoveryAssignment(task, sourceCandidate);
+          if (leadOnly) preferredAgentId = authorization.agentId;
+
           const tags = ["reboot-retry", "auto-generated"];
           if (preferredAgentId !== undefined) tags.push(REBOOT_RETRY_PIN_TAG);
+          const sourceAffinity = (await buildRoutingAffinityFromAgent(task.agentId)) ?? undefined;
+          const routingAffinity = leadOnly
+            ? {
+                ...(sourceAffinity ?? task.routingAffinity),
+                capabilities:
+                  task.routingAffinity?.capabilities ?? sourceAffinity?.capabilities ?? [],
+                leadOnly: true,
+              }
+            : sourceAffinity;
 
           const retryTask = await createTaskExtended(task.task, {
             parentTaskId: task.id,
@@ -716,8 +743,21 @@ export async function runRebootSweep(): Promise<void> {
             priority: task.priority,
             source: task.source,
             taskType: task.taskType ?? undefined,
-            routingAffinity: (await buildRoutingAffinityFromAgent(task.agentId)) ?? undefined,
+            routingAffinity,
           });
+          if (authorization.decision) {
+            await createLogEntry({
+              eventType: "task_recovery_authorization",
+              taskId: retryTask.id,
+              agentId: preferredAgentId,
+              metadata: {
+                leadOnly: true,
+                parentTaskId: task.id,
+                sourceAgentId: task.agentId,
+                decision: authorization.decision,
+              },
+            });
+          }
           retryTaskId = retryTask.id;
           console.log(`[Heartbeat] Reboot retry created: ${retryTaskId} (parent: ${task.id})`);
         } catch (err) {

--- a/src/server-user.ts
+++ b/src/server-user.ts
@@ -118,6 +118,7 @@ export function createUserServer(user: User): McpServer {
     if (denied) return denied;
     return sendTaskHandler(userCtx(user, info.sessionId), {
       offerMode: false,
+      leadOnly: false,
       allowDuplicate: false,
       overrideSlackContext: false,
       ...args,

--- a/src/tasks/worker-follow-up.ts
+++ b/src/tasks/worker-follow-up.ts
@@ -1,5 +1,6 @@
 import {
   buildRoutingAffinityFromAgent,
+  createLogEntry,
   createTaskExtended,
   getActiveTaskCount,
   getAgentById,
@@ -291,6 +292,12 @@ export async function createResumeFollowUp(args: {
   //   - `context_limits` / `manual_supersede`: the worker is alive and
   //     responsive, so keep requiring `fresh`.
   let preferredAgentId: string | undefined;
+  let authorizationDecision:
+    | "source_lead_pin"
+    | "rerouted_to_lead"
+    | "escalated_unassigned"
+    | undefined;
+  const leadOnly = parent.routingAffinity?.leadOnly === true;
   if (parent.agentId) {
     const candidate = await getPinCandidateAgent(parent.agentId);
     if (candidate) {
@@ -306,8 +313,13 @@ export async function createResumeFollowUp(args: {
       const isFreshPinnedReason = !isGracefulShutdown && fresh;
       // crash_recovery and graceful_shutdown pins ignore `fresh` when their
       // kill-switches are on; context_limits/manual_supersede still require it.
-      if (hasCap && (isCrashRecovery || isGracefulPin || isFreshPinnedReason)) {
+      if (
+        hasCap &&
+        (isCrashRecovery || isGracefulPin || isFreshPinnedReason) &&
+        (!leadOnly || candidate.isLead)
+      ) {
         preferredAgentId = candidate.id;
+        if (leadOnly) authorizationDecision = "source_lead_pin";
       } else if ((isCrashRecovery || isGracefulPin) && !hasCap) {
         // Surface capacity-driven pool fallback instead of letting a protected
         // pinned-reason skip happen silently.
@@ -315,6 +327,21 @@ export async function createResumeFollowUp(args: {
           `[Heartbeat] ${args.reason} resume for task ${parent.id.slice(0, 8)} NOT pinned: agent ${candidate.id.slice(0, 8)} at capacity (${activeCount}/${candidate.maxTasks ?? 1}); falling back to unassigned pool`,
         );
       }
+    }
+  }
+
+  // A worker-assigned privileged parent must never be pinned back to that
+  // worker. Route to the current Lead when one is available; otherwise leave
+  // the child unassigned. The leadOnly pool predicate keeps workers from
+  // claiming that fallback and starvation escalation gives the Lead an
+  // inspectable decision path.
+  if (leadOnly && !preferredAgentId) {
+    const lead = await getLeadAgent();
+    if (lead && lead.status !== "offline") {
+      preferredAgentId = lead.id;
+      authorizationDecision = "rerouted_to_lead";
+    } else {
+      authorizationDecision = "escalated_unassigned";
     }
   }
 
@@ -342,10 +369,10 @@ export async function createResumeFollowUp(args: {
   // pooled resume — including a crash_recovery resume that fell to the pool at
   // capacity — never gets this tag, so it can't be mistaken for a stale pin
   // after autoAssignPoolTasks flips it to `pending`.
-  if (args.reason === "crash_recovery" && preferredAgentId !== undefined) {
+  if (args.reason === "crash_recovery" && preferredAgentId === parent.agentId) {
     tags.push(CRASH_RECOVERY_PIN_TAG);
   }
-  if (args.reason === "graceful_shutdown" && preferredAgentId !== undefined) {
+  if (args.reason === "graceful_shutdown" && preferredAgentId === parent.agentId) {
     tags.push(GRACEFUL_SHUTDOWN_PIN_TAG);
   }
 
@@ -364,9 +391,16 @@ export async function createResumeFollowUp(args: {
   // `null` and we pass `undefined`, letting `createTaskExtended`'s
   // parentTaskId inheritance block fall back to the parent's OWN
   // (already-inherited) `routingAffinity` instead.
-  const routingAffinity = parent.agentId
+  const sourceAffinity = parent.agentId
     ? ((await buildRoutingAffinityFromAgent(parent.agentId)) ?? undefined)
     : undefined;
+  const routingAffinity = leadOnly
+    ? {
+        ...(sourceAffinity ?? parent.routingAffinity),
+        capabilities: sourceAffinity?.capabilities ?? parent.routingAffinity?.capabilities ?? [],
+        leadOnly: true,
+      }
+    : sourceAffinity;
   const created = await createTaskExtended(followUpDescription, {
     agentId: preferredAgentId,
     creatorAgentId: parent.creatorAgentId,
@@ -377,6 +411,22 @@ export async function createResumeFollowUp(args: {
     parentTaskId: parent.id,
     routingAffinity,
   });
+
+  if (authorizationDecision) {
+    try {
+      await createLogEntry({
+        eventType: "task_recovery_authorization",
+        taskId: created.id,
+        agentId: preferredAgentId,
+        metadata: {
+          leadOnly: true,
+          parentTaskId: parent.id,
+          sourceAgentId: parent.agentId,
+          decision: authorizationDecision,
+        },
+      });
+    } catch {}
+  }
 
   // Repoint Linear / Jira `tracker_sync` rows from the (now terminal) parent
   // to the resume child. Without this, outbound completion posts for the

--- a/src/tasks/worker-follow-up.ts
+++ b/src/tasks/worker-follow-up.ts
@@ -9,6 +9,7 @@ import {
   getTaskAttachments,
   getTaskById,
   hasNonTerminalRerouteDecisionChild,
+  isAgentEligibleForTask,
 } from "../be/db";
 import { repointTrackerSyncBySwarmId } from "../be/db-queries/tracker";
 import { resolveTemplate } from "../prompts/resolver";
@@ -96,6 +97,29 @@ export async function getPinCandidateAgent(agentId: string): Promise<Agent | nul
   const candidate = await getAgentById(agentId);
   if (!candidate || candidate.status === "offline") return null;
   return candidate;
+}
+
+/**
+ * Applies the Lead-only recovery boundary shared by normal resume and reboot
+ * recovery. A worker source is never a valid pin; use an available Lead or
+ * leave the task unassigned so only a Lead can claim it.
+ */
+export async function resolveLeadOnlyRecoveryAssignment(
+  task: Pick<AgentTask, "routingAffinity" | "routingAffinityInvalid">,
+  sourceCandidate: Agent | null,
+): Promise<{
+  agentId?: string;
+  decision?: "source_lead_pin" | "rerouted_to_lead" | "escalated_unassigned";
+}> {
+  if (!task.routingAffinity?.leadOnly) return {};
+  if (sourceCandidate?.isLead && isAgentEligibleForTask(sourceCandidate, task)) {
+    return { agentId: sourceCandidate.id, decision: "source_lead_pin" };
+  }
+  const lead = await getLeadAgent();
+  if (lead && lead.status !== "offline" && isAgentEligibleForTask(lead, task)) {
+    return { agentId: lead.id, decision: "rerouted_to_lead" };
+  }
+  return { decision: "escalated_unassigned" };
 }
 
 export function getResumeGeneration(task: Pick<AgentTask, "tags">): number {
@@ -330,19 +354,14 @@ export async function createResumeFollowUp(args: {
     }
   }
 
-  // A worker-assigned privileged parent must never be pinned back to that
-  // worker. Route to the current Lead when one is available; otherwise leave
-  // the child unassigned. The leadOnly pool predicate keeps workers from
-  // claiming that fallback and starvation escalation gives the Lead an
-  // inspectable decision path.
-  if (leadOnly && !preferredAgentId) {
-    const lead = await getLeadAgent();
-    if (lead && lead.status !== "offline") {
-      preferredAgentId = lead.id;
-      authorizationDecision = "rerouted_to_lead";
-    } else {
-      authorizationDecision = "escalated_unassigned";
-    }
+  // Apply the same Lead-only recovery decision used by reboot recovery. A
+  // non-Lead source can never win the earlier pin attempt, so this chooses a
+  // Lead reroute or an authorization-gated unassigned fallback.
+  if (leadOnly) {
+    const source = preferredAgentId ? await getAgentById(preferredAgentId) : null;
+    const resolution = await resolveLeadOnlyRecoveryAssignment(parent, source);
+    preferredAgentId = resolution.agentId;
+    authorizationDecision = resolution.decision;
   }
 
   const parentDesc = parent.task.slice(0, 200);

--- a/src/tasks/worker-follow-up.ts
+++ b/src/tasks/worker-follow-up.ts
@@ -405,9 +405,11 @@ export async function createResumeFollowUp(args: {
   //
   // Routing affinity: stamp a FRESH snapshot from the parent's own agent —
   // this covers every leg (pinned AND the pool-fallback legs) so a resume
-  // that falls to the unassigned pool is still role/capability-gated. When
-  // the agent row is already gone, `buildRoutingAffinityFromAgent` returns
-  // `null` and we pass `undefined`, letting `createTaskExtended`'s
+  // that falls to the unassigned pool is still role/capability-gated. A
+  // Lead-only task retains its parent-declared required capabilities instead:
+  // the source snapshot is provenance, not an authorization requirement.
+  // When the agent row is already gone, `buildRoutingAffinityFromAgent`
+  // returns `null` and we pass `undefined`, letting `createTaskExtended`'s
   // parentTaskId inheritance block fall back to the parent's OWN
   // (already-inherited) `routingAffinity` instead.
   const sourceAffinity = parent.agentId
@@ -416,7 +418,7 @@ export async function createResumeFollowUp(args: {
   const routingAffinity = leadOnly
     ? {
         ...(sourceAffinity ?? parent.routingAffinity),
-        capabilities: sourceAffinity?.capabilities ?? parent.routingAffinity?.capabilities ?? [],
+        capabilities: parent.routingAffinity?.capabilities ?? [],
         leadOnly: true,
       }
     : sourceAffinity;

--- a/src/tests/heartbeat.test.ts
+++ b/src/tests/heartbeat.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { unlink } from "node:fs/promises";
 import {
+  claimTask,
   closeDb,
   createAgent,
   createTaskExtended,
@@ -679,6 +680,69 @@ describe("Heartbeat Triage", () => {
       expect(tags).toContain("reboot-retry");
       expect(tags).toContain("auto-generated");
       expect(tags).toContain("reboot-retry-pin");
+    });
+
+    test("reboot recovery reroutes a legacy worker-owned lead-only task to a Lead", async () => {
+      const worker = await createAgent({
+        name: "reboot-misrouted-worker",
+        isLead: false,
+        status: "busy",
+      });
+      const lead = await createAgent({
+        name: "reboot-recovery-lead",
+        isLead: true,
+        status: "idle",
+      });
+      const task = await createTaskExtended("Merge this PR", { agentId: worker.id });
+      await startTask(task.id);
+      await getDbClient().run(
+        "UPDATE agent_tasks SET routingAffinity = ?, lastUpdatedAt = ? WHERE id = ?",
+        [
+          JSON.stringify({ sourceAgentId: worker.id, capabilities: [], leadOnly: true }),
+          new Date(Date.now() - 1000).toISOString(),
+          task.id,
+        ],
+      );
+
+      await runRebootSweep();
+
+      const retryId = getRebootAffectedTasks()[0]?.retryTaskId;
+      const retry = retryId ? await getTaskById(retryId) : null;
+      expect(retry?.agentId).toBe(lead.id);
+      expect(retry?.routingAffinity?.leadOnly).toBe(true);
+      const audit = await getDbClient().get<{ metadata: string }>(
+        "SELECT metadata FROM agent_log WHERE taskId = ? AND eventType = 'task_recovery_authorization'",
+        [retryId],
+      );
+      expect(audit?.metadata).toContain("rerouted_to_lead");
+    });
+
+    test("no-Lead reboot fallback remains claimable after an eligible Lead arrives", async () => {
+      const worker = await createAgent({ name: "no-lead-worker", isLead: false, status: "busy" });
+      const task = await createTaskExtended("Merge this PR", { agentId: worker.id });
+      await startTask(task.id);
+      await getDbClient().run(
+        "UPDATE agent_tasks SET routingAffinity = ?, lastUpdatedAt = ? WHERE id = ?",
+        [
+          JSON.stringify({
+            sourceAgentId: worker.id,
+            role: "worker",
+            capabilities: [],
+            leadOnly: true,
+          }),
+          new Date(Date.now() - 1000).toISOString(),
+          task.id,
+        ],
+      );
+
+      await runRebootSweep();
+      const retryId = getRebootAffectedTasks()[0]?.retryTaskId;
+      const retry = retryId ? await getTaskById(retryId) : null;
+      expect(retry?.status).toBe("unassigned");
+      expect(retry?.routingAffinity?.leadOnly).toBe(true);
+
+      const lead = await createAgent({ name: "arriving-lead", isLead: true, status: "idle" });
+      expect(await claimTask(retryId!, lead.id)).not.toBeNull();
     });
 
     test("falls back to an affinity-stamped pool retry when the agent is at capacity", async () => {

--- a/src/tests/heartbeat.test.ts
+++ b/src/tests/heartbeat.test.ts
@@ -19,6 +19,7 @@ import {
   MAX_EMPTY_POLLS,
   resetOrphanedInProgressTasksForAgent,
   startTask,
+  updateAgentProfile,
   updateAgentStatus,
   updateTaskClaudeSessionId,
 } from "../be/db";
@@ -512,6 +513,41 @@ describe("Heartbeat Triage", () => {
         [result.task.id],
       );
       expect(audit?.metadata).toContain("rerouted_to_lead");
+    });
+
+    test("privileged crash recovery preserves parent capabilities on an unassigned child", async () => {
+      const worker = await createAgent({
+        name: "capability-source-worker",
+        isLead: false,
+        status: "idle",
+      });
+      const underprivilegedLead = await createAgent({
+        name: "capability-underprivileged-lead",
+        isLead: true,
+        status: "idle",
+      });
+      await updateAgentProfile(worker.id, { capabilities: ["typescript"] });
+      await updateAgentProfile(underprivilegedLead.id, { capabilities: ["typescript"] });
+      const parent = await createTaskExtended("Merge this PR", { agentId: worker.id });
+      // Simulate legacy privileged work whose source snapshot has capabilities
+      // unrelated to its authorization requirement.
+      await getDbClient().run(
+        "UPDATE agent_tasks SET status = 'superseded', routingAffinity = ? WHERE id = ?",
+        [
+          JSON.stringify({ sourceAgentId: worker.id, capabilities: ["merge"], leadOnly: true }),
+          parent.id,
+        ],
+      );
+
+      const result = await createResumeFollowUp({ parentId: parent.id, reason: "crash_recovery" });
+      expect(result.kind).toBe("created");
+      if (result.kind !== "created") return;
+      expect(result.task.status).toBe("unassigned");
+      expect(result.task.routingAffinity).toMatchObject({
+        leadOnly: true,
+        capabilities: ["merge"],
+      });
+      expect(await claimTask(result.task.id, underprivilegedLead.id)).toBeNull();
     });
 
     test("privileged recovery retains a safe Lead source pin", async () => {

--- a/src/tests/heartbeat.test.ts
+++ b/src/tests/heartbeat.test.ts
@@ -31,6 +31,7 @@ import {
   startHeartbeat,
   stopHeartbeat,
 } from "../heartbeat/heartbeat";
+import { createResumeFollowUp } from "../tasks/worker-follow-up";
 
 const TEST_DB_PATH = "./test-heartbeat.sqlite";
 
@@ -488,6 +489,45 @@ describe("Heartbeat Triage", () => {
 
       const findings = await codeLevelTriage();
       expect(findings.stalledTasks.length).toBe(0);
+    });
+
+    test("privileged crash recovery reroutes a legacy worker parent to the Lead", async () => {
+      const worker = await createAgent({ name: "misrouted-worker", isLead: false, status: "idle" });
+      const lead = await createAgent({ name: "recovery-lead", isLead: true, status: "idle" });
+      const parent = await createTaskExtended("Merge this PR", { agentId: worker.id });
+      // Simulate a legacy row created before the structured constraint existed.
+      await getDbClient().run(
+        "UPDATE agent_tasks SET status = 'superseded', routingAffinity = ? WHERE id = ?",
+        [JSON.stringify({ sourceAgentId: worker.id, capabilities: [], leadOnly: true }), parent.id],
+      );
+
+      const result = await createResumeFollowUp({ parentId: parent.id, reason: "crash_recovery" });
+      expect(result.kind).toBe("created");
+      if (result.kind !== "created") return;
+      expect(result.task.agentId).toBe(lead.id);
+      expect(result.task.routingAffinity?.leadOnly).toBe(true);
+      const audit = await getDbClient().get<{ metadata: string }>(
+        "SELECT metadata FROM agent_log WHERE taskId = ? AND eventType = 'task_recovery_authorization'",
+        [result.task.id],
+      );
+      expect(audit?.metadata).toContain("rerouted_to_lead");
+    });
+
+    test("privileged recovery retains a safe Lead source pin", async () => {
+      const lead = await createAgent({ name: "source-lead", isLead: true, status: "idle" });
+      const parent = await createTaskExtended("Merge this PR", {
+        agentId: lead.id,
+        routingAffinity: { capabilities: [], leadOnly: true },
+      });
+      await getDbClient().run("UPDATE agent_tasks SET status = 'superseded' WHERE id = ?", [
+        parent.id,
+      ]);
+
+      const result = await createResumeFollowUp({ parentId: parent.id, reason: "crash_recovery" });
+      expect(result.kind).toBe("created");
+      if (result.kind !== "created") return;
+      expect(result.task.agentId).toBe(lead.id);
+      expect(result.task.tags).toContain("crash-recovery-pin");
     });
 
     test("sets agent to idle after auto-superseding its only task", async () => {

--- a/src/tests/pool-affinity.test.ts
+++ b/src/tests/pool-affinity.test.ts
@@ -293,12 +293,19 @@ describe("Pool Affinity", () => {
       expect(claimed?.agentId).toBe(agent.id);
     });
 
-    test("a child cannot downgrade a lead-only parent's affinity", async () => {
+    test("a child cannot downgrade a lead-only parent's affinity or capabilities", async () => {
       const worker = await createAgent({ name: "child-worker", isLead: false, status: "idle" });
       const lead = await createAgent({ name: "child-lead", isLead: true, status: "idle" });
+      const underprivilegedLead = await createAgent({
+        name: "child-underprivileged-lead",
+        isLead: true,
+        status: "idle",
+      });
+      await updateAgentProfile(lead.id, { capabilities: ["merge"] });
+      await updateAgentProfile(underprivilegedLead.id, { capabilities: ["typescript"] });
       const parent = await createTaskExtended("Merge", {
         agentId: lead.id,
-        routingAffinity: affinity({ leadOnly: true }),
+        routingAffinity: affinity({ leadOnly: true, capabilities: ["merge"] }),
       });
 
       await expect(
@@ -312,7 +319,9 @@ describe("Pool Affinity", () => {
         parentTaskId: parent.id,
         routingAffinity: affinity({ leadOnly: false, capabilities: ["typescript"] }),
       });
-      expect(child.routingAffinity?.leadOnly).toBe(true);
+      expect(child.routingAffinity).toMatchObject({ leadOnly: true });
+      expect(child.routingAffinity?.capabilities).toEqual(["merge", "typescript"]);
+      expect(await claimTask(child.id, underprivilegedLead.id)).toBeNull();
     });
   });
 

--- a/src/tests/pool-affinity.test.ts
+++ b/src/tests/pool-affinity.test.ts
@@ -63,6 +63,35 @@ describe("Pool Affinity", () => {
       expect(isAgentEligibleForTask(agent, task)).toBe(true);
     });
 
+    test("lead-only blocks a worker even when it is the affinity source", async () => {
+      const worker = await createAgent({
+        name: "privileged-worker",
+        isLead: false,
+        status: "idle",
+      });
+      const task = await createTaskExtended("Merge", {
+        routingAffinity: affinity({ sourceAgentId: worker.id, leadOnly: true }),
+      });
+      expect(isAgentEligibleForTask(worker, task)).toBe(false);
+      expect(await claimTask(task.id, worker.id)).toBeNull();
+    });
+
+    test("lead-only accepts a Lead and rejects direct worker assignment", async () => {
+      const worker = await createAgent({ name: "direct-worker", isLead: false, status: "idle" });
+      const lead = await createAgent({ name: "privileged-lead", isLead: true, status: "idle" });
+      await expect(
+        createTaskExtended("Merge", {
+          agentId: worker.id,
+          routingAffinity: affinity({ leadOnly: true }),
+        }),
+      ).rejects.toThrow("Lead-only task");
+      const task = await createTaskExtended("Merge", {
+        agentId: lead.id,
+        routingAffinity: affinity({ leadOnly: true }),
+      });
+      expect(task.agentId).toBe(lead.id);
+    });
+
     test("sourceAgentId bypass: own work is eligible even with a mismatched role", async () => {
       const owner = await createAgent({ name: "owner", isLead: false, status: "idle" });
       await updateAgentProfile(owner.id, { role: "researcher" });

--- a/src/tests/pool-affinity.test.ts
+++ b/src/tests/pool-affinity.test.ts
@@ -92,6 +92,46 @@ describe("Pool Affinity", () => {
       expect(task.agentId).toBe(lead.id);
     });
 
+    test("an unassigned lead-only task is claimable by a Lead but not a worker", async () => {
+      const worker = await createAgent({ name: "pool-worker", isLead: false, status: "idle" });
+      const lead = await createAgent({ name: "pool-lead", isLead: true, status: "idle" });
+      const task = await createTaskExtended("Merge", {
+        routingAffinity: affinity({ leadOnly: true }),
+      });
+
+      expect(await claimTask(task.id, worker.id)).toBeNull();
+      expect(await claimTask(task.id, lead.id)).not.toBeNull();
+    });
+
+    test("malformed and schema-invalid persisted affinities are quarantined", async () => {
+      const worker = await createAgent({
+        name: "quarantine-worker",
+        isLead: false,
+        status: "idle",
+      });
+      const lead = await createAgent({ name: "quarantine-lead", isLead: true, status: "idle" });
+      const malformed = await createTaskExtended("Malformed affinity");
+      const schemaInvalid = await createTaskExtended("Invalid affinity", {
+        routingAffinity: affinity({ leadOnly: true }),
+      });
+      await getDbClient().run("UPDATE agent_tasks SET routingAffinity = ? WHERE id = ?", [
+        "{not-json",
+        malformed.id,
+      ]);
+      await getDbClient().run("UPDATE agent_tasks SET routingAffinity = ? WHERE id = ?", [
+        JSON.stringify({ leadOnly: true, capabilities: "bad" }),
+        schemaInvalid.id,
+      ]);
+
+      for (const task of [malformed, schemaInvalid]) {
+        expect((await getTaskById(task.id))?.routingAffinityInvalid).toBe(true);
+        expect(await claimTask(task.id, worker.id)).toBeNull();
+        expect(await assignUnassignedTaskPending(task.id, lead.id)).toBeNull();
+        expect(await getUnassignedTaskIdsForAgent(lead.id)).not.toContain(task.id);
+        expect((await getTaskById(task.id))?.status).toBe("unassigned");
+      }
+    });
+
     test("sourceAgentId bypass: own work is eligible even with a mismatched role", async () => {
       const owner = await createAgent({ name: "owner", isLead: false, status: "idle" });
       await updateAgentProfile(owner.id, { role: "researcher" });
@@ -251,6 +291,28 @@ describe("Pool Affinity", () => {
       const claimed = await claimTask(task.id, agent.id);
       expect(claimed).not.toBeNull();
       expect(claimed?.agentId).toBe(agent.id);
+    });
+
+    test("a child cannot downgrade a lead-only parent's affinity", async () => {
+      const worker = await createAgent({ name: "child-worker", isLead: false, status: "idle" });
+      const lead = await createAgent({ name: "child-lead", isLead: true, status: "idle" });
+      const parent = await createTaskExtended("Merge", {
+        agentId: lead.id,
+        routingAffinity: affinity({ leadOnly: true }),
+      });
+
+      await expect(
+        createTaskExtended("Child", {
+          parentTaskId: parent.id,
+          agentId: worker.id,
+          routingAffinity: affinity({ leadOnly: false, capabilities: ["typescript"] }),
+        }),
+      ).rejects.toThrow("Lead-only task");
+      const child = await createTaskExtended("Child", {
+        parentTaskId: parent.id,
+        routingAffinity: affinity({ leadOnly: false, capabilities: ["typescript"] }),
+      });
+      expect(child.routingAffinity?.leadOnly).toBe(true);
     });
   });
 

--- a/src/tests/task-tools-ctx.test.ts
+++ b/src/tests/task-tools-ctx.test.ts
@@ -1,6 +1,13 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { unlink } from "node:fs/promises";
-import { closeDb, createTaskExtended, createUser, getTaskById, initDb } from "../be/db";
+import {
+  closeDb,
+  createAgent,
+  createTaskExtended,
+  createUser,
+  getTaskById,
+  initDb,
+} from "../be/db";
 import { getTasksHandler } from "../tools/get-tasks";
 import { sendTaskHandler } from "../tools/send-task";
 import { assertOwnsTask, ownerCtx, userCtx } from "../tools/task-tool-ctx";
@@ -46,6 +53,31 @@ describe("task tool ctx", () => {
     const stored = await getTaskById(data.task.id);
     expect(stored?.creatorAgentId).toBeUndefined();
     expect(stored?.requestedByUserId).toBe(user.id);
+  });
+
+  test("send-task continuation cannot shed a lead-only parent boundary", async () => {
+    const lead = await createAgent({ name: "continuation lead", isLead: true, status: "idle" });
+    const sender = await createAgent({
+      name: "continuation sender",
+      isLead: false,
+      status: "idle",
+    });
+    const parent = await createTaskExtended("privileged parent", {
+      agentId: lead.id,
+      routingAffinity: { capabilities: [], leadOnly: true },
+    });
+
+    const result = await sendTaskHandler(ownerCtx({ agentId: sender.id }), {
+      task: "attempted ordinary child",
+      parentTaskId: parent.id,
+      requiredCapabilities: [],
+      offerMode: true,
+      allowDuplicate: false,
+    });
+
+    expect(result.ok).toBe(true);
+    const data = result.data as { task: { id: string } };
+    expect((await getTaskById(data.task.id))?.routingAffinity?.leadOnly).toBe(true);
   });
 
   test("getTasksHandler with user ctx only returns that user's tasks", async () => {

--- a/src/tests/task-tools-ctx.test.ts
+++ b/src/tests/task-tools-ctx.test.ts
@@ -1,12 +1,14 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { unlink } from "node:fs/promises";
 import {
+  claimTask,
   closeDb,
   createAgent,
   createTaskExtended,
   createUser,
   getTaskById,
   initDb,
+  updateAgentProfile,
 } from "../be/db";
 import { getTasksHandler } from "../tools/get-tasks";
 import { sendTaskHandler } from "../tools/send-task";
@@ -55,29 +57,40 @@ describe("task tool ctx", () => {
     expect(stored?.requestedByUserId).toBe(user.id);
   });
 
-  test("send-task continuation cannot shed a lead-only parent boundary", async () => {
+  test("send-task continuations cannot shed lead-only parent capabilities when omitted or empty", async () => {
     const lead = await createAgent({ name: "continuation lead", isLead: true, status: "idle" });
+    const underprivilegedLead = await createAgent({
+      name: "continuation underprivileged lead",
+      isLead: true,
+      status: "idle",
+    });
     const sender = await createAgent({
       name: "continuation sender",
       isLead: false,
       status: "idle",
     });
+    await updateAgentProfile(lead.id, { capabilities: ["merge"] });
+    await updateAgentProfile(underprivilegedLead.id, { capabilities: ["typescript"] });
     const parent = await createTaskExtended("privileged parent", {
       agentId: lead.id,
-      routingAffinity: { capabilities: [], leadOnly: true },
+      routingAffinity: { capabilities: ["merge"], leadOnly: true },
     });
 
-    const result = await sendTaskHandler(ownerCtx({ agentId: sender.id }), {
-      task: "attempted ordinary child",
-      parentTaskId: parent.id,
-      requiredCapabilities: [],
-      offerMode: true,
-      allowDuplicate: false,
-    });
+    for (const requiredCapabilities of [undefined, []] as const) {
+      const result = await sendTaskHandler(ownerCtx({ agentId: sender.id }), {
+        task: `attempted ordinary child ${requiredCapabilities ? "empty" : "omitted"}`,
+        parentTaskId: parent.id,
+        ...(requiredCapabilities !== undefined ? { requiredCapabilities } : {}),
+        offerMode: true,
+        allowDuplicate: false,
+      });
 
-    expect(result.ok).toBe(true);
-    const data = result.data as { task: { id: string } };
-    expect((await getTaskById(data.task.id))?.routingAffinity?.leadOnly).toBe(true);
+      expect(result.ok).toBe(true);
+      const data = result.data as { task: { id: string } };
+      const child = await getTaskById(data.task.id);
+      expect(child?.routingAffinity).toMatchObject({ leadOnly: true, capabilities: ["merge"] });
+      expect(await claimTask(data.task.id, underprivilegedLead.id)).toBeNull();
+    }
   });
 
   test("getTasksHandler with user ctx only returns that user's tasks", async () => {

--- a/src/tests/task-tools-ctx.test.ts
+++ b/src/tests/task-tools-ctx.test.ts
@@ -57,6 +57,48 @@ describe("task tool ctx", () => {
     expect(stored?.requestedByUserId).toBe(user.id);
   });
 
+  test("send-task directly assigns an ordinary task to a Lead", async () => {
+    const sender = await createAgent({
+      name: "ordinary-task sender",
+      isLead: false,
+      status: "idle",
+    });
+    const lead = await createAgent({ name: "ordinary-task lead", isLead: true, status: "idle" });
+
+    const result = await sendTaskHandler(ownerCtx({ agentId: sender.id }), {
+      task: "ordinary direct assignment",
+      agentId: lead.id,
+      offerMode: false,
+      allowDuplicate: false,
+    });
+
+    expect(result.ok).toBe(true);
+    const data = result.data as { task: { id: string; agentId?: string } };
+    expect(data.task.agentId).toBe(lead.id);
+    expect((await getTaskById(data.task.id))?.agentId).toBe(lead.id);
+  });
+
+  test("send-task offers an ordinary task to a Lead", async () => {
+    const sender = await createAgent({
+      name: "ordinary-offer sender",
+      isLead: false,
+      status: "idle",
+    });
+    const lead = await createAgent({ name: "ordinary-offer lead", isLead: true, status: "idle" });
+
+    const result = await sendTaskHandler(ownerCtx({ agentId: sender.id }), {
+      task: "ordinary offer",
+      agentId: lead.id,
+      offerMode: true,
+      allowDuplicate: false,
+    });
+
+    expect(result.ok).toBe(true);
+    const data = result.data as { task: { id: string; offeredTo?: string } };
+    expect(data.task.offeredTo).toBe(lead.id);
+    expect((await getTaskById(data.task.id))?.offeredTo).toBe(lead.id);
+  });
+
   test("send-task continuations cannot shed lead-only parent capabilities when omitted or empty", async () => {
     const lead = await createAgent({ name: "continuation lead", isLead: true, status: "idle" });
     const underprivilegedLead = await createAgent({

--- a/src/tools/get-task-details.ts
+++ b/src/tools/get-task-details.ts
@@ -40,6 +40,7 @@ const looseRoutingAffinitySchema = z.looseObject({
   role: z.string().optional(),
   harnessProvider: z.string().optional(),
   capabilities: z.array(z.string()).optional(),
+  leadOnly: z.boolean().optional(),
 });
 
 export const looseAgentTaskOutputSchema = z.looseObject({

--- a/src/tools/send-task.ts
+++ b/src/tools/send-task.ts
@@ -463,12 +463,10 @@ export async function sendTaskHandler(
       };
     }
 
-    if (agent.isLead !== effectiveLeadOnly) {
+    if (effectiveLeadOnly && !agent.isLead) {
       return {
         success: false,
-        message: effectiveLeadOnly
-          ? `Lead-only task requires a Lead agent; "${agent.name}" is not a Lead.`
-          : `Cannot assign a non-Lead-only task to Lead agent "${agent.name}".`,
+        message: `Lead-only task requires a Lead agent; "${agent.name}" is not a Lead.`,
       };
     }
 

--- a/src/tools/send-task.ts
+++ b/src/tools/send-task.ts
@@ -62,8 +62,12 @@ export const sendTaskInputSchema = z
     requiredCapabilities: z
       .array(z.string())
       .optional()
+      .describe("Capabilities required for pool routing."),
+    leadOnly: z
+      .boolean()
+      .default(false)
       .describe(
-        "Capabilities a claiming agent must have (declared via join-swarm/update-profile) to be pool-eligible for this task. Written into the created task's routingAffinity (role is left unset — only enforced when the pool auto-claim/claim-tool paths check it). Most useful when omitting agentId (unassigned pool task); a no-op for a task with an explicit agentId, which bypasses the pool gate entirely.",
+        "Structured authorization constraint for merge or other privileged work. Only Lead agents may be assigned, offered, or claim it; never inferred from task text.",
       ),
     priority: z.number().int().min(0).max(100).optional().describe("Priority 0-100 (default: 50)."),
     dependsOn: z.array(z.uuid()).optional().describe("Task IDs this task depends on."),
@@ -198,6 +202,7 @@ export async function sendTaskHandler(
     taskType,
     tags,
     requiredCapabilities,
+    leadOnly,
     priority,
     dependsOn,
     dir,
@@ -423,13 +428,10 @@ export async function sendTaskHandler(
         slackUserId,
         overrideSlackContext,
         followUpConfig,
-        // Only meaningful here: a pool task's routingAffinity gates
-        // claimTask/autoAssignPoolTasks. offer/direct-assign below bypass the
-        // pool gate entirely via an explicit agentId, so requiredCapabilities
-        // is a no-op there.
-        routingAffinity: requiredCapabilities?.length
-          ? { capabilities: requiredCapabilities }
-          : undefined,
+        routingAffinity:
+          leadOnly || requiredCapabilities?.length
+            ? { leadOnly, capabilities: requiredCapabilities ?? [] }
+            : undefined,
       });
       await transferTrackerSyncToResumeChild({
         parentTaskId: effectiveParentTaskId,
@@ -453,10 +455,12 @@ export async function sendTaskHandler(
       };
     }
 
-    if (agent.isLead) {
+    if (agent.isLead !== leadOnly) {
       return {
         success: false,
-        message: `Cannot assign tasks to the lead agent "${agent.name}", wtf?`,
+        message: leadOnly
+          ? `Lead-only task requires a Lead agent; "${agent.name}" is not a Lead.`
+          : `Cannot assign a non-Lead-only task to Lead agent "${agent.name}".`,
       };
     }
 
@@ -492,6 +496,10 @@ export async function sendTaskHandler(
         slackUserId,
         overrideSlackContext,
         followUpConfig,
+        routingAffinity:
+          leadOnly || requiredCapabilities?.length
+            ? { leadOnly, capabilities: requiredCapabilities ?? [] }
+            : undefined,
       });
       await transferTrackerSyncToResumeChild({
         parentTaskId: effectiveParentTaskId,
@@ -528,6 +536,10 @@ export async function sendTaskHandler(
       slackUserId,
       overrideSlackContext,
       followUpConfig,
+      routingAffinity:
+        leadOnly || requiredCapabilities?.length
+          ? { leadOnly, capabilities: requiredCapabilities ?? [] }
+          : undefined,
     });
     await transferTrackerSyncToResumeChild({
       parentTaskId: effectiveParentTaskId,

--- a/src/tools/send-task.ts
+++ b/src/tools/send-task.ts
@@ -245,6 +245,14 @@ export async function sendTaskHandler(
   const effectiveParentTask = effectiveParentTaskId
     ? await getTaskById(effectiveParentTaskId)
     : null;
+  if (effectiveParentTask?.routingAffinityInvalid) {
+    return toolErr("Cannot continue a task with an invalid routing affinity.", {
+      data: { yourAgentId: creatorAgentId },
+    });
+  }
+  // A public continuation cannot accidentally declassify its parent before
+  // createTaskExtended performs the authoritative merge.
+  const effectiveLeadOnly = leadOnly || effectiveParentTask?.routingAffinity?.leadOnly === true;
 
   // Slack-routing coherence guard: reject a hand-typed slackChannelId/slackThreadTs
   // that disagrees with the parent task or the contextKey this child will inherit.
@@ -429,8 +437,8 @@ export async function sendTaskHandler(
         overrideSlackContext,
         followUpConfig,
         routingAffinity:
-          leadOnly || requiredCapabilities?.length
-            ? { leadOnly, capabilities: requiredCapabilities ?? [] }
+          effectiveLeadOnly || requiredCapabilities?.length
+            ? { leadOnly: effectiveLeadOnly, capabilities: requiredCapabilities ?? [] }
             : undefined,
       });
       await transferTrackerSyncToResumeChild({
@@ -455,10 +463,10 @@ export async function sendTaskHandler(
       };
     }
 
-    if (agent.isLead !== leadOnly) {
+    if (agent.isLead !== effectiveLeadOnly) {
       return {
         success: false,
-        message: leadOnly
+        message: effectiveLeadOnly
           ? `Lead-only task requires a Lead agent; "${agent.name}" is not a Lead.`
           : `Cannot assign a non-Lead-only task to Lead agent "${agent.name}".`,
       };
@@ -497,8 +505,8 @@ export async function sendTaskHandler(
         overrideSlackContext,
         followUpConfig,
         routingAffinity:
-          leadOnly || requiredCapabilities?.length
-            ? { leadOnly, capabilities: requiredCapabilities ?? [] }
+          effectiveLeadOnly || requiredCapabilities?.length
+            ? { leadOnly: effectiveLeadOnly, capabilities: requiredCapabilities ?? [] }
             : undefined,
       });
       await transferTrackerSyncToResumeChild({
@@ -537,8 +545,8 @@ export async function sendTaskHandler(
       overrideSlackContext,
       followUpConfig,
       routingAffinity:
-        leadOnly || requiredCapabilities?.length
-          ? { leadOnly, capabilities: requiredCapabilities ?? [] }
+        effectiveLeadOnly || requiredCapabilities?.length
+          ? { leadOnly: effectiveLeadOnly, capabilities: requiredCapabilities ?? [] }
           : undefined,
     });
     await transferTrackerSyncToResumeChild({

--- a/src/tools/task-action.ts
+++ b/src/tools/task-action.ts
@@ -102,8 +102,12 @@ export const taskActionInputSchema = z.object({
   requiredCapabilities: z
     .array(z.string())
     .optional()
+    .describe("Capabilities required for pool routing."),
+  leadOnly: z
+    .boolean()
+    .default(false)
     .describe(
-      "Capabilities a claiming agent must have (declared via join-swarm/update-profile) to be pool-eligible for this task. Written into the created task's routingAffinity (role is left unset). Only used with 'create' action.",
+      "Structured authorization constraint: only Lead agents may claim this privileged task.",
     ),
 });
 
@@ -193,6 +197,7 @@ export async function taskActionHandler(
     dir,
     model,
     requiredCapabilities,
+    leadOnly,
   } = input;
   const normalizedModel = splitLegacyModelAlias({ model, modelTier: input.modelTier });
 
@@ -296,9 +301,10 @@ export async function taskActionHandler(
           model: normalizedModel.model,
           modelTier: normalizedModel.modelTier,
           effort: input.effort,
-          routingAffinity: requiredCapabilities?.length
-            ? { capabilities: requiredCapabilities }
-            : undefined,
+          routingAffinity:
+            leadOnly || requiredCapabilities?.length
+              ? { leadOnly, capabilities: requiredCapabilities ?? [] }
+              : undefined,
         });
         return {
           success: true,
@@ -349,7 +355,9 @@ export async function taskActionHandler(
         if (claimingAgent && !isAgentEligibleForTask(claimingAgent, existingTask)) {
           return {
             success: false,
-            message: `Task "${taskId}" requires role "${existingTask.routingAffinity?.role ?? "(unspecified)"}"; yours is "${claimingAgent.role ?? "(unspecified)"}". Cannot claim.`,
+            message: existingTask.routingAffinity?.leadOnly
+              ? `Task "${taskId}" is Lead-only; you are not authorized to claim it.`
+              : `Task "${taskId}" requires role "${existingTask.routingAffinity?.role ?? "(unspecified)"}"; yours is "${claimingAgent.role ?? "(unspecified)"}". Cannot claim.`,
           };
         }
         // Atomic claim — only one agent can win this race

--- a/src/types.ts
+++ b/src/types.ts
@@ -633,6 +633,9 @@ export const AgentTaskSchema = z
     // behavior. Inherited from parentTaskId when not explicitly set (see
     // `createTaskExtended` in src/be/db.ts). See `isAgentEligibleForTask`.
     routingAffinity: RoutingAffinitySchema.optional(),
+    // Stored affinity that fails validation is quarantined rather than silently
+    // treated as an ordinary, claimable task. Internal read-path signal.
+    routingAffinityInvalid: z.boolean().optional(),
   })
   .openapi("AgentTask");
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -475,6 +475,8 @@ export const RoutingAffinitySchema = z
     role: z.string().max(100).optional(),
     harnessProvider: ProviderNameSchema.optional(),
     capabilities: z.array(z.string()).default([]),
+    /** Explicit authorization boundary for merge and other control-plane work. */
+    leadOnly: z.boolean().optional(),
   })
   .openapi("RoutingAffinity");
 export type RoutingAffinity = z.infer<typeof RoutingAffinitySchema>;
@@ -722,8 +724,10 @@ export const CreateTaskOptionsSchema = z.object({
    */
   bypassTrackerContextDedup: z.boolean().optional(),
   /**
-   * Routing-affinity snapshot gating pool eligibility (see
-   * `isAgentEligibleForTask`). Inherited from the parent (via `parentTaskId`)
+   * Routing-affinity snapshot gating task authorization (see
+   * `isAgentEligibleForTask`). `leadOnly: true` is an explicit, structured
+   * constraint: only an agent with `isLead` may be assigned, offered, claim,
+   * or recover this task. It is never inferred from task text. Inherited from the parent (via `parentTaskId`)
    * when not explicitly set — same treatment as `vcsRepo`/`contextKey`.
    */
   routingAffinity: RoutingAffinitySchema.optional(),
@@ -1296,6 +1300,8 @@ export const AgentLogEventTypeSchema = z.enum([
   "task_rejected",
   "task_claimed",
   "task_claim_rejected_affinity",
+  "task_authorization_rejected",
+  "task_recovery_authorization",
   "task_released",
   "channel_message",
   // Service registry events


### PR DESCRIPTION
## Summary
- add explicit routingAffinity.leadOnly task constraint and expose it on task creation tools
- enforce it for direct assignment, offers, pool claims, and crash recovery
- reroute legacy worker-owned privileged recovery to a Lead and emit audit events

## Tests
- bun run tsc:check
- bun run test:root -- src/tests/pool-affinity.test.ts src/tests/heartbeat.test.ts
- bun run lint
- bun run docs:openapi