### PR TITLE
feat(e2e): Slack visuals on PRs (legacy vs v2 screenshots from slack-mock)

### DIFF
--- a/.github/workflows/slack-visuals.yml
+++ b/.github/workflows/slack-visuals.yml
@@ -1,0 +1,113 @@
+# Informational job, not part of the merge gate. It runs the three Slack E2E scenarios twice
+# (legacy renderer, then SLACK_RENDER_V2=true), renders one PNG per Slack event from the
+# slack-mock journal, and upserts one sticky PR comment with both columns side by side.
+# Images live on the single-commit `ci-visuals` branch (rebuilt on every run, so history never
+# grows). Fork PRs have a read-only token and only get the artifact.
+name: Slack Visuals
+
+on:
+  pull_request:
+    paths:
+      - "src/slack/**"
+      - "src/prompts/**"
+      - "scripts/e2e/**"
+      - "slack-manifest.json"
+      - "bun.lock"
+      - ".github/workflows/slack-visuals.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: slack-visuals-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  visuals:
+    if: github.repository == 'desplega-ai/agent-swarm' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run legacy Slack E2E
+        id: legacy
+        continue-on-error: true
+        run: bun run e2e --only slack-mention,slack-follow-up,slack-failed-task --visuals visuals/legacy --json visuals/legacy.json
+
+      - name: Run v2 Slack E2E
+        id: v2
+        continue-on-error: true
+        run: bun run e2e --only slack-mention,slack-follow-up,slack-failed-task --sut-env SLACK_RENDER_V2=true --visuals visuals/v2 --json visuals/v2.json
+
+      - name: Render Slack visuals
+        if: always()
+        run: |
+          set -euo pipefail
+          if test -f visuals/legacy/manifest.json; then bun run e2e:visuals visuals/legacy; fi
+          if test -f visuals/v2/manifest.json; then bun run e2e:visuals visuals/v2; fi
+
+      - name: Upload Slack visuals
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: slack-visuals
+          path: visuals/
+          if-no-files-found: warn
+
+      - name: Publish Slack visuals
+        if: always() && github.event_name == 'pull_request'
+        id: publish
+        env:
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          publish_output=$(bash scripts/e2e/visuals-publish.sh visuals "$PR" "$HEAD_SHA")
+          printf '%s\n' "$publish_output"
+          base_url=$(printf '%s\n' "$publish_output" | tail -n 1)
+          echo "base_url=${base_url#base_url=}" >> "$GITHUB_OUTPUT"
+
+      - name: Post Slack visual preview
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_URL: ${{ steps.publish.outputs.base_url }}
+        run: |
+          set -euo pipefail
+          bun scripts/e2e/visuals-comment.ts \
+            --base-url "$BASE_URL" \
+            --profile legacy=visuals/legacy \
+            --profile v2=visuals/v2 \
+            --out comment.md \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --sha "$HEAD_SHA"
+          # --paginate emits one JSON array per page; --jq runs per page, so take the first id.
+          comment_id=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR/comments?per_page=100" \
+            --jq '.[] | select(.body | startswith("<!-- slack-visuals -->")) | .id' | head -n 1)
+          if [ -n "$comment_id" ]; then
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" --raw-field body="$(<comment.md)"
+          else
+            gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --raw-field body="$(<comment.md)"
+          fi
+
+      - name: Fail when Slack E2E failed
+        if: always()
+        run: |
+          if [ "${{ steps.legacy.outcome }}" != "success" ] || [ "${{ steps.v2.outcome }}" != "success" ]; then
+            echo "Slack visual E2E failed. See the uploaded artifact for partial output." >&2
+            exit 1
+          fi

--- a/LOCAL_TESTING.md
+++ b/LOCAL_TESTING.md
@@ -54,7 +54,9 @@ It writes `./e2e-results.json` by default.
 
 Every run also boots an in-process `@desplega.ai/slack-mock` before the API and starts the server with `NODE_ENV=test`,
 so Bolt connects to the mock over Socket Mode (the socket-mode guard refuses `NODE_ENV=development`).
-Scenarios drive that Slack workspace through `ctx.slack` (see `slack-mention`: mention, eyes reaction, task, threaded outcome).
+Scenarios drive that Slack workspace through `ctx.slack`.
+The Slack scenarios are `slack-mention`, `slack-follow-up`, and `slack-failed-task`.
+They cover a mention, a thread follow-up, and a failed task outcome.
 `ctx.db` is a read-only SQLite handle on the SUT database for assertions only; seed every fixture through the API.
 
 ```bash
@@ -66,6 +68,23 @@ bun run e2e --skip workflow-script-node
 bun run e2e --json /tmp/e2e.json --summary-md /tmp/e2e.md
 bun run e2e --min-route-coverage 4 --min-tool-coverage 3
 bun run e2e --keep
+```
+
+Use repeatable `--sut-env KEY=VALUE` flags to override environment variables for the spawned API server.
+Use `--visuals <dir>` to retain the Slack journal and write its `manifest.json` file.
+Render the journal with `bun run e2e:visuals <dir>`.
+
+Run both Slack rendering profiles locally:
+
+```bash
+env -u ANTHROPIC_API_KEY bun run e2e --only slack-mention,slack-follow-up,slack-failed-task --visuals /tmp/vis/legacy
+env -u ANTHROPIC_API_KEY bun run e2e --only slack-mention,slack-follow-up,slack-failed-task --sut-env SLACK_RENDER_V2=true --visuals /tmp/vis/v2
+```
+
+Then render both profiles:
+
+```bash
+bun run e2e:visuals /tmp/vis/legacy && bun run e2e:visuals /tmp/vis/v2
 ```
 
 Use `--harness claude,codex,pi,opencode` to add real worker legs after the contract layer.

--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.10",
-        "@desplega.ai/slack-mock": "^0.1.2",
+        "@desplega.ai/slack-mock": "^0.2.0",
         "@faker-js/faker": "^10.4.0",
         "@opencode-ai/plugin": "1.17.4",
         "@types/bun": "latest",
@@ -326,7 +326,7 @@
 
     "@desplega.ai/localtunnel": ["@desplega.ai/localtunnel@2.2.0", "", { "dependencies": { "axios": "0.21.4", "debug": "4.3.2", "openurl": "1.1.1", "yargs": "17.1.1" }, "bin": { "lt": "bin/lt.js" } }, "sha512-HK+ML28ey2FzIxutyQEhiJzkKSViGGNzlUV82Zov8SIXS/jAL+yt0O1fW/FV5v2BJGNINifOttP2JYN67bf9qA=="],
 
-    "@desplega.ai/slack-mock": ["@desplega.ai/slack-mock@0.1.2", "", { "bin": { "slack-mock": "dist/cli.js" } }, "sha512-WF/RadnVD/EG5HKtO5wJSa1V8rlXfQ6/2JSTnEskuiestlgn/0MDN5mx99TE2BwP2YZuekKct/SSHXREtPGqCw=="],
+    "@desplega.ai/slack-mock": ["@desplega.ai/slack-mock@0.2.0", "", { "bin": { "slack-mock": "dist/cli.js" } }, "sha512-LLZly6Mfm7MgGnDzBhctGs6kaS2ye4W8clwC9PKZ7jN4bgwtykrF9SEUcgTN4An23fg7r9PwvBhX45HdXSjAsw=="],
 
     "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.4", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.4", "@earendil-works/pi-telemetry": "^0.84.4", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-HyUnjaOXj6oN/6SNcr8A1J/ElRQA50FtIE0XUTSKAQVqmdlb9qdojOyUQwF/jULE5+yOEtGuVgi/N1RnBiNG+g=="],
 

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.10",
-    "@desplega.ai/slack-mock": "^0.1.2",
+    "@desplega.ai/slack-mock": "^0.2.0",
     "@faker-js/faker": "^10.4.0",
     "@opencode-ai/plugin": "1.17.4",
     "@types/bun": "latest",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "mono:dev": "turbo run dev",
     "test:root": "bash scripts/run-bun-tests.sh",
     "e2e": "bun scripts/e2e/run.ts",
+    "e2e:visuals": "bun scripts/e2e/visuals.ts",
     "e2e:codex-oauth-blob": "bun scripts/e2e/codex-oauth-blob.ts",
     "e2e:tsc": "bun tsc --noEmit -p scripts/e2e/tsconfig.json",
     "prepack": "bun run build:cli",

