### PR TITLE
feat(slack): honor SLACK_API_URL to point Bolt at a mock Slack server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,7 @@ MCP_BASE_URL=
 SLACK_BOT_TOKEN=xoxb-...      # Bot User OAuth Token
 SLACK_APP_TOKEN=xapp-...      # App-Level Token (for Socket Mode)
 SLACK_SIGNING_SECRET=...      # Signing Secret (optional for Socket Mode)
+# SLACK_API_URL=http://127.0.0.1:4040/api/  # Point Bolt at a mock Slack server (slack-mock) for e2e tests
 SLACK_DISABLE=true            # Set to "true" to disable Slack integration
 # SLACK_ALLOW_DEV_SOCKET_MODE=true  # Explicitly allow Socket Mode when NODE_ENV=development (default: false)
 # SLACK_RENDER_V2=true        # Opt in to one editable thread tree + streamed outcome cards (default: false)

--- a/src/slack/app.ts
+++ b/src/slack/app.ts
@@ -41,11 +41,14 @@ export async function initSlackApp(): Promise<App | null> {
     return null;
   }
 
+  // SLACK_API_URL points Bolt (Web API and apps.connections.open) at a mock Slack server for e2e tests.
+  const slackApiUrl = process.env.SLACK_API_URL;
   app = new App({
     token: botToken,
     appToken: appToken,
     socketMode: true,
     logLevel: process.env.NODE_ENV === "development" ? LogLevel.DEBUG : LogLevel.INFO,
+    ...(slackApiUrl ? { clientOptions: { slackApiUrl } } : {}),
   });
 
   // Register handlers


### PR DESCRIPTION
## Summary

- Read `SLACK_API_URL` into Bolt's `clientOptions.slackApiUrl` in `src/slack/app.ts`. Bolt forwards it to its Web API client and to the Socket Mode client's `apps.connections.open` call, so the whole Slack integration can run against a local mock. Nothing changes when the variable is unset.
- Document the variable in `.env.example`.

This is the one change needed by [slack-mock](https://github.com/desplega-ai/slack-mock), whose `bun run test:e2e` boots this API server, sends a channel mention, claims and finishes the resulting task with a fake lead over HTTP, and checks the watcher's reply and reactions.

## Verification

- `bun run tsc:check` clean.
- `bun test src/slack/socket-mode-guard.test.ts src/slack/handlers.test.ts src/tests/slack-assistant.test.ts`: 73 pass.
- `bunx biome check` aborts locally with a Biome stack overflow on this repo, with and without this change; CI's lint job should be authoritative.
- slack-mock e2e against this branch: 3 pass (boot + Socket Mode connect, mention to completed task with outcome posted, `/agent-swarm-status`).