### PR TITLE
fix(tasks): stop reporting lastUpdatedAt as a sibling's start time

### DIFF
--- a/src/tasks/sibling-awareness.ts
+++ b/src/tasks/sibling-awareness.ts
@@ -58,6 +58,7 @@ async function toSiblingTaskInfo(task: AgentTask): Promise<SiblingTaskInfo> {
     agentName: agent?.name ?? null,
     description: stripSiblingBlock(task.task),
     updatedAt: task.lastUpdatedAt,
+    createdAt: task.createdAt,
   };
 }
 

--- a/src/tasks/sibling-block.ts
+++ b/src/tasks/sibling-block.ts
@@ -18,9 +18,15 @@ export type SiblingTaskInfo = {
   agentId: string | null;
   agentName: string | null;
   description: string;
-  // Most recent change timestamp (ISO string). Used for relative-time render
-  // and for picking the "best" sibling to wire as parent.
+  // Most recent change timestamp (ISO string). Used for the "last active"
+  // relative-time render and for picking the "best" sibling to wire as parent.
+  // NOTE: this ticks on every progress event, so it is NOT a proxy for when
+  // the sibling (or the user input behind it) started.
   updatedAt: string;
+  // Creation timestamp (ISO string) — when the user input behind this sibling
+  // actually arrived. Optional so existing callers keep compiling; when it is
+  // absent we omit the "started" clause rather than guess from `updatedAt`.
+  createdAt?: string;
 };
 
 const DESCRIPTION_TRUNCATE = 200;
@@ -100,8 +106,15 @@ export function renderSiblingBlock(
       : s.agentId
         ? `agent:${s.agentId}`
         : "agent:unassigned";
-    const rel = formatRelativeTime(s.updatedAt, now);
-    lines.push(`- [${s.status}] task:${s.id} — ${agentLabel} — started ${rel} ago`);
+    // `updatedAt` advances on every progress event, so rendering it as
+    // "started" made a minutes-old sibling look seconds-old and invited the
+    // reader to conclude two unrelated user inputs were a double-submit.
+    // Report each timestamp under its own name instead.
+    const lastActive = `last active ${formatRelativeTime(s.updatedAt, now)} ago`;
+    const timing = s.createdAt
+      ? `started ${formatRelativeTime(s.createdAt, now)} ago, ${lastActive}`
+      : lastActive;
+    lines.push(`- [${s.status}] task:${s.id} — ${agentLabel} — ${timing}`);
     lines.push(`  "${truncateForBlock(s.description)}"`);
   }
   lines.push("</sibling_tasks_in_progress>");

--- a/src/tests/sibling-block.test.ts
+++ b/src/tests/sibling-block.test.ts
@@ -19,6 +19,7 @@ function sibling(overrides: Partial<SiblingTaskInfo> = {}): SiblingTaskInfo {
     agentName: "Picateclas",
     description: "Do the thing",
     updatedAt: new Date(NOW - 60_000).toISOString(),
+    createdAt: new Date(NOW - 60_000).toISOString(),
     ...overrides,
   };
 }
@@ -100,7 +101,34 @@ describe("renderSiblingBlock", () => {
     );
     expect(out).toContain("[in_progress] task:id-1");
     expect(out).toContain("[pending] task:id-2");
-    expect(out).toContain("started 1h ago");
+    expect(out).toContain("last active 1h ago");
+  });
+
+  test("reports start time from createdAt, not from the progress-bumped updatedAt", () => {
+    // Regression: a sibling created 60s ago that emitted a progress event 1s
+    // ago used to render as "started 1s ago", making two independent user
+    // inputs look like a double-submit of the same one.
+    const out = renderSiblingBlock(
+      "task:slack:C1:1",
+      [
+        sibling({
+          createdAt: new Date(NOW - 60_000).toISOString(),
+          updatedAt: new Date(NOW - 1_000).toISOString(),
+        }),
+      ],
+      NOW,
+    );
+    expect(out).toContain("started 1m ago, last active 1s ago");
+    expect(out).not.toContain("started 1s ago");
+  });
+
+  test("omits the started clause rather than guessing when createdAt is absent", () => {
+    const { createdAt: _omitted, ...withoutCreatedAt } = sibling({
+      updatedAt: new Date(NOW - 1_000).toISOString(),
+    });
+    const out = renderSiblingBlock("task:slack:C1:1", [withoutCreatedAt], NOW);
+    expect(out).toContain("last active 1s ago");
+    expect(out).not.toContain("started");
   });
 
   test("falls back to agent:unassigned when no agent info", () => {


### PR DESCRIPTION
Fixes #1280.

## Problem

`renderSiblingBlock()` rendered each sibling's `lastUpdatedAt` under the label `started … ago`. `lastUpdatedAt` is bumped by every `task_progress` event, so a sibling that started a minute ago renders as `started 1s ago` the moment it emits any progress.

The block's preamble frames these entries as *user input that arrived while other work was in flight*, so a reader takes the rendered age to mean **how long ago the user submitted that input**.

## Observed impact (production, 2026-08-30)

Two continuation tasks in `slack/C0BQM3Z4KT5`, created **60.1 s** apart (`15:42:18.123Z` and `15:43:18.223Z`) from two *different* parent questions. The first emitted a progress event 1.4 s before the second was created, so the block injected into the second read:

```
- [in_progress] task:09498c2d-… — agent:Lead — started 1s ago
```

The reading agent concluded that two opposing answers had arrived one second apart, inferred a double-submit bug that does not exist, paused, and spent a human round-trip re-asking an already-answered question. Full evidence in #1280.

## Change

Carry `createdAt` through `SiblingTaskInfo` and report each timestamp under its own name:

```
started <createdAt> ago, last active <updatedAt> ago
```

Both are useful to a coordinating agent — when the user spoke, and whether the sibling is still alive — and neither is inferred from the other. `createdAt` is optional; when absent the `started` clause is omitted rather than falling back to the misleading value, so no caller is forced to change.

## Tests

`src/tests/sibling-block.test.ts` — 32 pass / 0 fail. Two added regression tests:

- a sibling created 60 s ago that emitted progress 1 s ago renders `started 1m ago, last active 1s ago` and **not** `started 1s ago`;
- with `createdAt` absent, the `started` clause is omitted rather than guessed.

Also run locally: `bun run lint`, `bun run tsc:check`, `check-db-boundary.sh`, `check-api-key-boundary.sh`, `check-test-spawn-sync.sh`, `check:dep-graph` — all clean. No dependency or lockfile changes.
