### PR TITLE
test: unpin the docs page count and wait for slow src/http.ts boots

### DIFF
--- a/src/tests/docs-index-footprint.test.js
+++ b/src/tests/docs-index-footprint.test.js
@@ -107,13 +107,12 @@ describe("docs API index footprint", () => {
     expect(new Set(generatedKeys)).toEqual(new Set(operationKeys));
   });
 
-  test("keeps retired routes out of the 135-page sitemap source inventory", async () => {
+  test("keeps retired routes out of the sitemap source inventory", async () => {
     const urls = contentRoutes().map((route) => `${baseUrl}${route}`);
     const sitemapSource = await Bun.file(resolve(repoRoot, "docs-site/app/sitemap.ts")).text();
 
     expect(sitemapSource).toContain("source.getPages().map((page) => ({");
     expect(sitemapSource).toMatch(/url:\s*`\$\{baseUrl\}\$\{page\.url\}`/);
-    expect(urls).toHaveLength(135);
     expect(new Set(urls).size).toBe(urls.length);
     for (const route of retiredRoutes) {
       expect(urls).not.toContain(`${baseUrl}${route}`);

--- a/src/tests/events-http.test.ts
+++ b/src/tests/events-http.test.ts
@@ -10,21 +10,34 @@ const TEST_API_KEY = "test-events-http-key";
 
 let serverProc: Subprocess;
 
-async function waitForEventsApi(timeoutMs = 10_000): Promise<void> {
+/**
+ * Poll the child until the authenticated events route answers.
+ *
+ * A refused connection means the child is still booting: keep waiting. The
+ * ceiling matches waitForServer() in test-net.ts because a boot under
+ * --parallel load on a shared runner takes far longer than the ~1 s it takes
+ * idle, and restarting a slow child only resets its progress.
+ *
+ * Any HTTP response that is not a 200 events list comes from another server:
+ * a parallel test claimed the released getFreePort() socket first and the
+ * child's own listen failed with EADDRINUSE. Report "foreign" so the caller
+ * retries on a fresh port right away.
+ */
+async function waitForEventsApi(timeoutMs = 60_000): Promise<"ready" | "foreign"> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
       const response = await fetch(`${BASE}/api/events`, {
         headers: { Authorization: `Bearer ${TEST_API_KEY}` },
       });
-      const body = (await response.json()) as { events?: unknown };
-      if (response.status === 200 && Array.isArray(body.events)) return;
+      const body = (await response.json().catch(() => null)) as { events?: unknown } | null;
+      return response.status === 200 && Array.isArray(body?.events) ? "ready" : "foreign";
     } catch {
-      // The child may still be booting, or another parallel test may own the port.
+      // Connection refused: the child has not bound the port yet.
     }
     await Bun.sleep(50);
   }
-  throw new Error(`Events API did not become ready on ${BASE}`);
+  throw new Error(`Events API did not become ready on ${BASE} within ${timeoutMs}ms`);
 }
 
 async function cleanupTestDb(): Promise<void> {
@@ -61,8 +74,10 @@ async function api(
 const get = (p: string) => api("GET", p);
 const post = (p: string, body?: unknown) => api("POST", p, { body });
 
+const PORT_CLAIM_ATTEMPTS = 3;
+
 beforeAll(async () => {
-  for (let attempt = 1; attempt <= 3; attempt++) {
+  for (let attempt = 1; attempt <= PORT_CLAIM_ATTEMPTS; attempt++) {
     TEST_PORT = await getFreePort();
     BASE = `http://localhost:${TEST_PORT}`;
     await cleanupTestDb();
@@ -83,18 +98,16 @@ beforeAll(async () => {
       stderr: "ignore",
     });
 
-    try {
-      // A generic /health response can come from another parallel test that
-      // claimed the released getFreePort() socket first. Verify this child
-      // serves the authenticated events route before the suite sends requests.
-      await waitForEventsApi();
-      return;
-    } catch (error) {
-      serverProc.kill();
-      await serverProc.exited.catch(() => {});
-      if (attempt === 3) throw error;
-    }
+    // A slow boot throws here and fails the suite: afterAll still kills the child.
+    if ((await waitForEventsApi()) === "ready") return;
+
+    // Another server owns this port. Drop the child and try a fresh port.
+    serverProc.kill();
+    await serverProc.exited.catch(() => {});
   }
+  throw new Error(
+    `another server claimed the events-http port on ${PORT_CLAIM_ATTEMPTS} consecutive attempts`,
+  );
 }, SERVER_BOOT_HOOK_TIMEOUT_MS);
 
 afterAll(async () => {


### PR DESCRIPTION
## Why

`main` is red on `Run Tests (1/2)` for two independent reasons ([run 33378621614](https://github.com/desplega-ai/agent-swarm/actions/runs/33378621614/job/99445711380), and every CI run on `main` since):

1. `src/tests/docs-index-footprint.test.js` pinned the docs content tree to exactly 135 pages. #1283 added `releases/2026-08-31.mdx`, so it is 136. Release notes land weekly, so a pinned count breaks `main` every week.
2. `src/tests/events-http.test.ts` gave each spawned `src/http.ts` child 10s to boot, three times over. Under `--parallel=4` on a shared runner a boot often exceeds 10s (the last passing timings snapshot shows ~20s for this file). The shard rebalance after #1281 put `http-api-integration` in the same shard, and all three attempts timed out on every run since (3/3 on `main`, 2/2 on this branch before the second commit). Restarting a slow child does not help: it only resets the boot.

## What

- Drop the `toHaveLength(135)` assertion and the number in the test title. The checks the test exists for stay: `sitemap.ts` derives URLs from `source.getPages()`, routes are unique, retired routes are absent, their parents are present.
- `events-http`: wait up to 60s for a refused connection, the same ceiling every other spawned-server test uses via `waitForServer()`. Keep the retry loop for the one case it exists for: an HTTP answer that is not our events list means another parallel test claimed the released `getFreePort()` socket, so drop the child and try a fresh port immediately. Worst case stays inside the 90s hook timeout.

## Verification

```
bun test src/tests/docs-index-footprint.test.js   # 4 pass
bun test src/tests/events-http.test.ts            # 19 pass
bun test --parallel=4 --timeout 10000 src/tests/events-http.test.ts src/tests/http-api-integration.test.ts \
  src/tests/docs-index-footprint.test.js src/tests/memory-rate-endpoint.test.ts src/tests/kv-page-proxy.test.ts   # 203 pass
bun run tsc:check
```