### PR TITLE
fix(runner): refresh agent identity per task instead of caching it at boot

### DIFF
--- a/src/commands/identity-refresh.ts
+++ b/src/commands/identity-refresh.ts
@@ -1,0 +1,262 @@
+/**
+ * Worker-side per-task identity refresh (DB → runner cache → system prompt).
+ *
+ * The runner reads `GET /me` exactly ONCE, at boot, into module-local
+ * `agentSoulMd` / `agentIdentityMd` / `agentToolsMd` / `agentClaudeMd` / …
+ * variables. `buildSystemPrompt()` is re-invoked per task, but it re-reads
+ * those same boot-time values, so an identity change made after boot — Lead
+ * calling `update-profile`, or the agent editing `/workspace/TOOLS.md` and the
+ * PostToolUse hook syncing it — updates the DB (and the file on disk) while
+ * every subsequent task keeps receiving the boot-time copy in its injected
+ * system prompt. Only a container restart cleared it.
+ *
+ * This module is the identity counterpart of `src/utils/skills-refresh.ts`:
+ * the runner calls it once per task, it re-reads the profile, and reports
+ * which fields actually changed so the prompt is rebuilt with fresh content.
+ *
+ * Disk materialization is deliberately conservative. The runner writes the DB
+ * copy to `/workspace/*.md` at boot and records baseline hashes
+ * (`profile-sync.ts`) so session-end sync can tell "agent edited this file"
+ * from "file is still the DB copy". A refresh reuses those baselines:
+ *
+ *   - file still matches its baseline → safe to rewrite from DB, re-baseline
+ *   - file already equals the new DB content → nothing to write, re-baseline
+ *   - file diverges from both → the agent edited it in-session; leave the file
+ *     and the baseline untouched so session-end sync still pushes that edit
+ *
+ * The in-memory prompt fields always track the DB, which is the shared source
+ * of truth and the thing this module exists to un-stale.
+ *
+ * Boundary rules (enforced by CI): HTTP-only, no `src/be/db` import, and the
+ * API key is passed in by the caller (never read from `process.env` here).
+ */
+
+import {
+  contentSha256,
+  HEARTBEAT_MD_PATH,
+  IDENTITY_MD_PATH,
+  type IdentityBaselines,
+  readIdentityBaselines,
+  SOUL_MD_PATH,
+  TOOLS_MD_PATH,
+  WORKSPACE_CLAUDE_MD_PATH,
+  writeIdentityBaselines,
+} from "./profile-sync.ts";
+
+/** The identity-derived prompt inputs the runner caches at boot. */
+export interface IdentityProfileFields {
+  soulMd?: string;
+  identityMd?: string;
+  toolsMd?: string;
+  claudeMd?: string;
+  heartbeatMd?: string;
+  name?: string;
+  description?: string;
+}
+
+/** Fields that are materialized as a file in the workspace. */
+export const IDENTITY_FIELD_PATHS = {
+  soulMd: SOUL_MD_PATH,
+  identityMd: IDENTITY_MD_PATH,
+  toolsMd: TOOLS_MD_PATH,
+  heartbeatMd: HEARTBEAT_MD_PATH,
+  claudeMd: WORKSPACE_CLAUDE_MD_PATH,
+} as const;
+
+export type IdentityFileField = keyof typeof IDENTITY_FIELD_PATHS;
+export type IdentityField = keyof IdentityProfileFields;
+
+const IDENTITY_FIELDS: readonly IdentityField[] = [
+  "soulMd",
+  "identityMd",
+  "toolsMd",
+  "claudeMd",
+  "heartbeatMd",
+  "name",
+  "description",
+];
+
+function isFileField(field: IdentityField): field is IdentityFileField {
+  return field in IDENTITY_FIELD_PATHS;
+}
+
+/**
+ * Pure: which fields the server reports differently from the runner's cache.
+ *
+ * A field the server omits (`undefined`) is never a change — a slimmed or
+ * partial payload must not blank a prompt section that is currently populated.
+ */
+export function diffIdentityFields(
+  cached: IdentityProfileFields,
+  fetched: IdentityProfileFields,
+): IdentityField[] {
+  return IDENTITY_FIELDS.filter((field) => {
+    const next = fetched[field];
+    if (next === undefined) return false;
+    return next !== cached[field];
+  });
+}
+
+/** Injectable FS access so the write policy is testable without touching disk. */
+export interface IdentityFileIo {
+  read: (path: string) => Promise<string | undefined>;
+  write: (path: string, content: string) => Promise<void>;
+}
+
+const defaultFileIo: IdentityFileIo = {
+  read: async (path) => {
+    try {
+      const file = Bun.file(path);
+      if (!(await file.exists())) return undefined;
+      return await file.text();
+    } catch {
+      return undefined;
+    }
+  },
+  write: async (path, content) => {
+    await Bun.write(path, content);
+  },
+};
+
+export interface MaterializeResult {
+  /** Paths rewritten from the refreshed DB content. */
+  written: string[];
+  /** Paths left alone because the agent edited them during the session. */
+  skipped: string[];
+  /** Baselines to persist (input baselines plus any re-baselined field). */
+  baselines: IdentityBaselines;
+}
+
+/**
+ * Apply refreshed identity content to the workspace files, honoring the
+ * session baselines so an in-session agent edit is never clobbered.
+ */
+export async function materializeRefreshedIdentityFiles(
+  changedFields: readonly IdentityField[],
+  fetched: IdentityProfileFields,
+  baselines: IdentityBaselines | null,
+  io: IdentityFileIo = defaultFileIo,
+): Promise<MaterializeResult> {
+  const nextBaselines: IdentityBaselines = { ...(baselines ?? {}) };
+  const written: string[] = [];
+  const skipped: string[] = [];
+
+  for (const field of changedFields) {
+    if (!isFileField(field)) continue;
+    const content = fetched[field];
+    if (!content) continue;
+
+    const path = IDENTITY_FIELD_PATHS[field];
+    const onDisk = await io.read(path);
+
+    if (onDisk === undefined) {
+      // Nothing to clobber — materialize it.
+      await io.write(path, content);
+      nextBaselines[field] = contentSha256(content);
+      written.push(path);
+      continue;
+    }
+
+    if (onDisk === content) {
+      // Already current (e.g. `update-profile` wrote DB and disk together).
+      nextBaselines[field] = contentSha256(content);
+      continue;
+    }
+
+    if (baselines?.[field] && contentSha256(onDisk) === baselines[field]) {
+      // Untouched since boot — safe to replace with the newer DB copy.
+      await io.write(path, content);
+      nextBaselines[field] = contentSha256(content);
+      written.push(path);
+      continue;
+    }
+
+    // Diverges from both the baseline and the DB: an in-session agent edit.
+    // Leave the file AND its baseline so session-end sync still pushes it.
+    skipped.push(path);
+  }
+
+  return { written, skipped, baselines: nextBaselines };
+}
+
+export interface IdentityRefreshContext {
+  apiUrl: string;
+  apiKey: string;
+  agentId: string;
+  role: string;
+  /** Injectable for tests. */
+  fetchImpl?: typeof fetch;
+  /** Injectable for tests. */
+  io?: IdentityFileIo;
+  /** Injectable for tests. */
+  readBaselines?: typeof readIdentityBaselines;
+  /** Injectable for tests. */
+  writeBaselines?: typeof writeIdentityBaselines;
+}
+
+export interface IdentityRefreshResult {
+  changed: boolean;
+  /** Cached fields merged with whatever actually changed. */
+  fields: IdentityProfileFields;
+  changedFields: IdentityField[];
+}
+
+/**
+ * Re-read the agent profile and report the fields that drifted from the
+ * runner's cache. Never throws: a flaky API returns `changed: false` and the
+ * caller keeps its current prompt rather than churning it.
+ */
+export async function refreshIdentityIfChanged(
+  ctx: IdentityRefreshContext,
+  cached: IdentityProfileFields,
+): Promise<IdentityRefreshResult> {
+  const unchanged: IdentityRefreshResult = { changed: false, fields: cached, changedFields: [] };
+  const doFetch = ctx.fetchImpl ?? fetch;
+
+  let fetched: IdentityProfileFields;
+  try {
+    const headers: Record<string, string> = { "X-Agent-ID": ctx.agentId };
+    if (ctx.apiKey) headers.Authorization = `Bearer ${ctx.apiKey}`;
+    const resp = await doFetch(`${ctx.apiUrl}/me`, { headers });
+    if (!resp.ok) return unchanged;
+    fetched = (await resp.json()) as IdentityProfileFields;
+  } catch {
+    return unchanged;
+  }
+
+  const changedFields = diffIdentityFields(cached, fetched);
+  if (changedFields.length === 0) return unchanged;
+
+  const fields: IdentityProfileFields = { ...cached };
+  for (const field of changedFields) {
+    fields[field] = fetched[field];
+  }
+
+  try {
+    const baselines = (await ctx.readBaselines?.()) ?? (await readIdentityBaselines());
+    const result = await materializeRefreshedIdentityFiles(
+      changedFields,
+      fetched,
+      baselines,
+      ctx.io,
+    );
+    if (result.written.length > 0 || result.skipped.length > 0) {
+      if (result.written.length > 0) {
+        console.log(`[${ctx.role}] Identity files refreshed from DB: ${result.written.join(", ")}`);
+      }
+      if (result.skipped.length > 0) {
+        console.warn(
+          `[${ctx.role}] Identity files changed in DB but edited locally — left as-is: ${result.skipped.join(", ")}`,
+        );
+      }
+    }
+    const persist = ctx.writeBaselines ?? writeIdentityBaselines;
+    await persist(result.baselines);
+  } catch (err) {
+    // Non-fatal: the prompt still gets the fresh content even if the files or
+    // the baseline file could not be updated.
+    console.warn(`[${ctx.role}] Identity file refresh failed: ${(err as Error).message}`);
+  }
+
+  return { changed: true, fields, changedFields };
+}