--- a/scripts/e2e/report.ts
+++ b/scripts/e2e/report.ts
@@ -39,6 +39,8 @@ export type Options = {
   keep: boolean;
   minRouteCoverage: number;
   minToolCoverage: number;
+  sutEnv: Record<string, string>;
+  visualsDir?: string;
 };
 
 export const helpText = `Usage: bun run e2e [options]
@@ -51,6 +53,8 @@ Options:
   --list                        Print contract scenario names and exit
   --json path                   JSON result path (default: ./e2e-results.json)
   --summary-md path             Optional Markdown summary path
+  --sut-env KEY=VALUE           Set a SUT environment variable (repeatable)
+  --visuals dir                 Write a Slack journal and visual manifest
   --keep                        Keep the database, logs, and temporary directories
   --min-route-coverage N        Minimum route coverage percent (default: 0)
   --min-tool-coverage N         Minimum MCP tool coverage percent (default: 0)
@@ -77,6 +81,12 @@ function coverageValue(value: string, flag: string): number {
   return number;
 }
 
+function sutEnvValue(value: string): [string, string] {
+  const separator = value.indexOf("=");
+  if (separator < 1) throw new Error("--sut-env requires KEY=VALUE");
+  return [value.slice(0, separator), value.slice(separator + 1)];
+}
+
 export function parseOptions(args: string[], scenarioNames: string[]): Options {
   const options: Options = {
     harness: [],
@@ -87,6 +97,7 @@ export function parseOptions(args: string[], scenarioNames: string[]): Options {
     keep: false,
     minRouteCoverage: 0,
     minToolCoverage: 0,
+    sutEnv: {},
   };
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]!;
@@ -96,6 +107,10 @@ export function parseOptions(args: string[], scenarioNames: string[]): Options {
     else if (arg === "--skip") options.skip = new Set(listValue(value()));
     else if (arg === "--json") options.jsonPath = value();
     else if (arg === "--summary-md") options.summaryPath = value();
+    else if (arg === "--sut-env") {
+      const [key, envValue] = sutEnvValue(value());
+      options.sutEnv[key] = envValue;
+    } else if (arg === "--visuals") options.visualsDir = value();
     else if (arg === "--min-route-coverage") options.minRouteCoverage = coverageValue(value(), arg);
     else if (arg === "--min-tool-coverage") options.minToolCoverage = coverageValue(value(), arg);
     else if (arg === "--list") options.list = true;

--- a/scripts/e2e/run.ts
+++ b/scripts/e2e/run.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { basename, resolve } from "node:path";
 import type { SlackMock } from "@desplega.ai/slack-mock";
 import { type Coverage, computeCoverage } from "./coverage";
 import { openReadOnlyDb, type ReadOnlyDb } from "./db";
@@ -19,11 +20,13 @@ import { auth } from "./scenarios/auth";
 import { configRoundtrip } from "./scenarios/config-roundtrip";
 import { health } from "./scenarios/health";
 import { mcpSurface } from "./scenarios/mcp-surface";
+import { slackFailedTask } from "./scenarios/slack-failed-task";
+import { slackFollowUp } from "./scenarios/slack-follow-up";
 import { slackMention } from "./scenarios/slack-mention";
 import { taskLifecycle } from "./scenarios/task-lifecycle";
 import { workflowScriptNode } from "./scenarios/workflow-script-node";
 import { type SlackHarness, startSlackMock, stopSlackMock } from "./slack";
-import { type Sut, startSut, stopSut, tailLog } from "./sut";
+import { repoRoot, type Sut, startSut, stopSut, tailLog } from "./sut";
 
 export type ScenarioContext = {
   api: ApiClient;
@@ -33,6 +36,7 @@ export type ScenarioContext = {
   db: ReadOnlyDb;
   slack: SlackMock;
   log: (message: string) => void;
+  markThread: (label: string, channel: string, ts: string) => void;
   nonce: string;
 };
 export type Scenario = { name: string; run: (ctx: ScenarioContext) => Promise<void> };
@@ -45,7 +49,11 @@ const scenarios: Scenario[] = [
   workflowScriptNode,
   configRoundtrip,
   slackMention,
+  slackFollowUp,
+  slackFailedTask,
 ];
+
+type ThreadMark = { scenario: string; label: string; channel: string; ts: string };
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -104,8 +112,16 @@ async function main(): Promise<number> {
 
   const started = Date.now();
   const startedAt = new Date(started).toISOString();
-  activeSlack = await startSlackMock(options.keep);
-  activeSut = await startSut(options.keep, activeSlack.mock.env);
+  const visualsDir = options.visualsDir ? resolve(options.visualsDir) : undefined;
+  const journalPath = visualsDir ? `${visualsDir}/slack-journal.jsonl` : undefined;
+  if (visualsDir && journalPath) {
+    await Bun.$`mkdir -p ${visualsDir}`.quiet();
+    await Bun.file(journalPath)
+      .delete()
+      .catch(() => {});
+  }
+  activeSlack = await startSlackMock(options.keep, journalPath);
+  activeSut = await startSut(options.keep, activeSlack.mock.env, options.sutEnv);
   try {
     await activeSlack.mock.waitForConnection(60_000);
   } catch (error) {
@@ -116,7 +132,7 @@ async function main(): Promise<number> {
   }
   activeDb = openReadOnlyDb(activeSut.dbPath);
   const api = createApiClient(activeSut.baseUrl, activeSut.apiKey);
-  const ctx: ScenarioContext = {
+  const ctx: Omit<ScenarioContext, "markThread"> = {
     api,
     connectMcp: createMcpConnector(activeSut.baseUrl, activeSut.apiKey),
     baseUrl: activeSut.baseUrl,
@@ -127,10 +143,19 @@ async function main(): Promise<number> {
     nonce: randomBytes(6).toString("hex"),
   };
   const scenarioResults: ScenarioResult[] = [];
+  const threadMarks: ThreadMark[] = [];
   for (const scenario of scenarios) {
     if (options.only && !options.only.has(scenario.name)) continue;
     if (options.skip.has(scenario.name)) continue;
-    const result = await runScenario(scenario, ctx);
+    const result = await runScenario(scenario, {
+      ...ctx,
+      markThread(label, channel, ts) {
+        if (!/^[a-z0-9-]+$/.test(label)) {
+          throw new Error(`Invalid visual thread label: ${label}`);
+        }
+        threadMarks.push({ scenario: scenario.name, label, channel, ts });
+      },
+    });
     scenarioResults.push(result);
     printScenario(result);
   }
@@ -188,6 +213,30 @@ async function main(): Promise<number> {
     ok,
   };
   await writeReports(result, options.jsonPath, options.summaryPath);
+  if (visualsDir) {
+    await Bun.write(
+      `${visualsDir}/manifest.json`,
+      `${JSON.stringify(
+        {
+          profile: basename(visualsDir),
+          sutEnv: options.sutEnv,
+          journal: "slack-journal.jsonl",
+          slackManifest: resolve(repoRoot, "slack-manifest.json"),
+          scenarios: scenarioResults.map((scenario) => ({
+            name: scenario.name,
+            status: scenario.status,
+            durationMs: scenario.durationMs,
+            error: scenario.error ?? null,
+            threads: threadMarks
+              .filter((thread) => thread.scenario === scenario.name)
+              .map(({ label, channel, ts }) => ({ label, channel, ts })),
+          })),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  }
   console.log(
     `${ok ? "PASS" : "FAIL"}: ${passes} passed, ${failures + harnessFailures} failed, ${skips} skipped`,
   );

--- a/scripts/e2e/scenarios/slack-failed-task.ts
+++ b/scripts/e2e/scenarios/slack-failed-task.ts
@@ -1,0 +1,42 @@
+import { expect } from "../http";
+import type { Scenario } from "../run";
+import {
+  ask,
+  claim,
+  findSlackTask,
+  finish,
+  registerLead,
+  waitForEyes,
+  waitForOutcome,
+  waitForReaction,
+} from "./slack-helpers";
+
+export const slackFailedTask: Scenario = {
+  name: "slack-failed-task",
+  async run(ctx) {
+    const leadId = await registerLead(ctx, "e2e-lead-failed");
+    const message = await ask(ctx, "deploy the hotfix to staging");
+    ctx.markThread("failed", "C0GENERAL0", message.ts);
+    await waitForEyes(ctx, message.ts);
+
+    const task = await findSlackTask(ctx, message.ts);
+    const taskId = String(task.id);
+    expect(
+      task.status === "pending",
+      `Slack task ${taskId} in general thread ${message.ts} is ${String(task.status)}, not pending`,
+    );
+    await claim(ctx, leadId, taskId);
+    await finish(ctx, leadId, taskId, {
+      status: "failed",
+      output: "Deploy aborted: the staging database migration 131 failed a checksum.",
+      failureReason: "migration checksum mismatch",
+    });
+
+    const outcome = await waitForOutcome(ctx, message.ts, "checksum");
+    expect(
+      outcome.bot_id === ctx.slack.bot.botId,
+      `Outcome in C0GENERAL0 thread ${message.ts} came from ${String(outcome.bot_id)}, expected the bot`,
+    );
+    await waitForReaction(ctx, message.ts, "x");
+  },
+};

--- a/scripts/e2e/scenarios/slack-follow-up.ts
+++ b/scripts/e2e/scenarios/slack-follow-up.ts
@@ -1,0 +1,70 @@
+import { expect } from "../http";
+import type { Scenario } from "../run";
+import {
+  ask,
+  claim,
+  findSlackTask,
+  finish,
+  registerLead,
+  waitForBotReply,
+  waitForEyes,
+  waitForOutcome,
+  waitForReaction,
+} from "./slack-helpers";
+
+export const slackFollowUp: Scenario = {
+  name: "slack-follow-up",
+  async run(ctx) {
+    const leadId = await registerLead(ctx, "e2e-lead-follow-up");
+    const firstAsk = await ask(ctx, "summarize the release notes");
+    ctx.markThread("follow-up", "C0GENERAL0", firstAsk.ts);
+    await waitForEyes(ctx, firstAsk.ts);
+
+    const reply = await waitForBotReply(ctx, firstAsk.ts);
+    expect(
+      reply.thread_ts === firstAsk.ts,
+      `Bot replied in general on thread ${String(reply.thread_ts)}, expected ${firstAsk.ts}`,
+    );
+
+    const firstTask = await findSlackTask(ctx, firstAsk.ts);
+    const firstTaskId = String(firstTask.id);
+    expect(
+      firstTask.status === "pending",
+      `Slack task ${firstTaskId} in general thread ${firstAsk.ts} is ${String(firstTask.status)}, not pending`,
+    );
+    await claim(ctx, leadId, firstTaskId);
+    const firstOutput = "Three changes shipped: faster polling, a new Slack tree, and cost badges.";
+    await finish(ctx, leadId, firstTaskId, { status: "completed", output: firstOutput });
+    await waitForOutcome(ctx, firstAsk.ts, firstOutput);
+    await waitForReaction(ctx, firstAsk.ts, "white_check_mark");
+
+    const followUp = await ask(ctx, "and now list the open follow-ups", firstAsk.ts);
+    await waitForEyes(ctx, followUp.ts);
+    const followUpTask = await findSlackTask(ctx, followUp.ts);
+    const followUpTaskId = String(followUpTask.id);
+    expect(
+      followUpTaskId !== firstTaskId,
+      `Follow-up in general at ts ${followUp.ts} reused Slack task ${firstTaskId}`,
+    );
+    expect(
+      followUpTask.slackTriggerMessageTs === followUp.ts,
+      `Follow-up task ${followUpTaskId} in general has trigger ts ${String(followUpTask.slackTriggerMessageTs)}, expected ${followUp.ts}`,
+    );
+    expect(
+      followUpTask.slackThreadTs === firstAsk.ts,
+      `Follow-up task ${followUpTaskId} in general has thread ts ${String(followUpTask.slackThreadTs)}, expected ${firstAsk.ts}`,
+    );
+    expect(
+      followUpTask.status === "pending",
+      `Follow-up task ${followUpTaskId} in general thread ${firstAsk.ts} is ${String(followUpTask.status)}, not pending`,
+    );
+    await claim(ctx, leadId, followUpTaskId);
+    const followUpOutput = "Two follow-ups are open: docs refresh and the retention PR.";
+    await finish(ctx, leadId, followUpTaskId, {
+      status: "completed",
+      output: followUpOutput,
+    });
+    await waitForOutcome(ctx, firstAsk.ts, followUpOutput);
+    await waitForReaction(ctx, followUp.ts, "white_check_mark");
+  },
+};

--- a/scripts/e2e/scenarios/slack-helpers.ts
+++ b/scripts/e2e/scenarios/slack-helpers.ts
@@ -1,0 +1,148 @@
+import type { SlackMessage } from "@desplega.ai/slack-mock";
+import { asRecord, expect, expectStatus, pollUntil } from "../http";
+import type { ScenarioContext } from "../run";
+
+export async function registerLead(ctx: ScenarioContext, name: string): Promise<string> {
+  const response = await ctx.api("POST", "/api/agents", {
+    body: { name, isLead: true },
+  });
+  expectStatus(response, [201], `register ${name}`);
+  const leadId = asRecord(response.json).id;
+  expect(typeof leadId === "string", `Registered agent ${name} has no id`);
+  return leadId;
+}
+
+export async function ask(
+  ctx: ScenarioContext,
+  text: string,
+  threadTs?: string,
+): Promise<SlackMessage> {
+  return ctx.slack.postMessage({
+    channel: "general",
+    user: "alice",
+    text: `<@${ctx.slack.bot.userId}> ${text}`,
+    ...(threadTs ? { thread_ts: threadTs } : {}),
+  });
+}
+
+export async function waitForReaction(
+  ctx: ScenarioContext,
+  ts: string,
+  name: string,
+  timeoutMs = 30_000,
+): Promise<void> {
+  const found = await pollUntil(
+    () =>
+      ctx.slack
+        .messages("general")
+        .find((message) => message.ts === ts)
+        ?.reactions?.some((reaction) => reaction.name === name) === true,
+    timeoutMs,
+  );
+  expect(found, `Message ${ts} in general never got a ${name} reaction within ${timeoutMs}ms`);
+}
+
+export async function waitForEyes(ctx: ScenarioContext, ts: string): Promise<void> {
+  const reaction = await ctx.slack
+    .waitForApiCall("reactions.add", {
+      timeoutMs: 30_000,
+      where: (call) => call.args.name === "eyes" && call.args.timestamp === ts,
+    })
+    .catch((error) => {
+      throw new Error(
+        `eyes reaction on general ts ${ts}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+  expect(
+    reaction.ok === true,
+    `reactions.add in general on ts ${ts} failed: ${reaction.error ?? "no error reported"}`,
+  );
+}
+
+export async function waitForBotReply(
+  ctx: ScenarioContext,
+  threadTs: string,
+): Promise<SlackMessage> {
+  try {
+    return await ctx.slack.waitForMessage(
+      { channel: "general", thread_ts: threadTs, from: "bot" },
+      { timeoutMs: 30_000 },
+    );
+  } catch (error) {
+    throw new Error(
+      `bot reply in C0GENERAL0 thread ${threadTs}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+export async function findSlackTask(
+  ctx: ScenarioContext,
+  triggerTs: string,
+): Promise<Record<string, unknown>> {
+  let task: Record<string, unknown> | undefined;
+  const found = await pollUntil(async () => {
+    const response = await ctx.api("GET", "/api/tasks?source=slack&fields=full&limit=50");
+    expectStatus(response, [200], `list slack tasks for general ts ${triggerTs}`);
+    const tasks = asRecord(response.json).tasks;
+    expect(Array.isArray(tasks), `Task list for general ts ${triggerTs} has no tasks array`);
+    const records = tasks.map(asRecord);
+    task =
+      records.find((row) => row.slackTriggerMessageTs === triggerTs) ??
+      records.find((row) => row.slackThreadTs === triggerTs);
+    return task !== undefined;
+  }, 30_000);
+  expect(found && task, `No Slack task for general ts ${triggerTs} within 30 seconds`);
+  return task;
+}
+
+export async function claim(ctx: ScenarioContext, leadId: string, taskId: string): Promise<void> {
+  expectStatus(
+    await ctx.api("GET", "/api/poll", { agentId: leadId }),
+    [200],
+    `agent ${leadId} claims Slack task ${taskId}`,
+  );
+  const claimed = await pollUntil(async () => {
+    const response = await ctx.api("GET", `/api/tasks/${taskId}`);
+    expectStatus(response, [200], `read claimed Slack task ${taskId}`);
+    return asRecord(response.json).status === "in_progress";
+  }, 15_000);
+  expect(claimed, `Slack task ${taskId} did not reach in_progress within 15 seconds`);
+}
+
+export async function finish(
+  ctx: ScenarioContext,
+  leadId: string,
+  taskId: string,
+  body: {
+    status: "completed" | "failed";
+    output?: string;
+    failureReason?: string;
+    force?: boolean;
+  },
+): Promise<void> {
+  expectStatus(
+    await ctx.api("POST", `/api/tasks/${taskId}/finish`, { agentId: leadId, body }),
+    [200],
+    `finish Slack task ${taskId}`,
+  );
+}
+
+export async function waitForOutcome(
+  ctx: ScenarioContext,
+  threadTs: string,
+  needle: string,
+): Promise<SlackMessage> {
+  try {
+    return await ctx.slack.waitForMessage(
+      (message) =>
+        message.channel === "C0GENERAL0" &&
+        message.thread_ts === threadTs &&
+        JSON.stringify(message).includes(needle),
+      { timeoutMs: 30_000 },
+    );
+  } catch (error) {
+    throw new Error(
+      `task outcome in C0GENERAL0 thread ${threadTs}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/scripts/e2e/scenarios/slack-mention.ts
+++ b/scripts/e2e/scenarios/slack-mention.ts
@@ -1,14 +1,16 @@
-import { asRecord, expect, expectStatus, pollUntil } from "../http";
+import { expect } from "../http";
 import type { Scenario } from "../run";
-
-// The mock's timeout errors do not say which channel or thread was watched.
-async function waitNamed<T>(what: string, wait: Promise<T>): Promise<T> {
-  try {
-    return await wait;
-  } catch (error) {
-    throw new Error(`${what}: ${error instanceof Error ? error.message : String(error)}`);
-  }
-}
+import {
+  ask,
+  claim,
+  findSlackTask,
+  finish,
+  registerLead,
+  waitForBotReply,
+  waitForEyes,
+  waitForOutcome,
+  waitForReaction,
+} from "./slack-helpers";
 
 export const slackMention: Scenario = {
   name: "slack-mention",
@@ -23,55 +25,18 @@ export const slackMention: Scenario = {
       `Expected one socket mode connection, found ${ctx.slack.hub.connectionCount}`,
     );
 
-    const leadResponse = await ctx.api("POST", "/api/agents", {
-      body: { name: `e2e-lead-${ctx.nonce}`, isLead: true },
-    });
-    expectStatus(leadResponse, [201], "register lead");
-    const leadId = asRecord(leadResponse.json).id;
-    expect(typeof leadId === "string", "Registered lead has no id");
+    const leadId = await registerLead(ctx, "e2e-lead-mention");
+    const message = await ask(ctx, "say hello from the E2E worker");
+    ctx.markThread("mention", "C0GENERAL0", message.ts);
+    await waitForEyes(ctx, message.ts);
 
-    const ask = await ctx.slack.postMessage({
-      channel: "general",
-      user: "alice",
-      text: `<@${ctx.slack.bot.userId}> say hello from e2e ${ctx.nonce}`,
-    });
-
-    const reaction = await waitNamed(
-      `eyes reaction on general ts ${ask.ts}`,
-      ctx.slack.waitForApiCall("reactions.add", {
-        timeoutMs: 30_000,
-        where: (call) => call.args.name === "eyes" && call.args.timestamp === ask.ts,
-      }),
-    );
+    const reply = await waitForBotReply(ctx, message.ts);
     expect(
-      reaction.ok === true,
-      `reactions.add on ts ${ask.ts} failed: ${reaction.error ?? "no error reported"}`,
+      reply.thread_ts === message.ts,
+      `Bot replied in general on thread ${String(reply.thread_ts)}, expected ${message.ts}`,
     );
 
-    const reply = await waitNamed(
-      `bot reply in the general thread ${ask.ts}`,
-      ctx.slack.waitForMessage(
-        { channel: "general", thread_ts: ask.ts, from: "bot" },
-        { timeoutMs: 30_000 },
-      ),
-    );
-    expect(
-      reply.thread_ts === ask.ts,
-      `Bot replied on thread ${String(reply.thread_ts)}, expected ${ask.ts}`,
-    );
-
-    let task: Record<string, unknown> | undefined;
-    const listed = await pollUntil(async () => {
-      const response = await ctx.api("GET", "/api/tasks?source=slack&fields=full&limit=50");
-      expectStatus(response, [200], "list slack tasks");
-      const tasks = asRecord(response.json).tasks;
-      expect(Array.isArray(tasks), "Task list has no tasks array");
-      task = tasks
-        .map(asRecord)
-        .find((row) => row.slackThreadTs === ask.ts || row.slackTriggerMessageTs === ask.ts);
-      return task !== undefined;
-    }, 30_000);
-    expect(listed && task, `No slack task for thread ${ask.ts} within 30 seconds`);
+    const task = await findSlackTask(ctx, message.ts);
     const taskId = String(task.id);
     expect(
       task.status === "pending",
@@ -86,56 +51,15 @@ export const slackMention: Scenario = {
       `agent_tasks row for ${taskId} has source ${row?.source ?? "<missing row>"}`,
     );
 
-    // Exactly one poll: polling again while the task runs looks like a crash.
-    expectStatus(
-      await ctx.api("GET", "/api/poll", { agentId: leadId }),
-      [200],
-      "lead claims the slack task",
-    );
-    const claimed = await pollUntil(async () => {
-      const response = await ctx.api("GET", `/api/tasks/${taskId}`);
-      expectStatus(response, [200], "read the claimed slack task");
-      return asRecord(response.json).status === "in_progress";
-    }, 15_000);
-    expect(claimed, `Slack task ${taskId} did not reach in_progress within 15 seconds`);
+    await claim(ctx, leadId, taskId);
+    const output = "Hello from the E2E worker.";
+    await finish(ctx, leadId, taskId, { status: "completed", output });
 
-    const output = `hello from the e2e worker ${ctx.nonce}`;
-    expectStatus(
-      await ctx.api("POST", `/api/tasks/${taskId}/finish`, {
-        agentId: leadId,
-        body: { status: "completed", output },
-      }),
-      [200],
-      "finish the slack task",
-    );
-
-    const outcome = await waitNamed(
-      `task outcome in C0GENERAL0 thread ${ask.ts}`,
-      ctx.slack.waitForMessage(
-        (message) =>
-          message.channel === "C0GENERAL0" &&
-          message.thread_ts === ask.ts &&
-          JSON.stringify(message).includes(output),
-        { timeoutMs: 30_000 },
-      ),
-    );
+    const outcome = await waitForOutcome(ctx, message.ts, output);
     expect(
       outcome.bot_id === ctx.slack.bot.botId,
       `Outcome message came from ${String(outcome.bot_id)}, expected the bot`,
     );
-
-    // The Slack watcher ticks every three seconds before it flips the reaction.
-    const acknowledged = await pollUntil(
-      () =>
-        ctx.slack
-          .messages("general")
-          .find((message) => message.ts === ask.ts)
-          ?.reactions?.some((entry) => entry.name === "white_check_mark") === true,
-      30_000,
-    );
-    expect(
-      acknowledged,
-      `Message ${ask.ts} in general never got a white_check_mark within 30 seconds`,
-    );
+    await waitForReaction(ctx, message.ts, "white_check_mark");
   },
 };

--- a/scripts/e2e/slack.ts
+++ b/scripts/e2e/slack.ts
@@ -5,9 +5,9 @@ import { repoRoot } from "./sut";
 export type SlackHarness = { mock: SlackMock; dataFile?: string };
 
 // Started before the SUT so the API server finds a live mock Slack on boot.
-export async function startSlackMock(keep: boolean): Promise<SlackHarness> {
+export async function startSlackMock(keep: boolean, journalPath?: string): Promise<SlackHarness> {
   const stamp = `${Date.now()}-${randomBytes(4).toString("hex")}`;
-  const dataFile = keep ? `/tmp/e2e-slack-${stamp}.jsonl` : undefined;
+  const dataFile = journalPath ?? (keep ? `/tmp/e2e-slack-${stamp}.jsonl` : undefined);
   const mock = await SlackMock.start({
     port: 0,
     manifest: `${repoRoot}/slack-manifest.json`,

--- a/scripts/e2e/sut.ts
+++ b/scripts/e2e/sut.ts
@@ -53,7 +53,11 @@ export async function tailLog(path: string, lines: number): Promise<string> {
   return text.split("\n").slice(-lines).join("\n");
 }
 
-export async function startSut(keep: boolean, slackEnv: Record<string, string>): Promise<Sut> {
+export async function startSut(
+  keep: boolean,
+  slackEnv: Record<string, string>,
+  extraEnv: Record<string, string> = {},
+): Promise<Sut> {
   const stamp = `${Date.now()}-${randomBytes(4).toString("hex")}`;
   const port = await freePort();
   const apiKey = randomBytes(16).toString("hex");
@@ -85,6 +89,7 @@ export async function startSut(keep: boolean, slackEnv: Record<string, string>):
     AGENTMAIL_DISABLE: "true",
     AGENTMAIL_API_KEY: "",
     ANONYMIZED_TELEMETRY: "false",
+    ...extraEnv,
   };
   const writer = Bun.file(logPath).writer();
   const child = Bun.spawn(["bun", "run", "src/http.ts"], {

--- a/scripts/e2e/visuals-comment.ts
+++ b/scripts/e2e/visuals-comment.ts
@@ -1,0 +1,231 @@
+import { parseArgs } from "node:util";
+
+type Frame = {
+  file: string;
+  index: number;
+  kind: string;
+};
+
+type Thread = {
+  label: string;
+  channel: string;
+  ts: string;
+  frames: Frame[];
+  gif: string | null;
+  finalThread: string;
+  finalDesktop: string;
+};
+
+type Scenario = {
+  name: string;
+  status: string;
+  error: string | null;
+  threads: Thread[];
+};
+
+type VisualIndex = {
+  profile: string;
+  channel: string;
+  scenarios: Scenario[];
+};
+
+type Profile = {
+  name: string;
+  /** Null when the profile has no index.json (its E2E run or render failed). */
+  index: VisualIndex | null;
+};
+
+function required(value: string | undefined, flag: string): string {
+  if (!value) throw new Error(`${flag} is required`);
+  return value;
+}
+
+function markdownCell(value: string): string {
+  return value.replaceAll("|", "\\|").replaceAll("\n", "<br>");
+}
+
+function imageUrl(baseUrl: string, profile: string, file: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/${profile.replace(/^\/+|\/+$/g, "")}/${file.replace(/^\/+/, "")}`;
+}
+
+function image(baseUrl: string, profile: string, file: string): string {
+  return `<img src="${imageUrl(baseUrl, profile, file)}" width="420">`;
+}
+
+function table(profiles: Profile[], cells: (profile: Profile) => string): string[] {
+  return [
+    `| ${profiles.map((profile) => markdownCell(profile.name)).join(" | ")} |`,
+    `| ${profiles.map(() => "---").join(" | ")} |`,
+    `| ${profiles.map(cells).join(" | ")} |`,
+  ];
+}
+
+function scenarioFor(profile: Profile, name: string): Scenario | undefined {
+  return profile.index?.scenarios.find((scenario) => scenario.name === name);
+}
+
+function scenarioCell(
+  profile: Profile,
+  scenario: Scenario | undefined,
+  baseUrl: string,
+  file: (thread: Thread) => string | null,
+  missingFile = "not recorded",
+): string {
+  if (!profile.index) return "not rendered";
+  if (!scenario) return "not recorded";
+  const files = scenario.threads.map(file);
+  const images = files
+    .map((value) => (value ? image(baseUrl, profile.name, value) : missingFile))
+    .join("<br>");
+  if (scenario.status !== "pass") {
+    // A failed scenario may still have frames from the steps that ran before the failure.
+    const status = `**${scenario.status.toUpperCase()}**: ${markdownCell(scenario.error ?? "No error reported")}`;
+    return files.length === 0 ? status : `${status}<br>${images}`;
+  }
+  if (files.length === 0) return "not recorded";
+  return images;
+}
+
+function mainSection(
+  profiles: Profile[],
+  scenarioNames: string[],
+  baseUrl: string,
+  intro: string,
+  includeSteps: boolean,
+): string[] {
+  const lines = ["<!-- slack-visuals -->", "", "### Slack rendering preview", "", intro, ""];
+
+  for (const name of scenarioNames) {
+    lines.push(
+      `#### ${name}`,
+      "",
+      ...table(profiles, (profile) =>
+        scenarioCell(profile, scenarioFor(profile, name), baseUrl, (thread) => thread.finalThread),
+      ),
+    );
+    if (includeSteps) {
+      lines.push(
+        "",
+        "<details><summary>Step by step</summary>",
+        "",
+        ...table(profiles, (profile) => {
+          const scenario = scenarioFor(profile, name);
+          return scenarioCell(
+            profile,
+            scenario,
+            baseUrl,
+            (thread) => thread.gif,
+            "no ffmpeg on the runner",
+          );
+        }),
+        "",
+        "</details>",
+      );
+    }
+    lines.push("");
+  }
+  return lines;
+}
+
+function desktopSection(profiles: Profile[], scenarioNames: string[], baseUrl: string): string[] {
+  const lines = ["<details><summary>Desktop layout and channel</summary>", ""];
+  for (const name of scenarioNames) {
+    lines.push(
+      `##### ${name}`,
+      "",
+      ...table(profiles, (profile) =>
+        scenarioCell(profile, scenarioFor(profile, name), baseUrl, (thread) => thread.finalDesktop),
+      ),
+      "",
+    );
+  }
+  lines.push(
+    "##### Channel",
+    "",
+    ...table(profiles, (profile) =>
+      profile.index ? image(baseUrl, profile.name, profile.index.channel) : "not rendered",
+    ),
+    "",
+    "</details>",
+    "",
+  );
+  return lines;
+}
+
+async function readProfile(argument: string): Promise<Profile> {
+  const separator = argument.indexOf("=");
+  if (separator < 1 || separator === argument.length - 1) {
+    throw new Error(`--profile must use NAME=DIR: ${argument}`);
+  }
+  const name = argument.slice(0, separator);
+  const directory = argument.slice(separator + 1);
+  const indexPath = `${directory.replace(/\/+$/, "")}/index.json`;
+  if (!(await Bun.file(indexPath).exists())) {
+    console.error(`${name}: no ${indexPath}; the column will read "not rendered"`);
+    return { name, index: null };
+  }
+  try {
+    return { name, index: (await Bun.file(indexPath).json()) as VisualIndex };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Could not read ${indexPath}: ${message}`);
+  }
+}
+
+const { values } = parseArgs({
+  options: {
+    "base-url": { type: "string" },
+    profile: { type: "string", multiple: true },
+    out: { type: "string" },
+    "run-url": { type: "string" },
+    sha: { type: "string" },
+  },
+});
+
+const baseUrl = required(values["base-url"], "--base-url");
+const outputPath = required(values.out, "--out");
+const profiles = await Promise.all((values.profile ?? []).map(readProfile));
+if (profiles.length === 0) throw new Error("At least one --profile is required");
+if (profiles.every((profile) => profile.index === null)) {
+  throw new Error("No profile has an index.json; nothing to render");
+}
+
+const scenarioNames = [
+  ...new Set(
+    profiles.flatMap((profile) =>
+      (profile.index?.scenarios ?? []).map((scenario) => scenario.name),
+    ),
+  ),
+];
+const sha = values.sha ? values.sha.slice(0, 7) : "unknown";
+const run = values["run-url"] ? ` [Workflow run](${values["run-url"]}).` : "";
+const intro = `Rendered by slack-mock from the black-box E2E journal. Commit ${sha}.${run}`;
+
+function render(includeSteps: boolean, includeDesktop: boolean, note?: string): string {
+  const lines = mainSection(profiles, scenarioNames, baseUrl, intro, includeSteps);
+  if (includeDesktop) lines.push(...desktopSection(profiles, scenarioNames, baseUrl));
+  if (note) lines.push(note, "");
+  return lines.join("\n");
+}
+
+let comment = render(true, true);
+if (comment.length > 60_000) {
+  comment = render(
+    true,
+    false,
+    "Desktop layout omitted because the comment exceeded 60,000 characters.",
+  );
+}
+if (comment.length > 60_000) {
+  comment = render(
+    false,
+    false,
+    "Desktop layout and step-by-step images omitted because the comment exceeded 60,000 characters.",
+  );
+}
+if (comment.length > 60_000) {
+  const note =
+    "Additional scenario content omitted because the comment exceeded 60,000 characters.";
+  comment = `${comment.slice(0, 60_000 - note.length - 2)}\n\n${note}\n`;
+}
+await Bun.write(outputPath, comment);

--- a/scripts/e2e/visuals-publish.sh
+++ b/scripts/e2e/visuals-publish.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Publish rendered Slack visuals for one PR to the `ci-visuals` branch.
+# The branch is rebuilt as a single commit on every run, so history never grows, and
+# --force-with-lease guards against a concurrent run from another PR (retry on rejection).
+# Prints `base_url=<raw.githubusercontent.com prefix>` on the last line.
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <out-root> <pr-number> <head-sha>" >&2
+  exit 1
+fi
+
+out_root=$1
+pr_number=$2
+head_sha=$3
+sha7=${head_sha:0:7}
+
+if [ ! -d "$out_root" ]; then
+  echo "Output root does not exist: $out_root" >&2
+  exit 1
+fi
+out_root=$(cd "$out_root" && pwd -P)
+
+repository=${GITHUB_REPOSITORY:-}
+if [ -z "$repository" ]; then
+  remote_url=$(git remote get-url origin)
+  case "$remote_url" in
+    git@github.com:*) repository=${remote_url#git@github.com:} ;;
+    https://github.com/*) repository=${remote_url#https://github.com/} ;;
+    ssh://git@github.com/*) repository=${remote_url#ssh://git@github.com/} ;;
+    *)
+      echo "Cannot derive GitHub repository from origin: $remote_url" >&2
+      exit 1
+      ;;
+  esac
+  repository=${repository%.git}
+fi
+
+if [[ "$repository" != */* ]]; then
+  echo "GITHUB_REPOSITORY must be owner/repo: $repository" >&2
+  exit 1
+fi
+
+worktree_dir=""
+
+cleanup() {
+  if [ -n "$worktree_dir" ]; then
+    git worktree remove --force "$worktree_dir" >/dev/null 2>&1 || rm -rf "$worktree_dir"
+    worktree_dir=""
+  fi
+  git branch -D ci-visuals-build >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+for attempt in 1 2 3; do
+  fetched_sha=""
+  if git fetch origin ci-visuals; then
+    fetched_sha=$(git rev-parse FETCH_HEAD)
+  fi
+
+  worktree_dir=$(mktemp -d)
+  rmdir "$worktree_dir"
+  git worktree add --detach "$worktree_dir"
+  (
+    cd "$worktree_dir"
+    git checkout --orphan ci-visuals-build
+    git rm -rf . >/dev/null 2>&1 || true
+    git clean -fdx >/dev/null
+    if [ -n "$fetched_sha" ]; then
+      git checkout "$fetched_sha" -- .
+    fi
+
+    target="pr-$pr_number/$sha7"
+    rm -rf "pr-$pr_number"
+    for source_dir in "$out_root"/*; do
+      [ -d "$source_dir" ] || continue
+      profile=$(basename "$source_dir")
+      # A profile whose E2E run or render failed has no index.json; publish the others.
+      if [ ! -f "$source_dir/index.json" ]; then
+        echo "Skipping $profile: no index.json in $source_dir" >&2
+        continue
+      fi
+      for required_file in channel.png frames; do
+        if [ ! -e "$source_dir/$required_file" ]; then
+          echo "Missing $required_file in $source_dir" >&2
+          exit 1
+        fi
+      done
+      mkdir -p "$target/$profile"
+      cp "$source_dir/index.json" "$target/$profile/"
+      cp "$source_dir/channel.png" "$target/$profile/"
+      cp -R "$source_dir/frames" "$target/$profile/"
+    done
+    if [ ! -d "$target" ]; then
+      echo "No profile with an index.json found in $out_root" >&2
+      exit 1
+    fi
+    date -u +%FT%TZ > "pr-$pr_number/updated-at"
+
+    now=$(date -u +%s)
+    for pr_dir in pr-*; do
+      [ -d "$pr_dir" ] || continue
+      [ -f "$pr_dir/updated-at" ] || continue
+      updated_at=$(<"$pr_dir/updated-at")
+      if updated_seconds=$(date --date "$updated_at" +%s 2>/dev/null); then
+        :
+      elif updated_seconds=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$updated_at" +%s 2>/dev/null); then
+        :
+      else
+        continue
+      fi
+      if [ $((now - updated_seconds)) -gt $((30 * 24 * 60 * 60)) ]; then
+        rm -rf "$pr_dir"
+      fi
+    done
+
+    git add -A
+    git -c user.name='github-actions[bot]' \
+      -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+      commit --allow-empty -m "visuals: pr-$pr_number $sha7"
+  )
+
+  if git -C "$worktree_dir" push --force-with-lease="refs/heads/ci-visuals:$fetched_sha" origin HEAD:refs/heads/ci-visuals; then
+    cleanup
+    echo "base_url=https://raw.githubusercontent.com/$repository/ci-visuals/pr-$pr_number/$sha7"
+    exit 0
+  fi
+
+  echo "Push rejected on attempt $attempt of 3. Retrying." >&2
+  cleanup
+done
+
+echo "Could not publish ci-visuals after 3 attempts." >&2
+exit 1

--- a/scripts/e2e/visuals.ts
+++ b/scripts/e2e/visuals.ts
@@ -1,5 +1,5 @@
-import { basename, join, resolve } from "node:path";
-import { SlackMock, screenshot } from "@desplega.ai/slack-mock";
+import { basename, join, relative, resolve } from "node:path";
+import { frames, SlackMock, screenshot } from "@desplega.ai/slack-mock";
 
 type ManifestThread = { label: string; channel: string; ts: string };
 type ManifestScenario = {
@@ -16,10 +16,6 @@ type VisualManifest = {
   slackManifest: string;
   scenarios: ManifestScenario[];
 };
-type JournalEntry = {
-  kind: string;
-  message?: { ts?: string; thread_ts?: string };
-};
 type Frame = { file: string; index: number; kind: string };
 type RenderedThread = ManifestThread & {
   frames: Frame[];
@@ -27,15 +23,6 @@ type RenderedThread = ManifestThread & {
   finalThread: string;
   finalDesktop: string;
 };
-
-const frameKinds = new Set([
-  "message.add",
-  "message.update",
-  "message.delete",
-  "reaction.add",
-  "reaction.remove",
-  "file.add",
-]);
 
 type Options = {
   visualsDir: string;
@@ -81,28 +68,6 @@ function parseOptions(args: string[]): Options {
   return options;
 }
 
-async function renderFromJournal(
-  dataFile: string,
-  slackManifest: string,
-  path: string,
-  out: string,
-  width: number,
-  height: number,
-): Promise<void> {
-  const mock = await SlackMock.start({
-    port: 0,
-    seed: false,
-    dataFile,
-    manifest: slackManifest,
-    log: false,
-  });
-  try {
-    await screenshot(`${mock.baseUrl}${path}`, { out, width, height });
-  } finally {
-    await mock.stop();
-  }
-}
-
 async function createGif(ffmpeg: string, threadDir: string, frameFiles: string[]): Promise<void> {
   const listPath = join(threadDir, "frames.txt");
   const lastFrame = basename(frameFiles.at(-1)!);
@@ -138,138 +103,94 @@ async function createGif(ffmpeg: string, threadDir: string, frameFiles: string[]
   }
 }
 
-function relevantEntries(entries: JournalEntry[], threadTs: string): number[] {
-  const result: number[] = [];
-  for (const [index, entry] of entries.entries()) {
-    if (
-      frameKinds.has(entry.kind) &&
-      (entry.message?.ts === threadTs || entry.message?.thread_ts === threadTs)
-    ) {
-      result.push(index + 1);
-    }
-  }
-  return result;
-}
-
 async function main(): Promise<void> {
   const options = parseOptions(process.argv.slice(2));
   const manifest = JSON.parse(
     await Bun.file(join(options.visualsDir, "manifest.json")).text(),
   ) as VisualManifest;
   const journalPath = join(options.visualsDir, manifest.journal);
-  const journalLines = (await Bun.file(journalPath).text())
-    .split("\n")
-    .filter((line) => line.trim() !== "");
-  const entries = journalLines.map((line) => JSON.parse(line) as JournalEntry);
-  const prefixDir = (await Bun.$`mktemp -d`.text()).trim();
   const ffmpeg = options.noGif ? undefined : Bun.which("ffmpeg");
   if (!options.noGif && !ffmpeg) console.log("ffmpeg not found; step GIFs will be omitted.");
+  const relativeTo = (path: string) => relative(options.visualsDir, path);
 
-  try {
-    const renderedScenarios: Array<{
-      name: string;
-      status: "pass" | "fail" | "skip";
-      error: string | null;
-      threads: RenderedThread[];
-    }> = [];
+  const renderedScenarios: Array<{
+    name: string;
+    status: "pass" | "fail" | "skip";
+    error: string | null;
+    threads: RenderedThread[];
+  }> = [];
 
-    for (const scenario of manifest.scenarios) {
-      const renderedThreads: RenderedThread[] = [];
-      for (const thread of scenario.threads) {
-        const relativeDir = `frames/${scenario.name}/${thread.label}`;
-        const threadDir = join(options.visualsDir, relativeDir);
-        await Bun.$`mkdir -p ${threadDir}`.quiet();
-        const indexes = relevantEntries(entries, thread.ts);
-        if (indexes.length === 0) {
-          throw new Error(
-            `No visual journal events found for ${thread.channel} thread ${thread.ts}`,
-          );
-        }
-
-        const frames: Frame[] = [];
-        const frameFiles: string[] = [];
-        for (const [frameIndex, journalIndex] of indexes.entries()) {
-          const entry = entries[journalIndex - 1]!;
-          const prefixPath = join(prefixDir, `prefix-${journalIndex}.jsonl`);
-          await Bun.write(prefixPath, `${journalLines.slice(0, journalIndex).join("\n")}\n`);
-          const frameName = `${String(frameIndex + 1).padStart(2, "0")}-${entry.kind}.png`;
-          const relativeFrame = `${relativeDir}/${frameName}`;
-          const frameFile = join(options.visualsDir, relativeFrame);
-          await renderFromJournal(
-            prefixPath,
-            manifest.slackManifest,
-            `/c/${thread.channel}/t/${thread.ts}`,
-            frameFile,
-            options.width,
-            options.height,
-          );
-          frames.push({ file: relativeFrame, index: journalIndex, kind: entry.kind });
-          frameFiles.push(frameFile);
-        }
-
-        const finalThread = `${relativeDir}/final-thread.png`;
-        await Bun.write(join(options.visualsDir, finalThread), Bun.file(frameFiles.at(-1)!));
-        const gif = ffmpeg ? `${relativeDir}/steps.gif` : null;
-        if (ffmpeg) await createGif(ffmpeg, threadDir, frameFiles);
-        renderedThreads.push({
-          ...thread,
-          frames,
-          gif,
-          finalThread,
-          finalDesktop: `${relativeDir}/final-desktop.png`,
-        });
-      }
-      renderedScenarios.push({
-        name: scenario.name,
-        status: scenario.status,
-        error: scenario.error,
-        threads: renderedThreads,
+  for (const scenario of manifest.scenarios) {
+    const renderedThreads: RenderedThread[] = [];
+    for (const thread of scenario.threads) {
+      const threadDir = join(options.visualsDir, "frames", scenario.name, thread.label);
+      // One PNG per journal line that touched the thread, plus final-thread.png and
+      // final-desktop.png, all rendered by slack-mock from the journal in memory.
+      const result = await frames({
+        journal: journalPath,
+        channel: thread.channel,
+        thread: thread.ts,
+        out: threadDir,
+        manifest: manifest.slackManifest,
+        width: options.width,
+        height: options.height,
+      });
+      const frameFiles = result.frames.map((frame) => frame.path);
+      const gif = ffmpeg ? relativeTo(join(threadDir, "steps.gif")) : null;
+      if (ffmpeg) await createGif(ffmpeg, threadDir, frameFiles);
+      renderedThreads.push({
+        ...thread,
+        frames: result.frames.map((frame) => ({
+          file: relativeTo(frame.path),
+          index: frame.index,
+          kind: frame.kind,
+        })),
+        gif,
+        finalThread: relativeTo(result.finalThread),
+        finalDesktop: relativeTo(result.finalDesktop!),
       });
     }
-
-    const firstThread = renderedScenarios.flatMap((scenario) => scenario.threads)[0];
-    if (!firstThread) throw new Error("The visual manifest has no marked Slack threads");
-    const fullMock = await SlackMock.start({
-      port: 0,
-      seed: false,
-      dataFile: journalPath,
-      manifest: manifest.slackManifest,
-      log: false,
+    renderedScenarios.push({
+      name: scenario.name,
+      status: scenario.status,
+      error: scenario.error,
+      threads: renderedThreads,
     });
-    try {
-      for (const scenario of renderedScenarios) {
-        for (const thread of scenario.threads) {
-          await screenshot(`${fullMock.baseUrl}/c/${thread.channel}/t/${thread.ts}?screenshot=0`, {
-            out: join(options.visualsDir, thread.finalDesktop),
-            width: 1280,
-            height: 900,
-          });
-        }
-      }
-      await screenshot(`${fullMock.baseUrl}/c/${firstThread.channel}`, {
-        out: join(options.visualsDir, "channel.png"),
-        width: 800,
-        height: 700,
-      });
-    } finally {
-      await fullMock.stop();
-    }
-
-    await Bun.write(
-      join(options.visualsDir, "index.json"),
-      `${JSON.stringify(
-        {
-          profile: manifest.profile,
-          channel: "channel.png",
-          scenarios: renderedScenarios,
-        },
-        null,
-        2,
-      )}\n`,
-    );
-  } finally {
-    await Bun.$`rm -rf ${prefixDir}`.quiet();
   }
+
+  const firstThread = renderedScenarios.flatMap((scenario) => scenario.threads)[0];
+  if (!firstThread) throw new Error("The visual manifest has no marked Slack threads");
+  // The channel view after the whole run: one screenshot, so serve the full journal once
+  // instead of rendering a frame per channel event.
+  const mock = await SlackMock.start({
+    port: 0,
+    seed: false,
+    dataFile: journalPath,
+    manifest: manifest.slackManifest,
+    log: false,
+  });
+  try {
+    await screenshot(`${mock.baseUrl}/c/${firstThread.channel}`, {
+      out: join(options.visualsDir, "channel.png"),
+      width: 800,
+      height: 700,
+    });
+  } finally {
+    await mock.stop();
+  }
+
+  await Bun.write(
+    join(options.visualsDir, "index.json"),
+    `${JSON.stringify(
+      {
+        profile: manifest.profile,
+        channel: "channel.png",
+        scenarios: renderedScenarios,
+      },
+      null,
+      2,
+    )}\n`,
+  );
 }
 
 try {

--- a/scripts/e2e/visuals.ts
+++ b/scripts/e2e/visuals.ts
@@ -1,0 +1,280 @@
+import { basename, join, resolve } from "node:path";
+import { SlackMock, screenshot } from "@desplega.ai/slack-mock";
+
+type ManifestThread = { label: string; channel: string; ts: string };
+type ManifestScenario = {
+  name: string;
+  status: "pass" | "fail" | "skip";
+  durationMs: number;
+  error: string | null;
+  threads: ManifestThread[];
+};
+type VisualManifest = {
+  profile: string;
+  sutEnv: Record<string, string>;
+  journal: string;
+  slackManifest: string;
+  scenarios: ManifestScenario[];
+};
+type JournalEntry = {
+  kind: string;
+  message?: { ts?: string; thread_ts?: string };
+};
+type Frame = { file: string; index: number; kind: string };
+type RenderedThread = ManifestThread & {
+  frames: Frame[];
+  gif: string | null;
+  finalThread: string;
+  finalDesktop: string;
+};
+
+const frameKinds = new Set([
+  "message.add",
+  "message.update",
+  "message.delete",
+  "reaction.add",
+  "reaction.remove",
+  "file.add",
+]);
+
+type Options = {
+  visualsDir: string;
+  noGif: boolean;
+  width: number;
+  height: number;
+};
+
+function dimension(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0)
+    throw new Error(`${flag} must be a positive integer`);
+  return parsed;
+}
+
+function parseOptions(args: string[]): Options {
+  const visualsDir = args[0];
+  if (!visualsDir || visualsDir.startsWith("--")) {
+    throw new Error(
+      "Usage: bun run e2e:visuals <visualsDir> [--no-gif] [--height 700] [--width 800]",
+    );
+  }
+  const options: Options = {
+    visualsDir: resolve(visualsDir),
+    noGif: false,
+    width: 800,
+    height: 700,
+  };
+  for (let index = 1; index < args.length; index++) {
+    const arg = args[index]!;
+    if (arg === "--no-gif") {
+      options.noGif = true;
+      continue;
+    }
+    if (arg === "--height" || arg === "--width") {
+      const value = args[++index];
+      if (!value) throw new Error(`${arg} requires a value`);
+      options[arg === "--height" ? "height" : "width"] = dimension(value, arg);
+      continue;
+    }
+    throw new Error(`Unknown option: ${arg}`);
+  }
+  return options;
+}
+
+async function renderFromJournal(
+  dataFile: string,
+  slackManifest: string,
+  path: string,
+  out: string,
+  width: number,
+  height: number,
+): Promise<void> {
+  const mock = await SlackMock.start({
+    port: 0,
+    seed: false,
+    dataFile,
+    manifest: slackManifest,
+    log: false,
+  });
+  try {
+    await screenshot(`${mock.baseUrl}${path}`, { out, width, height });
+  } finally {
+    await mock.stop();
+  }
+}
+
+async function createGif(ffmpeg: string, threadDir: string, frameFiles: string[]): Promise<void> {
+  const listPath = join(threadDir, "frames.txt");
+  const lastFrame = basename(frameFiles.at(-1)!);
+  const lines = frameFiles.flatMap((file) => [`file '${basename(file)}'`, "duration 1.2"]);
+  lines.push(`file '${lastFrame}'`);
+  await Bun.write(listPath, `${lines.join("\n")}\n`);
+  try {
+    const process = Bun.spawn(
+      [
+        ffmpeg,
+        "-y",
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-i",
+        basename(listPath),
+        "-vf",
+        "fps=2,scale=800:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=128[p];[s1][p]paletteuse=dither=bayer",
+        "steps.gif",
+      ],
+      { cwd: threadDir, stdout: "ignore", stderr: "pipe" },
+    );
+    const stderr = new Response(process.stderr).text();
+    const exitCode = await process.exited;
+    if (exitCode !== 0) {
+      throw new Error(`ffmpeg exited with ${exitCode}: ${(await stderr).slice(-1_000)}`);
+    }
+  } finally {
+    await Bun.file(listPath)
+      .delete()
+      .catch(() => {});
+  }
+}
+
+function relevantEntries(entries: JournalEntry[], threadTs: string): number[] {
+  const result: number[] = [];
+  for (const [index, entry] of entries.entries()) {
+    if (
+      frameKinds.has(entry.kind) &&
+      (entry.message?.ts === threadTs || entry.message?.thread_ts === threadTs)
+    ) {
+      result.push(index + 1);
+    }
+  }
+  return result;
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+  const manifest = JSON.parse(
+    await Bun.file(join(options.visualsDir, "manifest.json")).text(),
+  ) as VisualManifest;
+  const journalPath = join(options.visualsDir, manifest.journal);
+  const journalLines = (await Bun.file(journalPath).text())
+    .split("\n")
+    .filter((line) => line.trim() !== "");
+  const entries = journalLines.map((line) => JSON.parse(line) as JournalEntry);
+  const prefixDir = (await Bun.$`mktemp -d`.text()).trim();
+  const ffmpeg = options.noGif ? undefined : Bun.which("ffmpeg");
+  if (!options.noGif && !ffmpeg) console.log("ffmpeg not found; step GIFs will be omitted.");
+
+  try {
+    const renderedScenarios: Array<{
+      name: string;
+      status: "pass" | "fail" | "skip";
+      error: string | null;
+      threads: RenderedThread[];
+    }> = [];
+
+    for (const scenario of manifest.scenarios) {
+      const renderedThreads: RenderedThread[] = [];
+      for (const thread of scenario.threads) {
+        const relativeDir = `frames/${scenario.name}/${thread.label}`;
+        const threadDir = join(options.visualsDir, relativeDir);
+        await Bun.$`mkdir -p ${threadDir}`.quiet();
+        const indexes = relevantEntries(entries, thread.ts);
+        if (indexes.length === 0) {
+          throw new Error(
+            `No visual journal events found for ${thread.channel} thread ${thread.ts}`,
+          );
+        }
+
+        const frames: Frame[] = [];
+        const frameFiles: string[] = [];
+        for (const [frameIndex, journalIndex] of indexes.entries()) {
+          const entry = entries[journalIndex - 1]!;
+          const prefixPath = join(prefixDir, `prefix-${journalIndex}.jsonl`);
+          await Bun.write(prefixPath, `${journalLines.slice(0, journalIndex).join("\n")}\n`);
+          const frameName = `${String(frameIndex + 1).padStart(2, "0")}-${entry.kind}.png`;
+          const relativeFrame = `${relativeDir}/${frameName}`;
+          const frameFile = join(options.visualsDir, relativeFrame);
+          await renderFromJournal(
+            prefixPath,
+            manifest.slackManifest,
+            `/c/${thread.channel}/t/${thread.ts}`,
+            frameFile,
+            options.width,
+            options.height,
+          );
+          frames.push({ file: relativeFrame, index: journalIndex, kind: entry.kind });
+          frameFiles.push(frameFile);
+        }
+
+        const finalThread = `${relativeDir}/final-thread.png`;
+        await Bun.write(join(options.visualsDir, finalThread), Bun.file(frameFiles.at(-1)!));
+        const gif = ffmpeg ? `${relativeDir}/steps.gif` : null;
+        if (ffmpeg) await createGif(ffmpeg, threadDir, frameFiles);
+        renderedThreads.push({
+          ...thread,
+          frames,
+          gif,
+          finalThread,
+          finalDesktop: `${relativeDir}/final-desktop.png`,
+        });
+      }
+      renderedScenarios.push({
+        name: scenario.name,
+        status: scenario.status,
+        error: scenario.error,
+        threads: renderedThreads,
+      });
+    }
+
+    const firstThread = renderedScenarios.flatMap((scenario) => scenario.threads)[0];
+    if (!firstThread) throw new Error("The visual manifest has no marked Slack threads");
+    const fullMock = await SlackMock.start({
+      port: 0,
+      seed: false,
+      dataFile: journalPath,
+      manifest: manifest.slackManifest,
+      log: false,
+    });
+    try {
+      for (const scenario of renderedScenarios) {
+        for (const thread of scenario.threads) {
+          await screenshot(`${fullMock.baseUrl}/c/${thread.channel}/t/${thread.ts}?screenshot=0`, {
+            out: join(options.visualsDir, thread.finalDesktop),
+            width: 1280,
+            height: 900,
+          });
+        }
+      }
+      await screenshot(`${fullMock.baseUrl}/c/${firstThread.channel}`, {
+        out: join(options.visualsDir, "channel.png"),
+        width: 800,
+        height: 700,
+      });
+    } finally {
+      await fullMock.stop();
+    }
+
+    await Bun.write(
+      join(options.visualsDir, "index.json"),
+      `${JSON.stringify(
+        {
+          profile: manifest.profile,
+          channel: "channel.png",
+          scenarios: renderedScenarios,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  } finally {
+    await Bun.$`rm -rf ${prefixDir}`.quiet();
+  }
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/thoughts/taras/plans/2026-09-04-slack-visual-e2e.md
+++ b/thoughts/taras/plans/2026-09-04-slack-visual-e2e.md
@@ -3,7 +3,7 @@ date: 2026-09-04
 author: Claude
 topic: "Slack visual E2E: screenshots and step GIFs from slack-mock, posted to the PR"
 tags: [e2e, slack, slack-mock, ci, visuals]
-status: in-progress
+status: implemented (PR #1338)
 autonomy: yolo
 ---
 
@@ -350,8 +350,9 @@ bunx actionlint .github/workflows/slack-visuals.yml 2>/dev/null || echo "actionl
 
 ## Follow-ups (not in this PR)
 
-- slack-mock `frames` command (prompt at `/tmp/2026-09-04-slack-mock-frames-prompt.md`) replaces the
-  per-frame `SlackMock.start` loop in `visuals.ts`.
+- DONE 2026-09-04: slack-mock 0.2.0 shipped `frames()`; `visuals.ts` now calls it per thread and only
+  boots one `SlackMock` for the channel screenshot. Note: `file.add` lines never produce a frame (the
+  file shows in the frame of the message that shares it).
 - Delegation scenario (child task nested under the parent in the v2 tree).
 - `/agent-swarm-status` ephemeral capture.
 - Prune `pr-*` dirs for closed PRs by API instead of the 30-day rule.

--- a/thoughts/taras/plans/2026-09-04-slack-visual-e2e.md
+++ b/thoughts/taras/plans/2026-09-04-slack-visual-e2e.md
@@ -1,0 +1,371 @@
+---
+date: 2026-09-04
+author: Claude
+topic: "Slack visual E2E: screenshots and step GIFs from slack-mock, posted to the PR"
+tags: [e2e, slack, slack-mock, ci, visuals]
+status: in-progress
+autonomy: yolo
+---
+
+# Slack visual E2E: screenshots + step GIFs from slack-mock, posted to the PR
+
+Date: 2026-09-04. Owner: Taras. Orchestrator: Claude. Executors: Codex (slice A: sol, slice B: terra).
+
+## Goal
+
+On a PR that touches Slack rendering, CI runs the black-box E2E Slack scenarios twice
+(legacy renderer and `SLACK_RENDER_V2=true`), renders one PNG per Slack event for each
+scenario thread from the slack-mock journal, stitches a step GIF, publishes the images to
+the `ci-visuals` branch, and upserts one sticky PR comment that shows legacy and v2 side by side.
+
+Verified by hand on 2026-09-04 with zero code changes (see
+`/tmp/2026-09-04-1215-comms-slack-visuals.md`): `bun run e2e --only slack-mention --keep`
+produces a journal, `slack-mock serve --data <prefix>` replays any prefix of it, and
+`slack-mock screenshot` renders thread, channel, and desktop views. Both renderers pass.
+
+## Facts the implementation relies on
+
+- Runner: `scripts/e2e/run.ts` boots `SlackMock.start({ port: 0, manifest: slack-manifest.json, dataFile? })`
+  in `scripts/e2e/slack.ts`, then the API as a child in `scripts/e2e/sut.ts` (`startSut(keep, slackEnv)`;
+  env is `minimalEnv()` + fixed keys + `slackEnv`). Options parse in `scripts/e2e/report.ts`.
+- `ScenarioContext` fields: `api`, `connectMcp`, `baseUrl`, `apiKey`, `db`, `slack`, `log`, `nonce`.
+- `@desplega.ai/slack-mock@0.1.2` exports `SlackMock`, `Store`, `screenshot(url, { out, width?, height?, timeoutMs? })`,
+  `findChrome()`. `SlackMock.start` options include `port`, `seed`, `dataFile`, `manifest`, `log`.
+  `mock.baseUrl`, `mock.stop()`, `mock.bot.userId`, `mock.bot.botId`, `mock.env`.
+- HTML views: `/c/<channelId>`, `/c/<channelId>/t/<ts>`. `screenshot()` appends `screenshot=1`
+  (no chrome, fixed width). `?screenshot=0` renders the desktop layout with the thread side panel.
+- Journal: one JSON line per change, `{"at": ISO, "kind": "...", ...}`. Kinds seen:
+  `user.add`, `channel.add`, `message.add`, `message.update`, `message.delete`, `reaction.add`,
+  `reaction.remove`, `file.add`, `member.join`, `channel.update`, `view.open`. Message-bearing kinds
+  carry `message: { ts, channel, thread_ts?, ... }`. A prefix of the file is a valid journal.
+  `SlackMock.start({ dataFile: prefix, seed: false })` replays it.
+- Chrome: `findChrome()` checks `/usr/bin/google-chrome` (present on `ubuntu-latest`) and macOS paths.
+- Legacy flow for one ask: `message.add` (ask), `reaction.add` eyes, `message.add` ack with Cancel
+  button, `message.update` ack -> outcome, `reaction.remove` eyes, `reaction.add` white_check_mark.
+  v2 flow: tree `message.add`, outcome card `message.add` (streaming), card `message.update`,
+  `reaction.remove`, tree `message.update`, `reaction.add`. Failure reaction is `x` (`src/slack/ack.ts`).
+- `POST /api/tasks/{id}/finish` body: `{ status: "completed" | "failed", output?, failureReason?, force? }`.
+- Boundary: `scripts/check-e2e-boundary.sh` forbids imports from `src/`, `apps/`, `packages/`, `@swarm/*`
+  and `bun:sqlite` outside `scripts/e2e/db.ts`. Reading `src/` files for reference is fine.
+- Typecheck: `bun run e2e:tsc` (tsconfig includes every `scripts/e2e/**/*.ts`). Lint: `node_modules/.bin/biome check scripts/e2e`.
+- `bun run lint` (biome on `src apps/evals`) does not cover `scripts/`, so run the targeted biome check.
+- ffmpeg is on `ubuntu-latest` and on Taras's Mac (`/opt/homebrew/bin/ffmpeg`).
+- Repo is public. `raw.githubusercontent.com/<owner>/<repo>/ci-visuals/<path>` URLs render in PR comments
+  through GitHub's image proxy. Put the head SHA in the path so every run has a fresh URL.
+
+## Contracts (frozen; both slices depend on them)
+
+### `manifest.json` (written by the runner into `<visualsDir>`)
+
+```json
+{
+  "profile": "legacy",
+  "sutEnv": { "SLACK_RENDER_V2": "true" },
+  "journal": "slack-journal.jsonl",
+  "slackManifest": "/abs/path/to/slack-manifest.json",
+  "scenarios": [
+    {
+      "name": "slack-mention",
+      "status": "pass",
+      "durationMs": 3400,
+      "error": null,
+      "threads": [{ "label": "mention", "channel": "C0GENERAL0", "ts": "1788516626.286000" }]
+    }
+  ]
+}
+```
+
+`profile` = basename of `<visualsDir>`. `journal` is relative to `<visualsDir>`. `sutEnv` is `{}` when no `--sut-env` was given.
+
+### `index.json` (written by `scripts/e2e/visuals.ts` into `<visualsDir>`)
+
+```json
+{
+  "profile": "legacy",
+  "channel": "channel.png",
+  "scenarios": [
+    {
+      "name": "slack-mention",
+      "status": "pass",
+      "error": null,
+      "threads": [
+        {
+          "label": "mention",
+          "channel": "C0GENERAL0",
+          "ts": "1788516626.286000",
+          "frames": [{ "file": "frames/slack-mention/mention/01-message.add.png", "index": 5, "kind": "message.add" }],
+          "gif": "frames/slack-mention/mention/steps.gif",
+          "finalThread": "frames/slack-mention/mention/final-thread.png",
+          "finalDesktop": "frames/slack-mention/mention/final-desktop.png"
+        }
+      ]
+    }
+  ]
+}
+```
+
+All paths are relative to `<visualsDir>`. `gif` is `null` when ffmpeg is missing. `index` is the
+1-based journal line number the frame was rendered after.
+
+### Published layout on the `ci-visuals` branch
+
+```
+pr-<number>/updated-at                      # ISO timestamp, one line
+pr-<number>/<sha7>/<profile>/index.json
+pr-<number>/<sha7>/<profile>/channel.png
+pr-<number>/<sha7>/<profile>/frames/**
+```
+
+Comment image URL = `<base-url>/<profile>/<relative file from index.json>` where
+`<base-url> = https://raw.githubusercontent.com/<owner>/<repo>/ci-visuals/pr-<number>/<sha7>`.
+
+### Sticky comment marker
+
+First line of the comment body: `<!-- slack-visuals -->`. The upsert step finds the existing
+comment by that marker and PATCHes it, else POSTs.
+
+## Slice A: runner, scenarios, frame renderer, docs (Codex sol, worktree `.claude/worktrees/slack-visuals`)
+
+Files: `scripts/e2e/report.ts`, `scripts/e2e/run.ts`, `scripts/e2e/sut.ts`, `scripts/e2e/slack.ts`,
+`scripts/e2e/scenarios/slack-mention.ts`, new `scripts/e2e/scenarios/slack-helpers.ts`,
+new `scripts/e2e/scenarios/slack-follow-up.ts`, new `scripts/e2e/scenarios/slack-failed-task.ts`,
+new `scripts/e2e/visuals.ts`, `package.json` (scripts only), `LOCAL_TESTING.md`.
+
+### A1. Runner flags
+
+- `--sut-env KEY=VALUE` (repeatable). Parsed into `options.sutEnv: Record<string, string>`.
+  Reject a value without `=`. Passed as a third argument `extraEnv` to `startSut`, spread LAST so it
+  overrides fixed keys.
+- `--visuals <dir>`. `options.visualsDir`. The runner `mkdir -p`s it, deletes a stale
+  `<dir>/slack-journal.jsonl`, and passes that path as the mock `dataFile` (independent of `--keep`).
+  After all scenarios and before cleanup it writes `<dir>/manifest.json` (contract above).
+- Update `helpText`.
+
+### A2. `ctx.markThread(label, channel, ts)`
+
+Add to `ScenarioContext`. Records `{ scenario: <running scenario name>, label, channel, ts }`.
+Always records (cheap); only `--visuals` writes the manifest. The runner knows the running scenario
+name because it calls `runScenario` sequentially. Labels are file-name safe (`[a-z0-9-]+`).
+
+### A3. Shared Slack steps: `scripts/e2e/scenarios/slack-helpers.ts`
+
+Functions (all take `ctx` first, all throw via `expect` with messages that name the channel and ts):
+
+- `registerLead(ctx, name)` -> `leadId`. `POST /api/agents { name, isLead: true }`, expect 201.
+  If the API rejects a second lead in one run, fall back to registering a non-lead worker and note it
+  in the report; do not silently hide it.
+- `ask(ctx, text, threadTs?)` -> message. `ctx.slack.postMessage({ channel: "general", user: "alice",
+  text: \`<@${ctx.slack.bot.userId}> ${text}\`, thread_ts })`.
+- `waitForReaction(ctx, ts, name, timeoutMs = 30_000)` polls `ctx.slack.messages("general")`.
+- `waitForEyes(ctx, ts)` = `ctx.slack.waitForApiCall("reactions.add", { where: name === "eyes" && timestamp === ts })`.
+- `findSlackTask(ctx, triggerTs)` polls `GET /api/tasks?source=slack&fields=full&limit=50` for
+  `slackTriggerMessageTs === triggerTs || slackThreadTs === triggerTs`, returns the task record.
+  For a follow-up, match on `slackTriggerMessageTs` only (the thread ts belongs to the first task).
+- `claim(ctx, leadId, taskId)`: exactly one `GET /api/poll` as the lead, then poll the task until `in_progress`.
+- `finish(ctx, leadId, taskId, body)`: `POST /api/tasks/{id}/finish`, expect 200.
+- `waitForOutcome(ctx, threadTs, needle)`: `ctx.slack.waitForMessage(m => m.channel === "C0GENERAL0" && m.thread_ts === threadTs && JSON.stringify(m).includes(needle))`.
+
+Refactor `slack-mention` to use them. Keep every assertion it has today (auth.test, connection count,
+source column via `ctx.db`, pending status, outcome from the bot, white_check_mark). Add
+`ctx.markThread("mention", "C0GENERAL0", ask.ts)`.
+
+Visible text must not contain the nonce. Use plain English asks and outputs. Uniqueness comes from
+the thread ts. Lead names: `e2e-lead-mention`, `e2e-lead-follow-up`, `e2e-lead-failed`.
+
+### A4. New scenarios
+
+`slack-follow-up`:
+1. ask "summarize the release notes" -> eyes -> bot reply in thread -> task pending -> claim -> finish
+   completed with output "Three changes shipped: faster polling, a new Slack tree, and cost badges." ->
+   outcome in thread -> white_check_mark on the ask.
+2. `ask("and now list the open follow-ups", ask.ts)` (a mention inside the same thread) -> eyes on the
+   follow-up ts -> a NEW task whose `slackTriggerMessageTs === followUp.ts` and whose
+   `slackThreadTs === ask.ts` (assert both) -> claim -> finish completed with output
+   "Two follow-ups are open: docs refresh and the retention PR." -> outcome in thread containing that
+   text -> white_check_mark on the follow-up ts.
+3. `ctx.markThread("follow-up", "C0GENERAL0", ask.ts)`.
+Hazard: `src/slack/handlers.ts` has an "additive" buffered path for thread messages. Mention the bot
+in the follow-up so the direct path is taken. If the follow-up still does not create a task, read
+`src/tests/slack-thread-followups.test.ts` and `src/slack/handlers.ts` around line 500 to see what the
+router expects, and report what you found instead of weakening the assertion.
+
+`slack-failed-task`:
+1. ask "deploy the hotfix to staging" -> eyes -> task -> claim -> finish
+   `{ status: "failed", output: "Deploy aborted: the staging database migration 131 failed a checksum.", failureReason: "migration checksum mismatch" }`.
+2. wait for an outcome message from the bot in the thread whose JSON contains "checksum"; wait for the
+   `x` reaction on the ask.
+3. `ctx.markThread("failed", "C0GENERAL0", ask.ts)`.
+
+Register both in `scenarios` in `run.ts` after `slackMention`.
+
+### A5. `scripts/e2e/visuals.ts` (`bun run e2e:visuals <visualsDir> [--no-gif] [--height 700] [--width 800]`)
+
+1. Read `manifest.json` and the journal lines (skip blank lines).
+2. For every scenario thread: relevant line numbers K (1-based) are those whose `kind` is in
+   `message.add | message.update | message.delete | reaction.add | reaction.remove | file.add` and whose
+   `message.ts === ts || message.thread_ts === ts`.
+3. For each K, in order: write lines `1..K` to `<tmp>/prefix-<K>.jsonl`; `SlackMock.start({ port: 0, seed: false, dataFile, manifest: slackManifest, log: false })`;
+   `screenshot(\`${baseUrl}/c/${channel}/t/${ts}\`, { out, width, height })`; `mock.stop()`.
+   Frame file: `frames/<scenario>/<label>/<NN>-<kind>.png`, NN zero-padded from 01.
+4. After the last frame: copy it to `final-thread.png`; render `final-desktop.png` from the FULL journal
+   with `?screenshot=0`, 1280x900.
+5. Once per profile: `channel.png` = `/c/<channel of the first thread>` from the full journal, 800x700.
+6. GIF: if `Bun.which("ffmpeg")` and not `--no-gif`: concat demuxer list with `duration 1.2` per frame
+   and the last frame repeated once more, `-vf "fps=2,scale=800:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=128[p];[s1][p]paletteuse=dither=bayer"`,
+   output `steps.gif`. Missing ffmpeg: print one line and set `gif: null`.
+7. Write `index.json` (contract above). Scenarios with status `fail`/`skip` keep their status and get
+   whatever frames could be rendered (a failed scenario may still have a thread).
+8. No Chrome: throw with the slack-mock error text. Do not swallow.
+9. Clean the tmp prefix dir at the end (also on error).
+
+Performance target: under 90 seconds for three scenarios on the CI runner. One Chrome spawn per frame is acceptable.
+
+### A6. Scripts and docs
+
+- `package.json`: `"e2e:visuals": "bun scripts/e2e/visuals.ts"`.
+- `LOCAL_TESTING.md`, section `Black-box E2E (bun run e2e)`: document `--sut-env`, `--visuals`, and
+  `bun run e2e:visuals`. Add the two-line local recipe (legacy then v2). Add the three Slack scenario names.
+
+### A7. Verification (run all, paste output in the report)
+
+```bash
+bun run e2e:tsc
+bash scripts/check-e2e-boundary.sh
+node_modules/.bin/biome check scripts/e2e
+env -u ANTHROPIC_API_KEY bun run e2e --only slack-mention,slack-follow-up,slack-failed-task --visuals /tmp/vis/legacy --json /tmp/vis/legacy.json
+env -u ANTHROPIC_API_KEY bun run e2e --only slack-mention,slack-follow-up,slack-failed-task --sut-env SLACK_RENDER_V2=true --visuals /tmp/vis/v2 --json /tmp/vis/v2.json
+bun run e2e:visuals /tmp/vis/legacy && bun run e2e:visuals /tmp/vis/v2
+ls -R /tmp/vis/legacy/frames /tmp/vis/v2/frames
+env -u ANTHROPIC_API_KEY bun run e2e        # full contract suite still green
+```
+
+Expected: every scenario PASS in both profiles; each thread has 5 or more frames; `steps.gif` exists;
+`index.json` validates against the contract; full suite unchanged.
+
+## Slice B: comment builder, publish script, workflow (Codex terra, worktree `.claude/worktrees/slack-visuals-ci`)
+
+Files: new `scripts/e2e/visuals-comment.ts`, new `scripts/e2e/visuals-publish.sh`,
+new `.github/workflows/slack-visuals.yml`. Do not touch `package.json`, `LOCAL_TESTING.md`, or any
+slice A file. Build against the frozen `index.json` contract using a fixture you create under
+`/tmp` (not in the repo).
+
+### B1. `scripts/e2e/visuals-comment.ts`
+
+`bun scripts/e2e/visuals-comment.ts --base-url URL --profile legacy=<dir> --profile v2=<dir> --out comment.md [--run-url URL] [--sha SHA]`
+
+- Reads `<dir>/index.json` per profile. Profiles keep the given order.
+- Output body (GitHub Markdown + inline HTML):
+  1. `<!-- slack-visuals -->`
+  2. `### Slack rendering preview` then one line: `Rendered by slack-mock from the black-box E2E journal. Commit <sha7>. [Workflow run](run-url).`
+  3. For each scenario name (union across profiles, in first-seen order): `#### <name>`; a table with one
+     column per profile (`| legacy | v2 |`), one row of `<img src="<url>" width="420">` for
+     `finalThread`; a scenario whose status is not `pass` in a profile shows `**<STATUS>**: <error>` in that cell.
+     Then `<details><summary>Step by step</summary>` containing the same table shape with the `gif`
+     (or `no ffmpeg on the runner` when `gif` is null), then `</details>`.
+  4. `<details><summary>Desktop layout and channel</summary>` with, per scenario, the `finalDesktop`
+     images side by side, and at the end the `channel` image per profile. `</details>`
+- Image URL = `${baseUrl}/${profile}/${file}`. No trailing-slash bugs: normalise.
+- Keep the body under 60,000 characters; if over, drop the desktop section first, then the step section,
+  and say so in a final line.
+- Exit non-zero on a missing `index.json`.
+
+### B2. `scripts/e2e/visuals-publish.sh`
+
+`bash scripts/e2e/visuals-publish.sh <out-root> <pr-number> <head-sha>`; prints `base_url=<url>` on the last line.
+
+- `<out-root>` contains one dir per profile (`legacy/`, `v2/`), each with `index.json`, `channel.png`, `frames/`.
+- Branch `ci-visuals`, always ONE commit deep (rebuilt every run, so history never grows):
+  1. `git fetch origin ci-visuals` (tolerate absence). Remember the fetched SHA or empty.
+  2. `git worktree add --detach <tmp>` then in it `git checkout --orphan ci-visuals-build`; if the remote
+     branch existed, `git checkout <fetched-sha> -- .` to restore its files, else start empty.
+  3. `rm -rf pr-<n>`; copy each profile dir into `pr-<n>/<sha7>/<profile>/` (only `index.json`, `channel.png`, `frames/`);
+     write `pr-<n>/updated-at` with `date -u +%FT%TZ`.
+  4. Prune every `pr-*/` whose `updated-at` is older than 30 days (skip dirs without the file).
+  5. `git add -A`, commit as `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`
+     with message `visuals: pr-<n> <sha7>`.
+  6. `git push --force-with-lease=refs/heads/ci-visuals:<fetched-sha-or-empty> origin HEAD:refs/heads/ci-visuals`.
+     On rejection: remove the tmp worktree and retry from step 1, at most 3 attempts. Fail loudly after that.
+  7. Remove the tmp worktree and the `ci-visuals-build` branch.
+- Derive `<owner>/<repo>` from `GITHUB_REPOSITORY` (fallback: parse `git remote get-url origin`).
+- Base URL: `https://raw.githubusercontent.com/<owner>/<repo>/ci-visuals/pr-<n>/<sha7>`.
+- `set -euo pipefail`, shellcheck-clean (`bunx shellcheck` if available, else review by eye).
+- Local test (run it, paste output): `git init --bare /tmp/visuals-remote.git`, clone a scratch repo with
+  `origin` pointing at it, create a fake `<out-root>` with two profiles from a fixture, run the script twice
+  with different SHAs, confirm the branch has one commit and `pr-<n>/` holds only the latest SHA dir.
+
+### B3. `.github/workflows/slack-visuals.yml`
+
+```yaml
+name: Slack Visuals
+on:
+  pull_request:
+    paths:
+      - "src/slack/**"
+      - "src/prompts/**"
+      - "scripts/e2e/**"
+      - "slack-manifest.json"
+      - "bun.lock"
+      - ".github/workflows/slack-visuals.yml"
+  workflow_dispatch:
+concurrency:
+  group: slack-visuals-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+```
+
+One job `visuals`, `runs-on: ubuntu-latest`, `timeout-minutes: 20`,
+`permissions: { contents: write, pull-requests: write }`,
+`if: github.repository == 'desplega-ai/agent-swarm' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)`.
+
+Steps (pin actions to the SHAs used in `.github/workflows/merge-gate.yml`: checkout `3d3c42e5aac5ba805825da76410c181273ba90b1`, setup-bun `0c5077e51419868618aeaa5fe8019c62421857d6` with `bun-version-file: package.json`, upload-artifact `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`):
+
+1. checkout, setup-bun, `bun install --frozen-lockfile`.
+2. `id: legacy`, `continue-on-error: true`: `bun run e2e --only slack-mention,slack-follow-up,slack-failed-task --visuals visuals/legacy --json visuals/legacy.json`
+3. `id: v2`, `continue-on-error: true`: same with `--sut-env SLACK_RENDER_V2=true --visuals visuals/v2 --json visuals/v2.json`
+4. `if: always()`: `bun run e2e:visuals visuals/legacy; bun run e2e:visuals visuals/v2` (each guarded by `test -f <dir>/manifest.json`).
+5. `if: always()`: upload-artifact `slack-visuals` with `visuals/`.
+6. `if: always() && github.event_name == 'pull_request'`, `id: publish`: run `visuals-publish.sh visuals <pr> <head sha>`; parse the `base_url=` line into a step output.
+7. same condition: build the comment with `visuals-comment.ts --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" --sha <head sha>`, then upsert with `gh api` using `GH_TOKEN: ${{ github.token }}`: list `repos/$REPO/issues/$PR/comments --paginate`, find the body starting with the marker, PATCH `repos/$REPO/issues/comments/$ID` else POST.
+8. `if: always()`: fail the job when `steps.legacy.outcome != 'success' || steps.v2.outcome != 'success'`.
+
+Add a header comment in the YAML that explains: informational job, not in the merge gate; images live on
+the single-commit `ci-visuals` branch; fork PRs get artifacts only.
+
+### B4. Verification (paste output)
+
+```bash
+bun run e2e:tsc                                   # the new .ts compiles
+node_modules/.bin/biome check scripts/e2e
+bash scripts/check-e2e-boundary.sh
+bun scripts/e2e/visuals-comment.ts --base-url https://example.test/base --profile legacy=/tmp/fx/legacy --profile v2=/tmp/fx/v2 --out /tmp/fx/comment.md --run-url https://example.test/run --sha 0123456789abcdef && cat /tmp/fx/comment.md
+bash scripts/e2e/visuals-publish.sh /tmp/fx 123 0123456789abcdef    # against the local bare remote
+bunx actionlint .github/workflows/slack-visuals.yml 2>/dev/null || echo "actionlint unavailable; reviewed by eye"
+```
+
+## Non-goals (both slices)
+
+- No changes under `src/`. No new dependencies. No agent-browser or Playwright.
+- No pixel diffing, no baseline images in the repo.
+- No changes to `nightly-e2e.yml` or `merge-gate.yml`.
+- Do not edit this plan file. Do not `git commit` (linked worktree; the orchestrator commits).
+
+## Follow-ups (not in this PR)
+
+- slack-mock `frames` command (prompt at `/tmp/2026-09-04-slack-mock-frames-prompt.md`) replaces the
+  per-frame `SlackMock.start` loop in `visuals.ts`.
+- Delegation scenario (child task nested under the parent in the v2 tree).
+- `/agent-swarm-status` ephemeral capture.
+- Prune `pr-*` dirs for closed PRs by API instead of the 30-day rule.
+
+## Manual E2E (after merge of both slices, on the PR itself)
+
+```bash
+# local
+env -u ANTHROPIC_API_KEY bun run e2e --only slack-mention,slack-follow-up,slack-failed-task --visuals /tmp/vis/legacy
+env -u ANTHROPIC_API_KEY bun run e2e --only slack-mention,slack-follow-up,slack-failed-task --sut-env SLACK_RENDER_V2=true --visuals /tmp/vis/v2
+bun run e2e:visuals /tmp/vis/legacy && bun run e2e:visuals /tmp/vis/v2
+bun scripts/e2e/visuals-comment.ts --base-url file:///tmp/vis --profile legacy=/tmp/vis/legacy --profile v2=/tmp/vis/v2 --out /tmp/vis/comment.md
+open /tmp/vis/legacy/frames/slack-follow-up/follow-up/steps.gif
+# CI: open the PR, wait for "Slack Visuals", check the sticky comment renders both columns,
+# push a second commit, confirm the same comment is updated and the ci-visuals branch has one commit.
+gh api repos/desplega-ai/agent-swarm/branches/ci-visuals --jq '.commit.sha'
+```


### PR DESCRIPTION
## What

Slack rendering changes become reviewable on the PR itself. A new informational workflow, **Slack Visuals**, runs the three Slack black-box E2E scenarios twice (legacy renderer and `SLACK_RENDER_V2=true`), renders one PNG per Slack event from the slack-mock journal, stitches a step GIF per thread, publishes the images to a single-commit `ci-visuals` branch, and upserts one sticky comment with legacy and v2 side by side.

No changes under `src/`. No new dependencies. Chrome comes preinstalled on `ubuntu-latest`; slack-mock's own `screenshot()` helper drives it.

## How

- `bun run e2e` gains `--sut-env KEY=VALUE` (repeatable) and `--visuals <dir>`. The second keeps the slack-mock journal and writes `manifest.json` with the threads each scenario marked through `ctx.markThread`.
- Shared Slack steps live in `scripts/e2e/scenarios/slack-helpers.ts`. `slack-mention` keeps every assertion it had. Two scenarios join it: `slack-follow-up` (second ask in the same thread) and `slack-failed-task` (failed finish, `x` reaction).
- `bun run e2e:visuals <dir>` calls slack-mock 0.2.0's `frames()` per marked thread (one PNG per journal line that touched the thread, plus `final-thread.png` and `final-desktop.png`), boots one `SlackMock` for the channel screenshot, stitches an ffmpeg GIF, and writes `index.json`. Dependency bumped `^0.1.2` to `^0.2.0`.
- `scripts/e2e/visuals-comment.ts` turns one or more `index.json` files into the comment body. `scripts/e2e/visuals-publish.sh` rebuilds the `ci-visuals` branch as one commit with `--force-with-lease` and a 30-day prune.
- `.github/workflows/slack-visuals.yml` wires it up. Path-filtered, not in the merge gate, fork PRs get the artifact only.

Spec with the frozen contracts: `thoughts/taras/plans/2026-09-04-slack-visual-e2e.md`.

## Verification

Local, from the branch:

```
bun run e2e:tsc
bash scripts/check-e2e-boundary.sh
node_modules/.bin/biome check scripts/e2e
bunx actionlint .github/workflows/slack-visuals.yml
bunx shellcheck scripts/e2e/visuals-publish.sh
env -u ANTHROPIC_API_KEY bun run e2e --only slack-mention,slack-follow-up,slack-failed-task --visuals /tmp/vis2/legacy
env -u ANTHROPIC_API_KEY bun run e2e --only slack-mention,slack-follow-up,slack-failed-task --sut-env SLACK_RENDER_V2=true --visuals /tmp/vis2/v2
bun run e2e:visuals /tmp/vis2/legacy && bun run e2e:visuals /tmp/vis2/v2
env -u ANTHROPIC_API_KEY bun run e2e
```

All green. 69 PNGs and 6 GIFs rendered locally (8, 15, and 8 frames per thread on v2; 6, 12, 6 on legacy). Rendering takes about 60 seconds per profile. The publish script was exercised against a local bare remote with two PRs and a broken profile dir.

This PR touches `scripts/e2e/**`, so the workflow runs on it. The sticky comment below is the real end-to-end check.

## Follow-ups

- Delegation scenario (child task nested in the v2 tree) and the `/agent-swarm-status` ephemeral.
- Prune `pr-*` dirs on the `ci-visuals` branch by PR state instead of the 30-day rule.
