### PR TITLE
feat(stats): expose multi-runtime feature state

### DIFF
--- a/docs-site/public/openapi.d.ts
+++ b/docs-site/public/openapi.d.ts
@@ -14428,6 +14428,7 @@ export interface paths {
                                 failed: number | null;
                             };
                             steeringEnabled: boolean;
+                            multiRuntimeEnabled: boolean;
                         };
                     };
                 };

--- a/openapi.json
+++ b/openapi.json
@@ -36681,12 +36681,16 @@
                     },
                     "steeringEnabled": {
                       "type": "boolean"
+                    },
+                    "multiRuntimeEnabled": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
                     "agents",
                     "tasks",
-                    "steeringEnabled"
+                    "steeringEnabled",
+                    "multiRuntimeEnabled"
                   ]
                 }
               }

--- a/src/http/stats.ts
+++ b/src/http/stats.ts
@@ -15,6 +15,7 @@ import { getDbRetentionStats } from "../be/db-retention";
 import { isSteeringEnabled } from "../be/steering";
 import type { AgentLog } from "../types";
 import { AgentLogSchema, ScheduledTaskSchema, ServiceSchema } from "../types";
+import { isMultiRuntimeEnabled } from "../utils/multi-runtime";
 import { resolveHttpFavoriteOwner } from "./favorite-owner";
 import { route } from "./route-def";
 
@@ -48,6 +49,7 @@ const DashboardStatsSchema = z.object({
   agents: AgentCountsSchema,
   tasks: TaskCountsSchema,
   steeringEnabled: z.boolean(),
+  multiRuntimeEnabled: z.boolean(),
 });
 
 /** Mirrors `DbRetentionTableStats` (src/be/db-retention.ts). */
@@ -259,6 +261,17 @@ export async function handleStats(
       // Authenticated home for the steering feature flag — deliberately NOT on
       // the unauthenticated /health endpoint (config must not leak).
       steeringEnabled: isSteeringEnabled(),
+      // Same authenticated home, for the same reason. Read through the helper
+      // the server itself branches on, and read PER REQUEST rather than
+      // captured at module load, so the reported value tracks a `swarm_config`
+      // reload the way every other consumer of the flag does.
+      //
+      // Worth stating because the difference is not visible from the outside:
+      // when the mode is off, runtime-instance rows are never written, so an
+      // empty runtime-instance list means either "no runtimes registered" or
+      // "this server does not track them at all". Those need different
+      // responses from a client, and nothing else on the API separates them.
+      multiRuntimeEnabled: isMultiRuntimeEnabled(),
     };
 
     getStats.respond(res, 200, stats);