--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -71,6 +71,7 @@ import {
   EX_CONFIG,
   retryBootStep,
 } from "./credential-wait.ts";
+import { refreshIdentityIfChanged } from "./identity-refresh.ts";
 import {
   contentSha256,
   prependProfileSyncRejectionBanner,
@@ -6024,6 +6025,37 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
               `[${role}] Skills changed — refreshing system prompt (${agentSkillsSummary.length} skills)`,
             );
           }
+        }
+
+        // Per-task identity hot-reload. `GET /me` is otherwise read once at
+        // boot, so a SOUL/IDENTITY/TOOLS/CLAUDE.md change landing after boot
+        // (Lead via `update-profile`, or the agent's own file edit synced by
+        // the PostToolUse hook) never reached the injected system prompt until
+        // the container restarted — the DB and the workspace file were fresh
+        // while every task kept getting the boot-time copy.
+        const identityResult = await refreshIdentityIfChanged(
+          { apiUrl, apiKey, agentId, role },
+          {
+            soulMd: agentSoulMd,
+            identityMd: agentIdentityMd,
+            toolsMd: agentToolsMd,
+            claudeMd: agentClaudeMd,
+            heartbeatMd: agentHeartbeatMd,
+            name: agentProfileName,
+            description: agentDescription,
+          },
+        );
+        if (identityResult.changed) {
+          agentSoulMd = identityResult.fields.soulMd;
+          agentIdentityMd = identityResult.fields.identityMd;
+          agentToolsMd = identityResult.fields.toolsMd;
+          agentClaudeMd = identityResult.fields.claudeMd;
+          agentHeartbeatMd = identityResult.fields.heartbeatMd;
+          agentProfileName = identityResult.fields.name;
+          agentDescription = identityResult.fields.description;
+          console.log(
+            `[${role}] Identity changed — refreshing system prompt (${identityResult.changedFields.join(", ")})`,
+          );
         }
 
         // Rebuild system prompt with per-task repo context

