### PR TITLE
feat(ui): VITE_PLAUSIBLE_SCRIPT_ID picks the Plausible site for a build

### DIFF
--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -10,14 +10,22 @@ const packageJson = JSON.parse(
   version?: string;
 };
 
+/** Plausible site script id of the hosted dashboard (app.agent-swarm.dev). */
+const DEFAULT_PLAUSIBLE_SCRIPT_ID = "aDF5FACknjhykIUMd6n_a";
+
 /**
  * Plausible analytics, injected into index.html at build time only when
  * `VITE_PLAUSIBLE_ANALYTICS=1` (or `true`) is set. Our Vercel production
  * project sets it; self-hosted and local builds ship with no analytics script.
+ * `VITE_PLAUSIBLE_SCRIPT_ID` picks the Plausible site (the `pa-<id>.js` part
+ * of the snippet) so a second deployment, such as the public demo, reports to
+ * its own site instead of the hosted dashboard's.
  */
 function plausibleAnalytics(): Plugin {
   const flag = (process.env.VITE_PLAUSIBLE_ANALYTICS ?? "").trim().toLowerCase();
   const enabled = flag === "1" || flag === "true";
+  const scriptId =
+    (process.env.VITE_PLAUSIBLE_SCRIPT_ID ?? "").trim() || DEFAULT_PLAUSIBLE_SCRIPT_ID;
   return {
     name: "plausible-analytics",
     transformIndexHtml() {
@@ -25,7 +33,7 @@ function plausibleAnalytics(): Plugin {
       return [
         {
           tag: "script",
-          attrs: { async: true, src: "https://plausible.io/js/pa-aDF5FACknjhykIUMd6n_a.js" },
+          attrs: { async: true, src: `https://plausible.io/js/pa-${scriptId}.js` },
           injectTo: "head",
         },
         {

--- a/docs-site/content/docs/(documentation)/reference/environment-variables.mdx
+++ b/docs-site/content/docs/(documentation)/reference/environment-variables.mdx
@@ -398,6 +398,7 @@ Install: `bun add -g portless`. Enable HTTPS: `portless trust && portless proxy 
 | `VITE_USER_ID` | unset | Fixes the dashboard identity to an existing user. Requires `VITE_API_URL` and `VITE_API_KEY`. |
 | `VITE_DEMO_MODE` | `false` | Shows a diagonal live demo ribbon when set to `true` or `1`. |
 | `VITE_PLAUSIBLE_ANALYTICS` | unset | Build-time flag. Set to `1` to inject the Plausible analytics snippet into the dashboard's `index.html` during `bun run build`. Only our hosted dashboard sets it; self-hosted and local builds ship with no analytics script. |
+| `VITE_PLAUSIBLE_SCRIPT_ID` | hosted dashboard's id | Plausible site script id (the `pa-<id>.js` part of the snippet) used when `VITE_PLAUSIBLE_ANALYTICS` is on. Set it on a second deployment, such as the public demo, so it reports to its own Plausible site. |
 
 Vite includes every `VITE_*` value in public browser assets. Use a restricted credential and a
 demo-safe API deployment for fixed public dashboards.

--- a/docs-site/content/docs/(documentation)/ui/index.mdx
+++ b/docs-site/content/docs/(documentation)/ui/index.mdx
@@ -45,7 +45,7 @@ bun run build   # outputs apps/ui/dist/
 
 Deploy the `dist/` directory to your static host of choice (Vercel, Netlify, nginx, S3 + CDN, ...).
 
-Self-hosted builds contain no analytics. The hosted dashboard sets the build-time flag `VITE_PLAUSIBLE_ANALYTICS=1`, which injects a [Plausible](https://plausible.io) snippet; leave it unset to keep your build analytics-free.
+Self-hosted builds contain no analytics. The hosted dashboard sets the build-time flag `VITE_PLAUSIBLE_ANALYTICS=1`, which injects a [Plausible](https://plausible.io) snippet; leave it unset to keep your build analytics-free. `VITE_PLAUSIBLE_SCRIPT_ID` selects the Plausible site for a second deployment such as the public demo.
 
 For local development:
 


### PR DESCRIPTION
## Why

The Plausible snippet injected by `apps/ui/vite.config.ts` hard-codes the hosted dashboard's site script (`pa-aDF5FACknjhykIUMd6n_a.js`). The public demo at demo.agent-swarm.dev is a second Vercel deployment of the same app and needs to report to its own Plausible site.

## What

- `VITE_PLAUSIBLE_SCRIPT_ID` (build-time) selects the `pa-<id>.js` script. Default is the current hosted id, so app.agent-swarm.dev is unchanged.
- `VITE_PLAUSIBLE_ANALYTICS` unset still means no analytics script at all.
- Docs: environment-variables reference table and the UI page.

## Verification

- `VITE_PLAUSIBLE_ANALYTICS=1 VITE_PLAUSIBLE_SCRIPT_ID=b4MWaEuTxgPCpr7aAdBQD bun run build` → `dist/index.html` references `pa-b4MWaEuTxgPCpr7aAdBQD.js`.
- Flag on without the id → `pa-aDF5FACknjhykIUMd6n_a.js` (unchanged default).
- Flag off → zero `plausible` references in `dist/index.html`.
- `apps/ui` biome lint clean.

## Rollout

`VITE_PLAUSIBLE_SCRIPT_ID` is already set on the `agent-swarm-demo` Vercel project. After merge, set `VITE_PLAUSIBLE_ANALYTICS=1` there and redeploy; that order avoids a window where the demo reports to the dashboard's site.

https://claude.ai/code/session_016iBgCe9GuoPsyTbCF2rvqj
