### PR TITLE
chore: bump agent-fs to 0.13.3

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -219,7 +219,7 @@ COPY --from=prek /prek /usr/local/bin/prek
 ARG SKILLS_CLI_VERSION
 # agent-fs version pins BOTH the skill source tag (here) and the CLI in
 # /opt/global-deps (below) — bump the ARG to update both in lockstep.
-ARG AGENT_FS_VERSION=0.13.2
+ARG AGENT_FS_VERSION=0.13.3
 RUN npx -y skills@${SKILLS_CLI_VERSION} add desplega-ai/agent-fs@v${AGENT_FS_VERSION} --skill agent-fs -g -a claude-code -y \
     && test -e /home/worker/.claude/skills/agent-fs/SKILL.md \
     && rm -rf /home/worker/.npm

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -218,7 +218,8 @@ COPY --from=prek /prek /usr/local/bin/prek
 # (its CLI isn't present in slim).
 ARG SKILLS_CLI_VERSION
 # agent-fs version pins BOTH the skill source tag (here) and the CLI in
-# /opt/global-deps (below) — bump the ARG to update both in lockstep.
+# /opt/global-deps (below). Bump with `bun run bump:agent-fs` so the chart,
+# Compose, and docs pins move in lockstep with this ARG.
 ARG AGENT_FS_VERSION=0.13.3
 RUN npx -y skills@${SKILLS_CLI_VERSION} add desplega-ai/agent-fs@v${AGENT_FS_VERSION} --skill agent-fs -g -a claude-code -y \
     && test -e /home/worker/.claude/skills/agent-fs/SKILL.md \