--- a/src/tests/identity-refresh.test.ts
+++ b/src/tests/identity-refresh.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test } from "bun:test";
+import {
+  diffIdentityFields,
+  IDENTITY_FIELD_PATHS,
+  type IdentityFileIo,
+  materializeRefreshedIdentityFiles,
+  refreshIdentityIfChanged,
+} from "../commands/identity-refresh";
+import { contentSha256, type IdentityBaselines } from "../commands/profile-sync";
+
+const TOOLS_PATH = IDENTITY_FIELD_PATHS.toolsMd;
+
+/** In-memory FS double that records every write. */
+function makeIo(initial: Record<string, string> = {}) {
+  const files: Record<string, string> = { ...initial };
+  const writes: string[] = [];
+  const io: IdentityFileIo = {
+    read: async (path) => files[path],
+    write: async (path, content) => {
+      files[path] = content;
+      writes.push(path);
+    },
+  };
+  return { io, files, writes };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const CTX = { apiUrl: "http://api.test", apiKey: "k", agentId: "agent-1", role: "worker" };
+
+describe("diffIdentityFields", () => {
+  test("reports only the fields whose server value differs", () => {
+    expect(
+      diffIdentityFields(
+        { toolsMd: "old", soulMd: "same", name: "Coder" },
+        { toolsMd: "new", soulMd: "same", name: "Coder" },
+      ),
+    ).toEqual(["toolsMd"]);
+  });
+
+  test("a field the server omits is never a change (partial payloads must not blank the prompt)", () => {
+    expect(diffIdentityFields({ toolsMd: "old", soulMd: "soul" }, { toolsMd: "old" })).toEqual([]);
+  });
+
+  test("a field appearing for the first time counts as a change", () => {
+    expect(diffIdentityFields({}, { heartbeatMd: "beat" })).toEqual(["heartbeatMd"]);
+  });
+
+  test("identical profiles produce no changes", () => {
+    const same = { soulMd: "s", identityMd: "i", toolsMd: "t", claudeMd: "c", name: "n" };
+    expect(diffIdentityFields(same, { ...same })).toEqual([]);
+  });
+});
+
+describe("materializeRefreshedIdentityFiles", () => {
+  test("rewrites a file that still matches its session baseline", async () => {
+    const { io, files, writes } = makeIo({ [TOOLS_PATH]: "boot" });
+    const baselines: IdentityBaselines = { toolsMd: contentSha256("boot") };
+
+    const result = await materializeRefreshedIdentityFiles(
+      ["toolsMd"],
+      { toolsMd: "fresh" },
+      baselines,
+      io,
+    );
+
+    expect(writes).toEqual([TOOLS_PATH]);
+    expect(files[TOOLS_PATH]).toBe("fresh");
+    expect(result.written).toEqual([TOOLS_PATH]);
+    expect(result.baselines.toolsMd).toBe(contentSha256("fresh"));
+  });
+
+  test("leaves an in-session agent edit alone and keeps its baseline for session-end sync", async () => {
+    const { io, files, writes } = makeIo({ [TOOLS_PATH]: "agent edit" });
+    const bootHash = contentSha256("boot");
+
+    const result = await materializeRefreshedIdentityFiles(
+      ["toolsMd"],
+      { toolsMd: "fresh" },
+      { toolsMd: bootHash },
+      io,
+    );
+
+    expect(writes).toEqual([]);
+    expect(files[TOOLS_PATH]).toBe("agent edit");
+    expect(result.skipped).toEqual([TOOLS_PATH]);
+    expect(result.baselines.toolsMd).toBe(bootHash);
+  });
+
+  test("re-baselines without writing when the file already holds the new content", async () => {
+    const { io, writes } = makeIo({ [TOOLS_PATH]: "fresh" });
+
+    const result = await materializeRefreshedIdentityFiles(
+      ["toolsMd"],
+      { toolsMd: "fresh" },
+      { toolsMd: contentSha256("boot") },
+      io,
+    );
+
+    expect(writes).toEqual([]);
+    expect(result.written).toEqual([]);
+    expect(result.skipped).toEqual([]);
+    expect(result.baselines.toolsMd).toBe(contentSha256("fresh"));
+  });
+
+  test("materializes a missing file", async () => {
+    const { io, files } = makeIo();
+
+    const result = await materializeRefreshedIdentityFiles(
+      ["toolsMd"],
+      { toolsMd: "fresh" },
+      null,
+      io,
+    );
+
+    expect(files[TOOLS_PATH]).toBe("fresh");
+    expect(result.written).toEqual([TOOLS_PATH]);
+  });
+
+  test("without a baseline, a differing file is treated as a local edit and preserved", async () => {
+    const { io, files, writes } = makeIo({ [TOOLS_PATH]: "local" });
+
+    const result = await materializeRefreshedIdentityFiles(
+      ["toolsMd"],
+      { toolsMd: "fresh" },
+      null,
+      io,
+    );
+
+    expect(writes).toEqual([]);
+    expect(files[TOOLS_PATH]).toBe("local");
+    expect(result.skipped).toEqual([TOOLS_PATH]);
+  });
+
+  test("ignores non-file fields (name/description have no workspace path)", async () => {
+    const { io, writes } = makeIo();
+
+    const result = await materializeRefreshedIdentityFiles(
+      ["name", "description"],
+      { name: "Coder", description: "ships code" },
+      null,
+      io,
+    );
+
+    expect(writes).toEqual([]);
+    expect(result.written).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  test("preserves baselines for fields it did not touch", async () => {
+    const { io } = makeIo({ [TOOLS_PATH]: "boot" });
+    const soulHash = contentSha256("soul");
+
+    const result = await materializeRefreshedIdentityFiles(
+      ["toolsMd"],
+      { toolsMd: "fresh" },
+      { toolsMd: contentSha256("boot"), soulMd: soulHash },
+      io,
+    );
+
+    expect(result.baselines.soulMd).toBe(soulHash);
+  });
+});
+
+describe("refreshIdentityIfChanged", () => {
+  test("returns the fresh value when the DB moved on after boot", async () => {
+    const { io, files } = makeIo({ [TOOLS_PATH]: "boot tools" });
+    const persisted: IdentityBaselines[] = [];
+
+    const result = await refreshIdentityIfChanged(
+      {
+        ...CTX,
+        fetchImpl: async () => jsonResponse({ toolsMd: "fresh tools", soulMd: "soul" }),
+        io,
+        readBaselines: async () => ({ toolsMd: contentSha256("boot tools") }),
+        writeBaselines: async (b) => {
+          persisted.push(b);
+        },
+      },
+      { toolsMd: "boot tools", soulMd: "soul" },
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.changedFields).toEqual(["toolsMd"]);
+    expect(result.fields.toolsMd).toBe("fresh tools");
+    expect(result.fields.soulMd).toBe("soul");
+    expect(files[TOOLS_PATH]).toBe("fresh tools");
+    expect(persisted[0]?.toolsMd).toBe(contentSha256("fresh tools"));
+  });
+
+  test("reports no change when the profile matches the cache", async () => {
+    const cached = { toolsMd: "same", soulMd: "same" };
+    const result = await refreshIdentityIfChanged(
+      { ...CTX, fetchImpl: async () => jsonResponse(cached) },
+      cached,
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.fields).toBe(cached);
+    expect(result.changedFields).toEqual([]);
+  });
+
+  test("a non-2xx response leaves the cached prompt untouched", async () => {
+    const cached = { toolsMd: "cached" };
+    const result = await refreshIdentityIfChanged(
+      { ...CTX, fetchImpl: async () => new Response("nope", { status: 503 }) },
+      cached,
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.fields).toBe(cached);
+  });
+
+  test("a thrown fetch never propagates", async () => {
+    const cached = { toolsMd: "cached" };
+    const result = await refreshIdentityIfChanged(
+      {
+        ...CTX,
+        fetchImpl: async () => {
+          throw new Error("network down");
+        },
+      },
+      cached,
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.fields.toolsMd).toBe("cached");
+  });
+
+  test("still surfaces the fresh prompt content when the file write fails", async () => {
+    const result = await refreshIdentityIfChanged(
+      {
+        ...CTX,
+        fetchImpl: async () => jsonResponse({ toolsMd: "fresh" }),
+        io: {
+          read: async () => undefined,
+          write: async () => {
+            throw new Error("read-only fs");
+          },
+        },
+        readBaselines: async () => null,
+        writeBaselines: async () => {},
+      },
+      { toolsMd: "boot" },
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.fields.toolsMd).toBe("fresh");
+  });
+
+  test("sends the agent id and bearer on the profile read", async () => {
+    let seen: Record<string, string> = {};
+    await refreshIdentityIfChanged(
+      {
+        ...CTX,
+        fetchImpl: async (_url, init) => {
+          seen = (init?.headers ?? {}) as Record<string, string>;
+          return jsonResponse({ toolsMd: "boot" });
+        },
+      },
+      { toolsMd: "boot" },
+    );
+
+    expect(seen["X-Agent-ID"]).toBe("agent-1");
+    expect(seen.Authorization).toBe("Bearer k");
+  });
+});


### PR DESCRIPTION
Fixes #1278.

## Problem

`src/commands/runner.ts` reads `GET /me` **exactly once, at boot**, into the module-local `agentSoulMd` / `agentIdentityMd` / `agentToolsMd` / `agentClaudeMd` / `agentHeartbeatMd` / `agentProfileName` / `agentDescription` variables that `buildSystemPrompt()` closes over.

The prompt *is* reassembled per task — but from those boot-time values. So an identity change landing after boot updates the DB row **and** the workspace file while every subsequent task keeps receiving the boot-time copy in its injected system prompt:

- Lead calls `update-profile` → `src/tools/update-profile.ts` writes the DB and `/workspace/TOOLS.md`.
- The agent edits `/workspace/TOOLS.md` → the `PostToolUse` hook in `src/hooks/hook.ts` syncs it to the DB with `changeSource: "self_edit"`.

Either way both sources of truth are current and the prompt is not. Only a container restart cleared it. Measured on a self-hosted swarm on 2026-08-30: DB `toolsMd` 19 893 chars and `/workspace/TOOLS.md` 19 982 bytes both carried the 2026-08-29 edit, while the running agent's injected `## Your Tools & Capabilities` block still carried the pre-edit text. Full numbers in the issue.

Skills already have a per-task hot-reload (`refreshSkillsIfChanged`, `src/utils/skills-refresh.ts`). Identity had no equivalent.

## Change

`src/commands/identity-refresh.ts` — the identity counterpart of `refreshSkillsIfChanged`, called once per task in the polling loop right before the prompt is rebuilt:

- re-reads `/me`, diffs against the runner's cache, and reports only the fields that actually drifted, so the prompt is rebuilt only on a real change;
- a field the server omits is never treated as a change — a partial payload must not blank a populated prompt section;
- never throws: a non-2xx or a thrown fetch returns `changed: false`, so a flaky API cannot churn the prompt (same posture as the skills refresh).

Disk materialization reuses the session baselines already recorded by `src/commands/profile-sync.ts`, so an in-session agent edit is never clobbered:

| On-disk state | Action |
|---|---|
| still matches its boot baseline | rewrite from DB, re-baseline |
| already equals the new DB content | re-baseline only, no write |
| diverges from both (in-session agent edit) | leave the file **and** its baseline, so session-end sync still pushes the agent's edit |

The in-memory prompt fields always track the DB, which is the shared source of truth and the thing this is meant to un-stale.

## Cost / open question

`/me` returns the full profile, so this is one full-profile read per task. A cheap signature endpoint (like `GET /api/agents/:id/skills/signature`) would avoid that, but adding a route felt like a maintainer call — happy to follow up with one if you'd prefer that shape.

## Tests

`src/tests/identity-refresh.test.ts` — 17 tests covering the diff semantics (including the omitted-field case), all four disk-materialization branches, baseline preservation for untouched fields, the no-change / non-2xx / thrown-fetch paths, a file-write failure still surfacing fresh prompt content, and the auth headers on the profile read.

## Verification

Run from the repo root on this branch:

- `bun run lint` — clean
- `bun run tsc:check` — clean
- `bun run check:dep-graph` — 0 errors (15 pre-existing warnings, unchanged)
- `bash scripts/check-db-boundary.sh` — passed
- `bash scripts/check-api-key-boundary.sh` — passed
- `bash scripts/check-audit-columns.sh` — passed
- `bun run test:root -- src/tests/identity-refresh.test.ts` — 17 pass / 0 fail
- `bun run test:root` (full suite) — the failing-test set on this branch is **byte-identical** to the failing set on the base commit (`e8b4878e`) in the same container: 122 failures, all in the scripts-runtime sandbox / app-sync suites, which time out under this environment's process limits. `diff` of the two sorted `(fail)` lists is empty. Zero failures introduced by this change; CI is the authority on those suites.
