### PR TITLE
ci(slack-visuals): install ffmpeg so the step GIFs render

### DIFF
--- a/.github/workflows/slack-visuals.yml
+++ b/.github/workflows/slack-visuals.yml
@@ -41,6 +41,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # ubuntu-latest ships without ffmpeg. Without it the renderer skips the step GIFs and
+      # the comment reads "no ffmpeg on the runner". Signed Ubuntu packages, about 40 seconds.
+      - name: Install ffmpeg for the step GIFs
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends ffmpeg
+          ffmpeg -version | head -n 1
+
       - name: Run legacy Slack E2E
         id: legacy
         continue-on-error: true


### PR DESCRIPTION
## What

One workflow step: `apt-get install --no-install-recommends ffmpeg` before the Slack E2E runs.

## Why

`ubuntu-latest` ships without ffmpeg. Both Slack Visuals runs on #1338 rendered every frame but skipped the GIFs, and the sticky comment read "no ffmpeg on the runner" in every step cell.

## Cost

About 40 seconds per run from Ubuntu's mirrors. GIF encoding itself is about one second per thread, 50 to 150 KB each. The `ci-visuals` branch is rebuilt as one commit per run, so nothing accumulates.

## Verification

`bunx actionlint` clean. This PR touches the workflow file, so the job runs here. The check is the sticky comment below: the "Step by step" cells should show GIFs instead of the "no ffmpeg" text.