### PR TITLE
feat(ui): gate Plausible analytics behind VITE_PLAUSIBLE_ANALYTICS build flag

### DIFF
--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 
 const packageJson = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "../../package.json"), "utf8"),
@@ -10,13 +10,42 @@ const packageJson = JSON.parse(
   version?: string;
 };
 
+/**
+ * Plausible analytics, injected into index.html at build time only when
+ * `VITE_PLAUSIBLE_ANALYTICS=1` (or `true`) is set. Our Vercel production
+ * project sets it; self-hosted and local builds ship with no analytics script.
+ */
+function plausibleAnalytics(): Plugin {
+  const flag = (process.env.VITE_PLAUSIBLE_ANALYTICS ?? "").trim().toLowerCase();
+  const enabled = flag === "1" || flag === "true";
+  return {
+    name: "plausible-analytics",
+    transformIndexHtml() {
+      if (!enabled) return [];
+      return [
+        {
+          tag: "script",
+          attrs: { async: true, src: "https://plausible.io/js/pa-aDF5FACknjhykIUMd6n_a.js" },
+          injectTo: "head",
+        },
+        {
+          tag: "script",
+          children:
+            "window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()",
+          injectTo: "head",
+        },
+      ];
+    },
+  };
+}
+
 const allowedHosts =
   process.env.VITE_ALLOWED_HOSTS === "*"
     ? true
     : process.env.VITE_ALLOWED_HOSTS?.split(",").map((host) => host.trim());
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), plausibleAnalytics()],
   define: {
     __APP_VERSION__: JSON.stringify(packageJson.version ?? "0.0.0"),
   },

--- a/docs-site/content/docs/(documentation)/reference/environment-variables.mdx
+++ b/docs-site/content/docs/(documentation)/reference/environment-variables.mdx
@@ -393,6 +393,7 @@ Install: `bun add -g portless`. Enable HTTPS: `portless trust && portless proxy 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `VITE_PROXY_TARGET` | `http://localhost:3013` | Overrides the API origin the `ui/` Vite dev server (`pnpm dev`, port 5274) proxies `/api`, `/health`, and `/status` requests to. Set when the API is running on a non-default port/host during local dashboard development. |
+| `VITE_PLAUSIBLE_ANALYTICS` | unset | Build-time flag. Set to `1` to inject the Plausible analytics snippet into the dashboard's `index.html` during `bun run build`. Only our hosted dashboard sets it; self-hosted and local builds ship with no analytics script. |
 
 ## Cloud Personalization & Adaptive Home
 

--- a/docs-site/content/docs/(documentation)/ui/index.mdx
+++ b/docs-site/content/docs/(documentation)/ui/index.mdx
@@ -45,6 +45,8 @@ bun run build   # outputs apps/ui/dist/
 
 Deploy the `dist/` directory to your static host of choice (Vercel, Netlify, nginx, S3 + CDN, ...).
 
+Self-hosted builds contain no analytics. The hosted dashboard sets the build-time flag `VITE_PLAUSIBLE_ANALYTICS=1`, which injects a [Plausible](https://plausible.io) snippet; leave it unset to keep your build analytics-free.
+
 For local development:
 
 ```bash


### PR DESCRIPTION
## Summary

- Add a small `plausibleAnalytics` Vite plugin in `apps/ui/vite.config.ts` that injects the Plausible script + init snippet into `index.html` at build time, only when `VITE_PLAUSIBLE_ANALYTICS=1` (or `true`) is set.
- `index.html` itself is untouched: self-hosted, local, and Vercel preview builds ship with no analytics script.
- Document the flag in the env-var reference and add a one-line note to the UI self-hosting docs page.

The Vercel project `desplega-labs/agent-swarm` (root `apps/ui`) now has `VITE_PLAUSIBLE_ANALYTICS=1` on the production target only, so the snippet goes live on the next production build after merge.

## Verification

- `cd apps/ui && bun run build` (runs `tsc -b`): passes, `dist/index.html` has no Plausible reference.
- `VITE_PLAUSIBLE_ANALYTICS=1 bun run build`: passes, `dist/index.html` contains both script tags in `<head>`.
- Biome check on `vite.config.ts`: clean.

No UI rendering changes, so no qa-use session: the diff is build config plus docs.