### PR TITLE
fix(codex-oauth): resolve ~/.codex through process.env.HOME (Bun caches os.homedir(), tests clobbered the real auth.json)

### DIFF
--- a/src/providers/codex-adapter.ts
+++ b/src/providers/codex-adapter.ts
@@ -49,7 +49,6 @@
  */
 
 import { existsSync as nodeExistsSync } from "node:fs";
-import os from "node:os";
 import { join } from "node:path";
 import {
   type AgentMessageItem,
@@ -82,6 +81,7 @@ import { scrubSecrets } from "../utils/secret-scrubber";
 import { type CodexAgentsMdHandle, writeCodexAgentsMd } from "./codex-agents-md";
 import { computeCodexCostUsd, getCodexContextWindow, resolveCodexModel } from "./codex-models";
 import { credentialsToAuthJson } from "./codex-oauth/auth-json.js";
+import { codexUserHome } from "./codex-oauth/home.js";
 import { CodexOAuthRefreshError, getValidCodexOAuth } from "./codex-oauth/storage.js";
 import { resolveCodexPrompt } from "./codex-skill-resolver";
 import { createCodexSwarmEventHandler } from "./codex-swarm-events";
@@ -204,7 +204,7 @@ export async function resolveCodexAuthMode(
   } = {},
 ): Promise<string | null> {
   const fsModule = await import("node:fs/promises");
-  const homedir = deps.homedir ?? os.homedir.bind(os);
+  const homedir = deps.homedir ?? codexUserHome;
   const fs = deps.fs ?? {
     readFile: (path: string, encoding: "utf-8") => fsModule.readFile(path, encoding),
     mkdir: (path: string, opts: { recursive: boolean; mode: number }) => fsModule.mkdir(path, opts),
@@ -586,7 +586,7 @@ export class CodexSession implements ProviderSession {
     // tree without polluting `~/.codex/skills` on the host. Fall back to the
     // runtime default of `${HOME}/.codex/skills`.
     this.skillsDir =
-      skillsDir ?? process.env.CODEX_SKILLS_DIR ?? join(os.homedir(), ".codex", "skills");
+      skillsDir ?? process.env.CODEX_SKILLS_DIR ?? join(codexUserHome(), ".codex", "skills");
     this.summarizeDeps = summarizeDeps;
     this.logFileHandle = Bun.file(config.logFile).writer();
     // Mirrors the resolution `buildCodexConfig` already applied when

--- a/src/providers/codex-oauth/auth-json-fs.ts
+++ b/src/providers/codex-oauth/auth-json-fs.ts
@@ -4,9 +4,9 @@
  * partial file, which would break the Codex CLI's auth bootstrap.
  */
 
-import os from "node:os";
 import { join } from "node:path";
 import { credentialsToAuthJson } from "./auth-json.js";
+import { codexUserHome } from "./home.js";
 import type { CodexOAuthCredentials } from "./types.js";
 
 /**
@@ -39,7 +39,7 @@ export async function materializeCodexAuthJson(
   } = {},
 ): Promise<void> {
   const fsModule = await import("node:fs/promises");
-  const homedir = deps.homedir ?? os.homedir.bind(os);
+  const homedir = deps.homedir ?? codexUserHome;
   const fs = deps.fs ?? {
     mkdir: (path: string, opts: { recursive: boolean; mode: number }) => fsModule.mkdir(path, opts),
     writeFile: (path: string, data: string, opts: { mode: number }) =>

--- a/src/providers/codex-oauth/home.ts
+++ b/src/providers/codex-oauth/home.ts
@@ -1,0 +1,13 @@
+import os from "node:os";
+
+/**
+ * Home directory that owns `~/.codex`.
+ *
+ * Prefers `process.env.HOME` over `os.homedir()`. Bun resolves `os.homedir()`
+ * once at process start, so a HOME override set later in the same process
+ * (test isolation, harness sandboxes) is ignored by `os.homedir()` and writes
+ * would land in the real home directory. `process.env.HOME` is read live.
+ */
+export function codexUserHome(): string {
+  return process.env.HOME || os.homedir();
+}

--- a/src/tests/codex-oauth-auth-json-fs.test.ts
+++ b/src/tests/codex-oauth-auth-json-fs.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
 import { materializeCodexAuthJson } from "../providers/codex-oauth/auth-json-fs.js";
 import type { CodexOAuthCredentials } from "../providers/codex-oauth/types.js";
 
@@ -107,6 +110,22 @@ describe("materializeCodexAuthJson", () => {
         },
       });
       expect(paths[0]).toBe("/home/w/.codex/auth.json.tmp");
+    }
+  });
+
+  it("honours a runtime HOME override instead of the cached os.homedir()", async () => {
+    // Bun resolves os.homedir() once at process start. Tests and harness
+    // sandboxes isolate via process.env.HOME, so the writer must read that.
+    const originalHome = process.env.HOME;
+    const tmpHome = await mkdtemp(join(os.tmpdir(), "codex-auth-json-home-"));
+    process.env.HOME = tmpHome;
+    try {
+      await materializeCodexAuthJson(0, mockCreds);
+      expect(await Bun.file(join(tmpHome, ".codex", "auth.json")).exists()).toBe(true);
+      expect(tmpHome).not.toBe(os.homedir());
+    } finally {
+      process.env.HOME = originalHome;
+      await rm(tmpHome, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## What

The codex-oauth path now resolves the home directory through `process.env.HOME` first, falling back to `os.homedir()`. New helper `codexUserHome()` in `src/providers/codex-oauth/home.ts`, used by `materializeCodexAuthJson`, the adapter's auth.json read/write, and the skills dir default.

## Why

Bun resolves `os.homedir()` once at process start. Setting `process.env.HOME` later in the same process does not change it (Node re-reads HOME on every call). Verified:

```
$ bun -e 'const os=require("os"); process.env.HOME="/tmp/x"; console.log(os.homedir())'
/Users/<user>
```

`src/tests/codex-oauth-credential-info.test.ts` isolates with `process.env.HOME = tmpHome`, then calls `resolveCodexOAuthCredentialInfo`, which for a pool-backed slot awaits `materializeCodexAuthJson`. That write went to the developer's REAL `~/.codex/auth.json`: chatgpt mode, fake `header.<b64>.sig` tokens, refresh token blanked. Symptoms afterwards: `codex login status` says `Invalid padding`, `codex exec` gets `401 Missing bearer or basic authentication in header`.

This bit us on 2026-08-21 and again today (2026-09-03) via the prek pre-push hook's full-suite fallback. Anyone with a Codex ChatGPT login who runs `bun run test:root` locally loses it and has to `codex login` again.

## Change

- `src/providers/codex-oauth/home.ts`: `codexUserHome()`.
- `src/providers/codex-oauth/auth-json-fs.ts`, `src/providers/codex-adapter.ts`: use it instead of `os.homedir()`.
- `src/tests/codex-oauth-auth-json-fs.test.ts`: regression test that a runtime HOME override is honoured with the real filesystem.

Runtime behavior is unchanged for workers: the entrypoint and the E2E harness set HOME at spawn time, where both resolutions agree.

## Verification

```
bun test src/tests/codex-oauth-auth-json-fs.test.ts src/tests/codex-oauth-credential-info.test.ts \
  src/tests/codex-adapter-pool-auth-revalidate.test.ts src/tests/codex-oauth-adapter.test.ts
 26 pass, 0 fail
real ~/.codex/auth.json mtime before and after: UNCHANGED
bun run tsc:check: clean
biome check on the four touched files: clean
```

## Follow-up

Other tests that swap `process.env.HOME` in-process should be audited for code under test that uses `os.homedir()` (pi, opencode, claude homes). Same pattern, same fix.