--- a/src/tests/multi-runtime-enabled-stats.test.ts
+++ b/src/tests/multi-runtime-enabled-stats.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { unlink } from "node:fs/promises";
+import {
+  createServer as createHttpServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import { closeDb, initDb } from "../be/db";
+import { handleCore } from "../http/core";
+import { handleStats } from "../http/stats";
+import { getPathSegments, parseQueryParams } from "../http/utils";
+import { isMultiRuntimeEnabled } from "../utils/multi-runtime";
+
+const TEST_DB_PATH = `/tmp/agent-swarm-multi-runtime-stats-${process.pid}.sqlite`;
+const originalDatabasePath = process.env.DATABASE_PATH;
+const originalMultiRuntime = process.env.MULTI_RUNTIME_ENABLED;
+let server: Server;
+let baseUrl: string;
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+/**
+ * Run `body` with MULTI_RUNTIME_ENABLED set to an exact raw value, or unset
+ * when `raw` is undefined, restoring the previous value afterwards so the flag
+ * never leaks into another test in this file or another file.
+ */
+async function withMultiRuntime<T>(raw: string | undefined, body: () => Promise<T>): Promise<T> {
+  const previous = process.env.MULTI_RUNTIME_ENABLED;
+  restoreEnv("MULTI_RUNTIME_ENABLED", raw);
+  try {
+    return await body();
+  } finally {
+    restoreEnv("MULTI_RUNTIME_ENABLED", previous);
+  }
+}
+
+async function removeTestDb(): Promise<void> {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      await unlink(`${TEST_DB_PATH}${suffix}`);
+    } catch {
+      // SQLite only creates sidecars after a write.
+    }
+  }
+}
+
+async function api(
+  method: string,
+  path: string,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers: { Authorization: "Bearer test-key", "Content-Type": "application/json" },
+  });
+  const text = await response.text();
+  return { status: response.status, body: text ? JSON.parse(text) : {} };
+}
+
+beforeAll(async () => {
+  await removeTestDb();
+  process.env.DATABASE_PATH = TEST_DB_PATH;
+  initDb(TEST_DB_PATH);
+  server = createHttpServer(async (req: IncomingMessage, res: ServerResponse) => {
+    res.setHeader("Content-Type", "application/json");
+    const agentId = req.headers["x-agent-id"] as string | undefined;
+    if (await handleCore(req, res, agentId, "test-key")) return;
+    const pathSegments = getPathSegments(req.url ?? "");
+    const queryParams = parseQueryParams(req.url ?? "");
+    if (await handleStats(req, res, pathSegments, queryParams, agentId)) return;
+    res.writeHead(404);
+    res.end(JSON.stringify({ error: "Not found" }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not listen");
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  restoreEnv("MULTI_RUNTIME_ENABLED", originalMultiRuntime);
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  closeDb();
+  restoreEnv("DATABASE_PATH", originalDatabasePath);
+  await removeTestDb();
+});
+
+describe("MULTI_RUNTIME_ENABLED on the authenticated stats endpoint", () => {
+  test("reports false when the flag is unset — multi-runtime is opt-in", async () => {
+    await withMultiRuntime(undefined, async () => {
+      const stats = await api("GET", "/api/stats");
+      expect(stats.status).toBe(200);
+      expect(stats.body.multiRuntimeEnabled).toBe(false);
+    });
+  });
+
+  test("reports false when the flag is explicitly falsy", async () => {
+    for (const raw of ["false", "0"]) {
+      await withMultiRuntime(raw, async () => {
+        const stats = await api("GET", "/api/stats");
+        expect(stats.status).toBe(200);
+        expect(stats.body.multiRuntimeEnabled).toBe(false);
+      });
+    }
+  });
+
+  test("reports true when the flag is explicitly truthy", async () => {
+    for (const raw of ["true", "1"]) {
+      await withMultiRuntime(raw, async () => {
+        const stats = await api("GET", "/api/stats");
+        expect(stats.status).toBe(200);
+        expect(stats.body.multiRuntimeEnabled).toBe(true);
+      });
+    }
+  });
+
+  test("agrees with the helper the server itself branches on", async () => {
+    // The field must not be a second parse of the same variable: a hand-rolled
+    // check here could disagree with `isMultiRuntimeEnabled` on exactly the
+    // values `parseEnvFlag` normalizes, and the API would then report a mode
+    // the server is not in. Compared against the helper, not a literal.
+    for (const raw of [undefined, "false", "0", "true", "1", "TRUE", " true ", "treu", ""]) {
+      await withMultiRuntime(raw, async () => {
+        const stats = await api("GET", "/api/stats");
+        expect(stats.body.multiRuntimeEnabled).toBe(isMultiRuntimeEnabled());
+      });
+    }
+  });
+
+  test("is read per request, so a mid-process change is reflected", async () => {
+    // The value must not be captured at module load. `swarm_config` reloads
+    // mutate `process.env` in a running server, and a cached read would report
+    // the boot-time mode forever after.
+    await withMultiRuntime("true", async () => {
+      expect((await api("GET", "/api/stats")).body.multiRuntimeEnabled).toBe(true);
+    });
+    await withMultiRuntime("false", async () => {
+      expect((await api("GET", "/api/stats")).body.multiRuntimeEnabled).toBe(false);
+    });
+  });
+
+  test("never leaks the flag on the unauthenticated health endpoint", async () => {
+    // /health is public — server configuration must not be discoverable there.
+    for (const raw of ["true", "false", undefined]) {
+      await withMultiRuntime(raw, async () => {
+        const health = await api("GET", "/health");
+        expect(health.status).toBe(200);
+        expect(health.body.multiRuntimeEnabled).toBeUndefined();
+      });
+    }
+  });
+
+  test("leaves the existing steering flag on the payload untouched", async () => {
+    await withMultiRuntime("true", async () => {
+      const stats = await api("GET", "/api/stats");
+      expect(stats.body.steeringEnabled).toBeDefined();
+      expect(typeof stats.body.steeringEnabled).toBe("boolean");
+      expect(stats.body.agents).toBeDefined();
+      expect(stats.body.tasks).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `multiRuntimeEnabled` to the authenticated `GET /api/stats` response.
- Report the value through the same `isMultiRuntimeEnabled()` helper the server itself branches on.
- Keep `/health` unchanged and preserve the existing multi-runtime default and lifecycle semantics.

## Motivation

`MULTI_RUNTIME_ENABLED` controls whether the server tracks per-process runtime instances. When the mode is off, runtime-instance rows are intentionally never written — so from `GET /api/agents/{id}/runtime-instances` alone, an authenticated client cannot tell

- multi-runtime **enabled**, nothing registered yet, from
- multi-runtime **disabled**

Both are an empty list, and the two want different handling.

The existing config surfaces are not equivalent to the effective process state:

- `/api/config/env-presence` proves a key is *set*, not what value it holds — so `MULTI_RUNTIME_ENABLED=false` reads the same as `=true`.
- A persisted `swarm_config` row is not necessarily the effective value: `loadGlobalConfigsIntoEnv` injects with `override = false`, so a deployment env var wins over the stored row.
- `/health` deliberately carries no feature flags.

`/api/stats` already exposes authenticated effective operational state such as `steeringEnabled`, so the effective multi-runtime state belongs beside it. This gives clients an authoritative, non-secret signal without changing runtime behaviour.

## Behavior

The stats payload gains one additive field:

```json
{
  "steeringEnabled": true,
  "multiRuntimeEnabled": true
}
```

The value comes from `isMultiRuntimeEnabled()`, read per request rather than captured at module load, so a `swarm_config` reload is reflected the same way it is for every other consumer of the flag.

No changes to:

- the default value of `MULTI_RUNTIME_ENABLED`
- registration or runtime lifecycle
- scheduling/capacity behavior
- `/health`
- configuration precedence

Older clients can ignore the additive field.

## Testing

New focused coverage in `src/tests/multi-runtime-enabled-stats.test.ts` (7 tests), driven over real HTTP against `handleCore` + `handleStats`:

- flag unset → `false` (multi-runtime is opt-in)
- flag explicitly falsy (`"false"`, `"0"`) → `false`
- flag explicitly truthy (`"true"`, `"1"`) → `true`
- the field agrees with `isMultiRuntimeEnabled()` across `undefined`, `"false"`, `"0"`, `"true"`, `"1"`, `"TRUE"`, `" true "`, `"treu"`, `""` — asserted against the helper rather than a literal, so a hand-rolled second parse cannot drift from what the server actually branches on
- read per request, so a mid-process change is reflected rather than cached
- never present on the unauthenticated `/health`
- existing `steeringEnabled` / `agents` / `tasks` payload intact

Each test saves and restores `MULTI_RUNTIME_ENABLED` so the flag cannot leak into other tests.

Commands run:

```
bun run lint                             # pass (1336 files)
bun run tsc:check                        # pass
bun run docs:openapi                     # regenerated; openapi.json + docs-site/public/openapi.d.ts
bun run check:openapi-response-coverage  # pass (352 routes)
bun run check:rbac-coverage              # pass (59 verbs, 201 non-GET routes)
bash scripts/check-db-boundary.sh        # pass
bash scripts/check-api-key-boundary.sh   # pass
bun run test:root -- --parallel=4        # 8165 pass, 12 skip, 2 fail
```

The 2 failures are pre-existing and unrelated — both are timing-sensitive under full-suite parallel load on this machine. I verified they reproduce identically on a clean worktree of `upstream/main` (43f9c46) with no changes applied: `8158 pass / 12 skip / 2 fail`, the same two tests (`/api/fs REST > upload against a stalled agent-fs provider answers 504` and `db-query bounded execution (Fix 1) > caps saturation ... 429`). The +7 delta on this branch is exactly the 7 tests added here.

OpenAPI was regenerated; the stats 200 schema now carries `multiRuntimeEnabled: { "type": "boolean" }` in `required`.