--- a/charts/agent-swarm/README.md
+++ b/charts/agent-swarm/README.md
@@ -78,7 +78,7 @@ Deploys the [agent-fs](https://github.com/desplega-ai/agent-fs) HTTP service alo
 agentFs:
   enabled: true
   image:
-    tag: 0.13.2
+    tag: 0.13.3
   bucket: my-agent-fs-bucket
   # Optional. When blank, the API boot seeder registers a service user with
   # agent-fs and stores the generated bootstrap key in encrypted swarm_config.

--- a/charts/agent-swarm/values.yaml
+++ b/charts/agent-swarm/values.yaml
@@ -227,7 +227,7 @@ agentFs:
     registry: ghcr.io
     repository: desplega-ai/agent-fs
     pullPolicy: IfNotPresent
-    tag: 0.13.2
+    tag: 0.13.3
   port: 7433
   # -- Optional API-owned bootstrap key for agent-fs. When blank, the swarm API
   # boot seeder registers a service user and persists its generated key in

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -47,7 +47,7 @@ services:
       "
 
   agent-fs:
-    image: ghcr.io/desplega-ai/agent-fs:0.13.2
+    image: ghcr.io/desplega-ai/agent-fs:0.13.3
     platform: linux/amd64
     pull_policy: always
     depends_on:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -45,7 +45,7 @@ services:
 
   agent-fs:
     container_name: swarm-agent-fs
-    image: ghcr.io/desplega-ai/agent-fs:0.13.2
+    image: ghcr.io/desplega-ai/agent-fs:0.13.3
     platform: linux/amd64
     depends_on:
       minio-init:

--- a/docker-compose.scripts-only.yml
+++ b/docker-compose.scripts-only.yml
@@ -45,7 +45,7 @@ services:
 
   agent-fs:
     container_name: so-agent-fs
-    image: ghcr.io/desplega-ai/agent-fs:0.13.2
+    image: ghcr.io/desplega-ai/agent-fs:0.13.3
     platform: linux/amd64
     depends_on:
       minio-init:

--- a/docs-site/content/docs/(documentation)/guides/agent-fs-co-deployment.mdx
+++ b/docs-site/content/docs/(documentation)/guides/agent-fs-co-deployment.mdx
@@ -75,7 +75,7 @@ Enable the co-deployed service with `agentFs.enabled=true`:
 agentFs:
   enabled: true
   image:
-    tag: 0.13.2
+    tag: 0.13.3
   bucket: agentfs
   s3:
     existingSecret: agent-fs-s3

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "prepare-release": "bun scripts/prepare-release.ts",
     "refresh:vendored-openapi": "bun scripts/refresh-vendored-openapi.ts",
     "sync-chart-version": "bun scripts/sync-chart-version.ts",
+    "bump:agent-fs": "bun scripts/bump-agent-fs.ts",
     "check-chart-version": "bun scripts/sync-chart-version.ts --check-if-package-version-changed",
     "cli": "bun src/cli.tsx",
     "hook": "bun src/hooks/hook.ts",

--- a/scripts/agent-fs-version-utils.ts
+++ b/scripts/agent-fs-version-utils.ts
@@ -1,0 +1,131 @@
+/**
+ * Shared helpers for the agent-fs version pins this repo carries.
+ *
+ * Used by:
+ *   - scripts/bump-agent-fs.ts       rewrites every pin to a target version
+ *   - scripts/sync-chart-version.ts  CI gate: chart tag must equal the latest GHCR tag
+ */
+
+export const AGENT_FS_REPO = "desplega-ai/agent-fs";
+export const AGENT_FS_IMAGE = "desplega-ai/agent-fs";
+export const AGENT_FS_NPM_PACKAGE = "@desplega.ai/agent-fs";
+/** Path inside the agent-fs repo that `npx skills add ... --skill agent-fs` resolves. */
+export const AGENT_FS_SKILL_PATH = "skills/agent-fs/SKILL.md";
+
+const GHCR_TOKEN_URL = `https://ghcr.io/token?scope=${encodeURIComponent(`repository:${AGENT_FS_IMAGE}:pull`)}&service=ghcr.io`;
+const GHCR_TAGS_URL = `https://ghcr.io/v2/${AGENT_FS_IMAGE}/tags/list?n=1000`;
+const OCI_ACCEPT = [
+  "application/vnd.oci.image.index.v1+json",
+  "application/vnd.oci.image.manifest.v1+json",
+  "application/vnd.docker.distribution.manifest.list.v2+json",
+  "application/vnd.docker.distribution.manifest.v2+json",
+].join(", ");
+
+/**
+ * Matches the `tag:` line under an `agentFs:` -> `image:` YAML block.
+ * Group 1 is everything up to the tag value, group 2 is the tag itself, so
+ * `replace(pattern, "$1<version>")` rewrites the pin and keeps quoting intact.
+ */
+export const AGENT_FS_HELM_TAG_PATTERN =
+  /(^agentFs:\s*$[\s\S]*?^ {2}image:\s*$[\s\S]*?^ {4}tag:\s*["']?)([^\s"']+)/m;
+
+export function stableVersionParts(value: string): [number, number, number] | undefined {
+  const match = value.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function compareStableVersions(left: string, right: string): number {
+  const a = stableVersionParts(left);
+  const b = stableVersionParts(right);
+  if (!a || !b) throw new Error(`Cannot compare non-stable image tags: ${left}, ${right}`);
+  for (let index = 0; index < 3; index += 1) {
+    const diff = (a[index] ?? 0) - (b[index] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+export async function fetchWithRetry(input: string, init: RequestInit = {}): Promise<Response> {
+  const maxAttempts = 3;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const response = await fetch(input, {
+        ...init,
+        signal: AbortSignal.timeout(10_000),
+      });
+      const retryable = response.status === 429 || response.status >= 500;
+      if (!retryable || attempt === maxAttempts) return response;
+      await response.body?.cancel();
+    } catch (error) {
+      if (attempt === maxAttempts) {
+        throw new Error(`Request failed after ${maxAttempts} attempts: ${input}`, {
+          cause: error,
+        });
+      }
+    }
+  }
+  throw new Error(`Request exhausted retries: ${input}`);
+}
+
+async function ghcrAuthHeaders(): Promise<Record<string, string>> {
+  const tokenResponse = await fetchWithRetry(GHCR_TOKEN_URL);
+  if (!tokenResponse.ok) {
+    throw new Error(`GHCR token request failed with HTTP ${tokenResponse.status}`);
+  }
+  const tokenPayload = (await tokenResponse.json()) as { token?: unknown };
+  if (typeof tokenPayload.token !== "string" || tokenPayload.token.length === 0) {
+    throw new Error("GHCR token response did not include a token");
+  }
+  return { Authorization: `Bearer ${tokenPayload.token}` };
+}
+
+/** HEADs the GHCR manifest for `tag` and returns the HTTP status (200 = image exists). */
+export async function checkAgentFsImageManifest(
+  tag: string,
+  headers?: Record<string, string>,
+): Promise<number> {
+  const authHeaders = headers ?? (await ghcrAuthHeaders());
+  const manifestResponse = await fetchWithRetry(
+    `https://ghcr.io/v2/${AGENT_FS_IMAGE}/manifests/${tag}`,
+    {
+      method: "HEAD",
+      headers: { ...authHeaders, Accept: OCI_ACCEPT },
+    },
+  );
+  return manifestResponse.status;
+}
+
+/** Newest stable semver tag on GHCR, verified to have a live manifest. */
+export async function resolveLatestAgentFsImage(): Promise<{
+  tag: string;
+  manifestStatus: number;
+}> {
+  const headers = await ghcrAuthHeaders();
+  const tagsResponse = await fetchWithRetry(GHCR_TAGS_URL, { headers });
+  if (!tagsResponse.ok) {
+    throw new Error(`GHCR tag-list request failed with HTTP ${tagsResponse.status}`);
+  }
+  const tagsPayload = (await tagsResponse.json()) as { tags?: unknown };
+  const tags = Array.isArray(tagsPayload.tags)
+    ? tagsPayload.tags.filter(
+        (tag): tag is string => typeof tag === "string" && stableVersionParts(tag) !== undefined,
+      )
+    : [];
+  const tag = tags.sort(compareStableVersions).at(-1);
+  if (!tag) throw new Error(`GHCR returned no stable semver tags for ${AGENT_FS_IMAGE}`);
+
+  const manifestStatus = await checkAgentFsImageManifest(tag, headers);
+  if (manifestStatus !== 200) {
+    throw new Error(
+      `GHCR manifest check for ${AGENT_FS_IMAGE}:${tag} returned HTTP ${manifestStatus}`,
+    );
+  }
+  return { tag, manifestStatus };
+}
+
+export function readAgentFsImageTag(valuesYaml: string, source: string): string {
+  const tag = valuesYaml.match(AGENT_FS_HELM_TAG_PATTERN)?.[2];
+  if (!tag) throw new Error(`${source} is missing agentFs.image.tag`);
+  return tag;
+}

--- a/scripts/bump-agent-fs.ts
+++ b/scripts/bump-agent-fs.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env bun
+/**
+ * Bump every agent-fs version pin in the repo in one go.
+ *
+ *   bun run bump:agent-fs            # newest stable tag on GHCR
+ *   bun run bump:agent-fs 0.13.3     # explicit version (leading "v" accepted)
+ *
+ * Before touching any file the target version is checked against the three
+ * places the worker image and the chart pull it from: the GHCR image manifest,
+ * the npm package, and the skill file at the git tag. A missing pin location
+ * (layout drift) fails loudly rather than leaving a partial bump behind.
+ */
+
+import {
+  AGENT_FS_HELM_TAG_PATTERN,
+  AGENT_FS_IMAGE,
+  AGENT_FS_NPM_PACKAGE,
+  AGENT_FS_REPO,
+  AGENT_FS_SKILL_PATH,
+  checkAgentFsImageManifest,
+  fetchWithRetry,
+  resolveLatestAgentFsImage,
+  stableVersionParts,
+} from "./agent-fs-version-utils";
+
+type Pin = {
+  path: string;
+  /** Group 1 = prefix kept verbatim, group 2 = the version to rewrite. */
+  pattern: RegExp;
+};
+
+const COMPOSE_IMAGE_PATTERN = new RegExp(`(ghcr\\.io/${AGENT_FS_IMAGE}:)(\\S+)`, "g");
+
+const PINS: Pin[] = [
+  { path: "Dockerfile.worker", pattern: /^(ARG AGENT_FS_VERSION=)(\S+)$/m },
+  { path: "docker-compose.local.yml", pattern: COMPOSE_IMAGE_PATTERN },
+  { path: "docker-compose.example.yml", pattern: COMPOSE_IMAGE_PATTERN },
+  { path: "docker-compose.scripts-only.yml", pattern: COMPOSE_IMAGE_PATTERN },
+  { path: "charts/agent-swarm/values.yaml", pattern: AGENT_FS_HELM_TAG_PATTERN },
+  { path: "charts/agent-swarm/README.md", pattern: AGENT_FS_HELM_TAG_PATTERN },
+  {
+    path: "docs-site/content/docs/(documentation)/guides/agent-fs-co-deployment.mdx",
+    pattern: AGENT_FS_HELM_TAG_PATTERN,
+  },
+];
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+function normalizeVersion(raw: string): string {
+  const version = raw.replace(/^v/, "");
+  if (!stableVersionParts(version)) {
+    fail(`Expected a stable semver version like 0.13.3, got "${raw}".`);
+  }
+  return version;
+}
+
+async function resolveTarget(requested: string | undefined): Promise<string> {
+  if (!requested) {
+    const latest = await resolveLatestAgentFsImage();
+    console.log(`Latest GHCR tag: ${latest.tag} (manifest HTTP ${latest.manifestStatus})`);
+    return latest.tag;
+  }
+  const version = normalizeVersion(requested);
+  const manifestStatus = await checkAgentFsImageManifest(version);
+  if (manifestStatus !== 200) {
+    fail(`GHCR has no image ${AGENT_FS_IMAGE}:${version} (manifest HTTP ${manifestStatus}).`);
+  }
+  console.log(`GHCR image ${AGENT_FS_IMAGE}:${version} exists (manifest HTTP ${manifestStatus})`);
+  return version;
+}
+
+async function preflight(version: string): Promise<void> {
+  const npmUrl = `https://registry.npmjs.org/${encodeURIComponent(AGENT_FS_NPM_PACKAGE)}/${version}`;
+  const npmResponse = await fetchWithRetry(npmUrl);
+  await npmResponse.body?.cancel();
+  if (npmResponse.status !== 200) {
+    fail(`npm has no ${AGENT_FS_NPM_PACKAGE}@${version} (HTTP ${npmResponse.status}).`);
+  }
+  console.log(`npm package ${AGENT_FS_NPM_PACKAGE}@${version} exists`);
+
+  const skillUrl = `https://raw.githubusercontent.com/${AGENT_FS_REPO}/v${version}/${AGENT_FS_SKILL_PATH}`;
+  const skillResponse = await fetchWithRetry(skillUrl, { method: "HEAD" });
+  await skillResponse.body?.cancel();
+  if (skillResponse.status !== 200) {
+    fail(
+      `Tag v${version} of ${AGENT_FS_REPO} has no ${AGENT_FS_SKILL_PATH} (HTTP ${skillResponse.status}).`,
+    );
+  }
+  console.log(`Skill file ${AGENT_FS_SKILL_PATH} exists at v${version}`);
+}
+
+function currentVersions(text: string, pattern: RegExp): string[] {
+  const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
+  return [...text.matchAll(new RegExp(pattern.source, flags))].map((match) => match[2] ?? "");
+}
+
+async function applyPins(version: string): Promise<void> {
+  const rendered: string[] = [];
+  for (const pin of PINS) {
+    const file = Bun.file(pin.path);
+    if (!(await file.exists()))
+      fail(`${pin.path} not found; update PINS in scripts/bump-agent-fs.ts.`);
+    const original = await file.text();
+    const before = currentVersions(original, pin.pattern);
+    if (before.length === 0) {
+      fail(
+        `${pin.path} has no agent-fs pin matching the expected layout; update PINS in scripts/bump-agent-fs.ts.`,
+      );
+    }
+    const updated = original.replace(pin.pattern, `$1${version}`);
+    const after = currentVersions(updated, pin.pattern);
+    const stale = after.filter((found) => found !== version);
+    if (stale.length > 0) {
+      fail(
+        `${pin.path} still carries ${stale.join(", ")} after rewrite; the pin pattern needs fixing.`,
+      );
+    }
+    if (updated !== original) await Bun.write(pin.path, updated);
+    const from = [...new Set(before)].join(", ");
+    rendered.push(
+      `${updated === original ? "unchanged" : "updated  "}  ${pin.path}  (${from} -> ${version})`,
+    );
+  }
+  console.log(rendered.join("\n"));
+}
+
+const args = process.argv.slice(2);
+const requested = args.find((arg) => !arg.startsWith("--"));
+
+const target = await resolveTarget(requested);
+await preflight(target);
+await applyPins(target);
+console.log(`agent-fs pins now at ${target}. Review with: git diff`);

--- a/scripts/sync-chart-version.ts
+++ b/scripts/sync-chart-version.ts
@@ -1,120 +1,27 @@
 #!/usr/bin/env bun
 
 import { spawnSync } from "node:child_process";
+import { readAgentFsImageTag, resolveLatestAgentFsImage } from "./agent-fs-version-utils";
 
 const PACKAGE_JSON = "package.json";
 const CHART_YAML = "charts/agent-swarm/Chart.yaml";
 const CHART_VALUES_YAML = "charts/agent-swarm/values.yaml";
-const AGENT_FS_IMAGE = "desplega-ai/agent-fs";
-const GHCR_TOKEN_URL = `https://ghcr.io/token?scope=${encodeURIComponent(`repository:${AGENT_FS_IMAGE}:pull`)}&service=ghcr.io`;
-const GHCR_TAGS_URL = `https://ghcr.io/v2/${AGENT_FS_IMAGE}/tags/list?n=1000`;
-const OCI_ACCEPT = [
-  "application/vnd.oci.image.index.v1+json",
-  "application/vnd.oci.image.manifest.v1+json",
-  "application/vnd.docker.distribution.manifest.list.v2+json",
-  "application/vnd.docker.distribution.manifest.v2+json",
-].join(", ");
 
 type ChartVersions = {
   version: string;
   appVersion: string;
 };
 
-function stableVersionParts(value: string): [number, number, number] | undefined {
-  const match = value.match(/^(\d+)\.(\d+)\.(\d+)$/);
-  if (!match) return undefined;
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
-}
-
-function compareStableVersions(left: string, right: string): number {
-  const a = stableVersionParts(left);
-  const b = stableVersionParts(right);
-  if (!a || !b) throw new Error(`Cannot compare non-stable image tags: ${left}, ${right}`);
-  for (let index = 0; index < 3; index += 1) {
-    if (a[index] !== b[index]) return a[index] - b[index];
-  }
-  return 0;
-}
-
-async function fetchGhcr(input: string, init: RequestInit = {}): Promise<Response> {
-  const maxAttempts = 3;
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    try {
-      const response = await fetch(input, {
-        ...init,
-        signal: AbortSignal.timeout(10_000),
-      });
-      const retryable = response.status === 429 || response.status >= 500;
-      if (!retryable || attempt === maxAttempts) return response;
-      await response.body?.cancel();
-    } catch (error) {
-      if (attempt === maxAttempts) {
-        throw new Error(`GHCR request failed after ${maxAttempts} attempts: ${input}`, {
-          cause: error,
-        });
-      }
-    }
-  }
-  throw new Error(`GHCR request exhausted retries: ${input}`);
-}
-
-async function resolveLatestAgentFsImage(): Promise<{ tag: string; manifestStatus: number }> {
-  const tokenResponse = await fetchGhcr(GHCR_TOKEN_URL);
-  if (!tokenResponse.ok) {
-    throw new Error(`GHCR token request failed with HTTP ${tokenResponse.status}`);
-  }
-  const tokenPayload = (await tokenResponse.json()) as { token?: unknown };
-  if (typeof tokenPayload.token !== "string" || tokenPayload.token.length === 0) {
-    throw new Error("GHCR token response did not include a token");
-  }
-
-  const headers = { Authorization: `Bearer ${tokenPayload.token}` };
-  const tagsResponse = await fetchGhcr(GHCR_TAGS_URL, { headers });
-  if (!tagsResponse.ok) {
-    throw new Error(`GHCR tag-list request failed with HTTP ${tagsResponse.status}`);
-  }
-  const tagsPayload = (await tagsResponse.json()) as { tags?: unknown };
-  const tags = Array.isArray(tagsPayload.tags)
-    ? tagsPayload.tags.filter(
-        (tag): tag is string => typeof tag === "string" && stableVersionParts(tag) !== undefined,
-      )
-    : [];
-  const tag = tags.sort(compareStableVersions).at(-1);
-  if (!tag) throw new Error(`GHCR returned no stable semver tags for ${AGENT_FS_IMAGE}`);
-
-  const manifestResponse = await fetchGhcr(
-    `https://ghcr.io/v2/${AGENT_FS_IMAGE}/manifests/${tag}`,
-    {
-      method: "HEAD",
-      headers: { ...headers, Accept: OCI_ACCEPT },
-    },
-  );
-  if (manifestResponse.status !== 200) {
-    throw new Error(
-      `GHCR manifest check for ${AGENT_FS_IMAGE}:${tag} returned HTTP ${manifestResponse.status}`,
-    );
-  }
-  return { tag, manifestStatus: manifestResponse.status };
-}
-
-function readAgentFsImageTag(valuesYaml: string): string {
-  const tag = valuesYaml.match(
-    /^agentFs:\s*$[\s\S]*?^ {2}image:\s*$[\s\S]*?^ {4}tag:\s*["']?([^\s"']+)["']?\s*$/m,
-  )?.[1];
-  if (!tag) throw new Error(`${CHART_VALUES_YAML} is missing agentFs.image.tag`);
-  return tag;
-}
-
 async function checkAgentFsImageTag(): Promise<void> {
   const valuesYaml = await Bun.file(CHART_VALUES_YAML).text();
-  const configuredTag = readAgentFsImageTag(valuesYaml);
+  const configuredTag = readAgentFsImageTag(valuesYaml, CHART_VALUES_YAML);
   const latest = await resolveLatestAgentFsImage();
   if (configuredTag !== latest.tag) {
     console.error(
       [
         `${CHART_VALUES_YAML} has a stale agentFs.image.tag.`,
         `Expected ${latest.tag} (GHCR manifest HTTP ${latest.manifestStatus}), but found ${configuredTag}.`,
-        "Update the chart, README, and Compose agent-fs image pins together.",
+        "Run `bun run bump:agent-fs` to update every agent-fs pin together and commit the result.",
       ].join("\n"),
     );
     process.exit(1);


### PR DESCRIPTION
## Summary

Bumps every agent-fs pin from 0.13.2 to 0.13.3, the latest release in [desplega-ai/agent-fs](https://github.com/desplega-ai/agent-fs/releases/tag/v0.13.3), and adds a script so the next bump is one command.

**Pin bump (commit 1)**
- `Dockerfile.worker`: `AGENT_FS_VERSION` (drives both the baked skill tag and the CLI in `/opt/global-deps`)
- `charts/agent-swarm/values.yaml` + `charts/agent-swarm/README.md`: `agentFs.image.tag`
- `docker-compose.{local,example,scripts-only}.yml`: `ghcr.io/desplega-ai/agent-fs` image
- `docs-site/.../guides/agent-fs-co-deployment.mdx`: Helm example

Upstream change in v0.13.3: first-class API key reset (self-service + org-admin), desplega-ai/agent-fs#36. No breaking changes noted.

**`bun run bump:agent-fs` (commit 2)**
- `scripts/bump-agent-fs.ts` rewrites all seven pins above in one run. No argument = newest stable GHCR tag; an explicit `0.13.3` / `v0.13.3` also works.
- Before writing it checks the GHCR manifest, the npm package, and `skills/agent-fs/SKILL.md` at the git tag (the three things the worker image and chart actually pull). A pin location that no longer matches the expected layout fails loudly instead of leaving a partial bump.
- GHCR tag resolution moved from `sync-chart-version.ts` into `scripts/agent-fs-version-utils.ts` so both scripts share it. The stale-tag CI error now points at the new command.

## Verification

- `bun run scripts/sync-chart-version.ts --check` passes: chart tag matches the latest GHCR tag (manifest HTTP 200).
- Round-trip: `bun run bump:agent-fs 0.13.2` then `bun run bump:agent-fs` restores the exact pin state of commit 1 (diff empty on all seven files).
- Negative paths: unknown version (`9.9.9`) fails on the GHCR manifest check, non-semver input fails validation.
- Scripts type-check under the root `tsconfig` options and pass Biome (checked in isolation, since `scripts/` is outside `tsc:check` and the local `biome check` currently aborts with a worker stack overflow on this machine, also on clean `main`).

https://claude.ai/code/session_01Kc6XnKcGG5v8LGqzJ9Rys5