### PR TITLE
ci(nightly-e2e): one report job, cost per leg, sonnet 5, worker-owned task dir

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -78,6 +80,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -117,6 +121,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -94,11 +94,15 @@ jobs:
           bun run e2e --only health --harness "${{ matrix.provider }}" --harness-attempts 2
           --keep --json out/e2e-results.json
 
-      - name: Collect logs
+      # The artifact is readable by anyone with read access to this public repository, so the
+      # copies are redacted: the provider credential this leg holds, plus common token shapes.
+      - name: Collect redacted logs
         if: always()
         run: |
+          set -euo pipefail
           mkdir -p out/logs
-          cp /tmp/e2e-*.log out/logs/ 2>/dev/null || true
+          ls /tmp/e2e-*.log >/dev/null 2>&1 || exit 0
+          bun scripts/e2e/redact.ts --out out/logs /tmp/e2e-*.log
 
       - name: Upload harness results
         if: always()
@@ -157,6 +161,7 @@ jobs:
             --results results \
             --previous previous \
             --out nightly-summary.md \
+            --issue-out nightly-issue.md \
             --json nightly-report.json \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
             --sha "$GITHUB_SHA" > /dev/null
@@ -171,8 +176,9 @@ jobs:
             nightly-summary.md
           retention-days: 90
 
-      # One issue carries the failure state. Its body is the latest summary, each failing run
-      # adds a comment, and the first green run closes it.
+      # One issue carries the failure state. Its body is the latest summary without worker-log
+      # tails (the issue is public), each failing run adds a comment, and the first green run
+      # closes it.
       - name: Update the sticky issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -190,7 +196,7 @@ jobs:
             fi
             exit 0
           fi
-          { printf '%s\n\n' "$marker"; cat nightly-summary.md; } > issue.md
+          { printf '%s\n\n' "$marker"; cat nightly-issue.md; } > issue.md
           if [ -n "$issue" ]; then
             gh issue edit "$issue" --body-file issue.md
             gh issue comment "$issue" --body "Still failing: $RUN_URL"

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -2,16 +2,58 @@
 # Seed E2E_CODEX_OAUTH from a dedicated login: `env HOME=/tmp/e2e-codex codex login`, then
 # `bun scripts/e2e/codex-oauth-blob.ts /tmp/e2e-codex/.codex/auth.json | gh secret set E2E_CODEX_OAUTH`.
 # Never use a developer's main login. CI refresh rotates its refresh token and breaks that login.
-# The Codex blob goes stale after its first refresh, about ten days after issue.
+# The Codex blob goes stale after its first refresh, about ten days after issue. The report
+# warns three days before the seeded access token expires.
 # E2E_OPENROUTER_API_KEY is a plain OpenRouter key.
+#
+# Shape: `contract` runs the deterministic scenarios once. Each `harness` leg runs one real
+# LLM task through one provider. `report` merges every result file into one step summary,
+# uploads it as `nightly-e2e-report`, and keeps one sticky issue open while the nightly fails.
 name: Nightly E2E
 
 on:
   schedule:
-    - cron: "0 3 * * *"
+    # Off the hour: on-the-hour schedules queue for a long time on GitHub.
+    - cron: "23 3 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: nightly-e2e
+  cancel-in-progress: false
+
 jobs:
+  contract:
+    if: github.repository == 'desplega-ai/agent-swarm'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # The floors guard the recorder, not the scenarios: coverage dropping to zero means
+      # the HTTP or MCP recorder broke, which no scenario assertion would catch.
+      - name: Run contract scenarios
+        run: bun run e2e --json out/e2e-results.json --min-route-coverage 3 --min-tool-coverage 2
+
+      - name: Upload contract results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nightly-e2e-contract
+          path: out/
+          if-no-files-found: warn
+
   harness:
     if: github.repository == 'desplega-ai/agent-swarm'
     strategy:
@@ -40,19 +82,119 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run harness E2E with one retry
+      # `--only health` keeps the contract scenarios in the contract job. The retry lives in
+      # the runner so both attempts land in the result file with their cost and log tail.
+      # `--keep` leaves the SUT log on disk for the upload step below.
+      - name: Run harness leg
         run: >-
-          bun run e2e --harness "${{ matrix.provider }}" --json e2e-results.json --summary-md e2e-summary.md ||
-          bun run e2e --harness "${{ matrix.provider }}" --json e2e-results.json --summary-md e2e-summary.md
+          bun run e2e --only health --harness "${{ matrix.provider }}" --harness-attempts 2
+          --keep --json out/e2e-results.json
 
-      - name: Add E2E job summary
+      - name: Collect logs
         if: always()
-        run: test ! -f e2e-summary.md || cat e2e-summary.md >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          mkdir -p out/logs
+          cp /tmp/e2e-*.log out/logs/ 2>/dev/null || true
 
-      - name: Upload E2E results
+      - name: Upload harness results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-e2e-${{ matrix.provider }}
-          path: e2e-results.json
+          path: out/
           if-no-files-found: warn
+
+  report:
+    needs: [contract, harness]
+    if: ${{ !cancelled() && github.repository == 'desplega-ai/agent-swarm' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: package.json
+
+      - name: Download job results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: nightly-e2e-*
+          path: results
+
+      # Best effort: a run that predates the report artifact, or an expired artifact, is skipped.
+      - name: Download earlier reports for the cost trend
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p previous
+          gh run list --workflow nightly-e2e.yml --status completed --limit 15 --json databaseId \
+            --jq '.[].databaseId' | while read -r run_id; do
+            [ "$run_id" = "$GITHUB_RUN_ID" ] && continue
+            gh run download "$run_id" -n nightly-e2e-report -D "previous/$run_id" 2>/dev/null || true
+          done
+          echo "earlier reports: $(find previous -name nightly-report.json | wc -l)"
+
+      - name: Build the report
+        id: report
+        run: |
+          set -euo pipefail
+          bun scripts/e2e/nightly-report.ts \
+            --results results \
+            --previous previous \
+            --out nightly-summary.md \
+            --json nightly-report.json \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --sha "$GITHUB_SHA" > /dev/null
+          cat nightly-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nightly-e2e-report
+          path: |
+            nightly-report.json
+            nightly-summary.md
+          retention-days: 90
+
+      # One issue carries the failure state. Its body is the latest summary, each failing run
+      # adds a comment, and the first green run closes it.
+      - name: Update the sticky issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OK: ${{ steps.report.outputs.ok }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          marker='<!-- nightly-e2e -->'
+          issue=$(gh issue list --state open --limit 100 --json number,body \
+            --jq ".[] | select(.body | startswith(\"$marker\")) | .number" | head -n 1)
+          if [ "$OK" = "true" ]; then
+            if [ -n "$issue" ]; then
+              gh issue comment "$issue" --body "Green again: $RUN_URL"
+              gh issue close "$issue"
+            fi
+            exit 0
+          fi
+          { printf '%s\n\n' "$marker"; cat nightly-summary.md; } > issue.md
+          if [ -n "$issue" ]; then
+            gh issue edit "$issue" --body-file issue.md
+            gh issue comment "$issue" --body "Still failing: $RUN_URL"
+          else
+            gh issue create --title "Nightly E2E is failing" --body-file issue.md
+          fi
+
+      - name: Fail when any job failed
+        run: |
+          if [ "${{ steps.report.outputs.ok }}" != "true" ]; then
+            echo "Nightly E2E failed. See the job summary." >&2
+            exit 1
+          fi

--- a/LOCAL_TESTING.md
+++ b/LOCAL_TESTING.md
@@ -70,6 +70,40 @@ bun run e2e --min-route-coverage 4 --min-tool-coverage 3
 bun run e2e --keep
 ```
 
+### Harness legs (`--harness`)
+
+A harness leg registers a worker agent, creates one task, and boots a real worker process for one provider.
+The task runs in a workspace directory under the leg's temporary HOME, never in the repository checkout.
+Defaults: claude `claude-sonnet-5`, codex `gpt-5.6-luna`, pi and opencode `openrouter/deepseek/deepseek-v4-flash`.
+Override with `E2E_MODEL_<PROVIDER>`. Each leg needs its provider credential in the environment.
+
+```bash
+bun run e2e --only health --harness claude
+bun run e2e --only health --harness claude,pi --harness-attempts 2
+E2E_MODEL_CLAUDE=claude-haiku-4-5 bun run e2e --only health --harness claude
+```
+
+`--harness-attempts N` runs a failed leg again, N attempts in total. Every attempt lands in the JSON
+result with its duration, its cost, and the last 60 lines of the worker log on failure. After the task
+turns terminal the leg polls `/api/session-costs` for up to 15 seconds (`E2E_COST_TIMEOUT_MS`) and records
+the USD total, token counts, and `costSource`. A passing task with no cost row is reported as `no record`.
+
+### Nightly E2E workflow
+
+`.github/workflows/nightly-e2e.yml` runs the contract scenarios once on plain Ubuntu, then one harness
+leg per provider inside the `worker:slim` image, then a `report` job that merges every result file with
+`scripts/e2e/nightly-report.ts` into one step summary and the `nightly-e2e-report` artifact. The report
+lists cost per leg, the cost trend over earlier runs, warnings (retries, missing cost rows, an expiring
+Codex OAuth blob), and the worker log tail of every failed attempt. While the nightly fails, one sticky
+issue (body starts with `<!-- nightly-e2e -->`) stays open; the first green run closes it.
+
+Rebuild a report locally from downloaded artifacts:
+
+```bash
+gh run download <run-id> -p 'nightly-e2e-*' -D /tmp/nightly/results
+bun scripts/e2e/nightly-report.ts --results /tmp/nightly/results --out /tmp/nightly/summary.md --json /tmp/nightly/report.json
+```
+
 Use repeatable `--sut-env KEY=VALUE` flags to override environment variables for the spawned API server.
 Use `--visuals <dir>` to retain the Slack journal and write its `manifest.json` file.
 Render the journal with `bun run e2e:visuals <dir>`.

--- a/LOCAL_TESTING.md
+++ b/LOCAL_TESTING.md
@@ -87,6 +87,8 @@ E2E_MODEL_CLAUDE=claude-haiku-4-5 bun run e2e --only health --harness claude
 result with its duration, its cost, and the last 60 lines of the worker log on failure. After the task
 turns terminal the leg polls `/api/session-costs` for up to 15 seconds (`E2E_COST_TIMEOUT_MS`) and records
 the USD total, token counts, and `costSource`. A passing task with no cost row is reported as `no record`.
+Log tails and error messages pass through `scripts/e2e/redact.ts` (exact credential values from the
+environment plus common token shapes) before they enter the result file or the console.
 
 ### Nightly E2E workflow
 
@@ -95,7 +97,8 @@ leg per provider inside the `worker:slim` image, then a `report` job that merges
 `scripts/e2e/nightly-report.ts` into one step summary and the `nightly-e2e-report` artifact. The report
 lists cost per leg, the cost trend over earlier runs, warnings (retries, missing cost rows, an expiring
 Codex OAuth blob), and the worker log tail of every failed attempt. While the nightly fails, one sticky
-issue (body starts with `<!-- nightly-e2e -->`) stays open; the first green run closes it.
+issue (body starts with `<!-- nightly-e2e -->`) stays open; the first green run closes it. The issue body
+omits the log tails, and the uploaded log files are redacted copies, because both are public.
 
 Rebuild a report locally from downloaded artifacts:
 

--- a/scripts/e2e/harness.ts
+++ b/scripts/e2e/harness.ts
@@ -1,10 +1,11 @@
 import type { ApiClient } from "./http";
 import { asRecord, expect, expectStatus, pollUntil } from "./http";
-import type { HarnessResult } from "./report";
+import type { HarnessAttempt, HarnessCost, HarnessFailureKind, HarnessResult } from "./report";
+import { usd } from "./report";
 import { minimalEnv, repoRoot, tailLog } from "./sut";
 
 const DEFAULT_MODELS: Record<string, string> = {
-  claude: "claude-haiku-4-5-20251001",
+  claude: "claude-sonnet-5",
   codex: "gpt-5.6-luna",
   pi: "openrouter/deepseek/deepseek-v4-flash",
   opencode: "openrouter/deepseek/deepseek-v4-flash",
@@ -160,12 +161,14 @@ function codexOAuthAuthJson(): string {
   });
 }
 
-async function prepareHarnessHome(homeDir: string, provider: string): Promise<void> {
+/** Seeds the temp HOME for one attempt and returns the session workspace directory. */
+async function prepareHarnessHome(homeDir: string, provider: string): Promise<string> {
   const claudeDir = `${homeDir}/.claude/commands`;
   const piDir = `${homeDir}/.pi/agent/skills/work-on-task`;
   const codexDir = `${homeDir}/.codex/skills/work-on-task`;
   const opencodeDir = `${homeDir}/.opencode/skills/work-on-task`;
-  await Bun.$`mkdir -p ${homeDir}/logs ${claudeDir} ${piDir} ${codexDir} ${opencodeDir}`.quiet();
+  const workspaceDir = `${homeDir}/workspace`;
+  await Bun.$`mkdir -p ${homeDir}/logs ${workspaceDir} ${claudeDir} ${piDir} ${codexDir} ${opencodeDir}`.quiet();
   const command = await Bun.file(`${repoRoot}/plugin/commands/work-on-task.md`).text();
   const piSkill = await Bun.file(`${repoRoot}/plugin/pi-skills/work-on-task/SKILL.md`).text();
   await Promise.all([
@@ -196,6 +199,7 @@ async function prepareHarnessHome(homeDir: string, provider: string): Promise<vo
   if (process.getuid?.() === 0 && Bun.which("gosu")) {
     await Bun.$`chown -R worker:worker ${homeDir}`.quiet();
   }
+  return workspaceDir;
 }
 
 function workerCommand(): string[] {
@@ -203,29 +207,92 @@ function workerCommand(): string[] {
   return process.getuid?.() === 0 && Bun.which("gosu") ? ["gosu", "worker", ...command] : command;
 }
 
+function codexCredentialExpiry(): string | undefined {
+  if (!process.env.CODEX_OAUTH) return undefined;
+  try {
+    const expires = (JSON.parse(process.env.CODEX_OAUTH) as { expires?: unknown }).expires;
+    if (typeof expires === "number" && Number.isFinite(expires)) {
+      return new Date(expires).toISOString();
+    }
+  } catch {}
+  return undefined;
+}
+
+const CREDENTIAL_FAILURE =
+  /status (401|403)|http (401|403)|\b(401|403) (unauthorized|forbidden)|invalid_grant|unauthorized|authentication failed|token (has )?expired|refresh token/i;
+
+function classifyFailure(
+  message: string,
+  tail: string,
+  phase: "setup" | "run",
+): HarnessFailureKind {
+  if (phase === "setup") return "setup";
+  if (message.includes("did not finish within")) return "timeout";
+  if (CREDENTIAL_FAILURE.test(tail)) return "credential";
+  return "task";
+}
+
+/**
+ * The worker POSTs its cost row when the session process exits, which lands a
+ * little after the task turns terminal. Poll briefly so a slow exit is not
+ * reported as a missing record.
+ */
+async function readCost(api: ApiClient, provider: string, agentId: string): Promise<HarnessCost> {
+  const timeoutMs = Number(process.env.E2E_COST_TIMEOUT_MS || 15_000);
+  let rows: Record<string, unknown>[] = [];
+  await pollUntil(
+    async () => {
+      const response = await api("GET", `/api/session-costs?agentId=${agentId}`);
+      if (response.status !== 200) return false;
+      const entries = asRecord(response.json).costs;
+      rows = Array.isArray(entries) ? entries.map(asRecord) : [];
+      return rows.length > 0;
+    },
+    timeoutMs,
+    500,
+  );
+  const sum = (key: string) =>
+    rows.reduce((total, row) => total + (typeof row[key] === "number" ? row[key] : 0), 0);
+  const sources = [...new Set(rows.map((row) => String(row.costSource ?? "harness")))].sort();
+  const cost: HarnessCost = {
+    records: rows.length,
+    totalUsd: sum("totalCostUsd"),
+    inputTokens: sum("inputTokens"),
+    outputTokens: sum("outputTokens"),
+    cacheReadTokens: sum("cacheReadTokens"),
+    cacheWriteTokens: sum("cacheWriteTokens"),
+    costSource: sources.join(","),
+  };
+  const detail = cost.records ? ` (${usd(cost.totalUsd)}, ${cost.costSource})` : "";
+  console.log(`INFO harness ${provider} cost records: ${cost.records}${detail}`);
+  return cost;
+}
+
 // The worker's own HTTP and MCP traffic bypasses the client recorder. It does not count toward MVP coverage.
-export async function runHarnessLeg(
+async function runHarnessAttempt(
   provider: string,
   api: ApiClient,
   baseUrl: string,
   apiKey: string,
   nonce: string,
-): Promise<HarnessResult> {
+  model: string,
+): Promise<HarnessAttempt> {
   const started = Date.now();
-  const model = modelFor(provider);
   const stamp = `${Date.now()}-${provider}`;
   const logPath = `/tmp/e2e-harness-${provider}-${stamp}.log`;
   const homeDir = `/tmp/e2e-harness-home-${stamp}`;
   let child: HarnessChild | undefined;
   let writer: Bun.FileSink | undefined;
   let drains: Promise<unknown> | undefined;
+  let phase: "setup" | "run" = "setup";
+  let cost: HarnessCost | undefined;
   try {
     expect(
       ["claude", "codex", "pi", "opencode"].includes(provider),
       `Unsupported harness provider: ${provider}`,
     );
     requireCredential(provider);
-    await prepareHarnessHome(homeDir, provider);
+    const workspaceDir = await prepareHarnessHome(homeDir, provider);
     const register = await api("POST", "/api/agents", {
       body: {
         name: `e2e-harness-${provider}-${nonce}`,
@@ -238,11 +305,14 @@ export async function runHarnessLeg(
     const agentId = asRecord(register.json).id;
     expect(typeof agentId === "string", `${provider} registration response has no id`);
     const marker = `PONG-${nonce}`;
+    // The session runs in a directory the worker user owns. In CI the checkout
+    // belongs to root, and codex writes AGENTS.md into the session cwd.
     const create = await api("POST", "/api/tasks", {
       body: {
         task: `Reply with exactly the text ${marker} and nothing else. Do not use any tools.`,
         agentId,
         source: "api",
+        dir: workspaceDir,
       },
     });
     expectStatus(create, [201], `create ${provider} harness task`);
@@ -258,6 +328,7 @@ export async function runHarnessLeg(
     });
     activeChildren.add(child);
     drains = Promise.all([drain(child.stdout, writer), drain(child.stderr, writer)]);
+    phase = "run";
 
     let task: Record<string, unknown> | undefined;
     const timeoutMs = Number(process.env.E2E_HARNESS_TIMEOUT_MS || 300_000);
@@ -272,6 +343,8 @@ export async function runHarnessLeg(
       1_000,
     );
     expect(terminal && task, `${provider} task did not finish within ${timeoutMs}ms`);
+    // Read the cost before the assertions so a failed task still reports what it spent.
+    cost = await readCost(api, provider, agentId);
     expect(
       task.status === "completed",
       `${provider} task finished with status ${String(task.status)}`,
@@ -296,25 +369,19 @@ export async function runHarnessLeg(
       typeof task.claudeSessionId === "string" && task.claudeSessionId.length > 0,
       `${provider} task has no session id`,
     );
-
-    const costs = await api("GET", `/api/session-costs?agentId=${agentId}`);
-    if (costs.status === 200) {
-      const entries = asRecord(costs.json).costs;
-      console.log(
-        `INFO harness ${provider} cost records: ${Array.isArray(entries) ? entries.length : 0}`,
-      );
-    }
-    return { provider, model, status: "pass", durationMs: Date.now() - started };
+    return { status: "pass", durationMs: Date.now() - started, cost };
   } catch (error) {
     writer?.flush();
     const tail = await tailLog(logPath, 60);
     if (tail) console.error(`Last 60 lines of ${logPath}:\n${tail}`);
+    const message = errorMessage(error);
     return {
-      provider,
-      model,
       status: "fail",
       durationMs: Date.now() - started,
-      error: errorMessage(error),
+      error: message,
+      failureKind: classifyFailure(message, tail, phase),
+      cost,
+      logTail: tail || undefined,
     };
   } finally {
     if (child) await stopChild(child);
@@ -322,4 +389,48 @@ export async function runHarnessLeg(
     writer?.end();
     await Bun.$`rm -rf ${homeDir}`.quiet().catch(() => {});
   }
+}
+
+export async function runHarnessLeg(
+  provider: string,
+  api: ApiClient,
+  baseUrl: string,
+  apiKey: string,
+  nonce: string,
+  maxAttempts = 1,
+): Promise<HarnessResult> {
+  const started = Date.now();
+  const model = modelFor(provider);
+  const attempts: HarnessAttempt[] = [];
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const result = await runHarnessAttempt(
+      provider,
+      api,
+      baseUrl,
+      apiKey,
+      `${nonce}-a${attempt}`,
+      model,
+    );
+    attempts.push(result);
+    if (result.status === "pass") break;
+    if (attempt < maxAttempts) {
+      console.log(
+        `WARN harness ${provider}: attempt ${attempt} of ${maxAttempts} failed, retrying`,
+      );
+    }
+  }
+  const last = attempts[attempts.length - 1]!;
+  return {
+    provider,
+    model,
+    status: last.status,
+    durationMs: Date.now() - started,
+    error: last.error,
+    failureKind: last.failureKind,
+    attempts,
+    cost: last.cost,
+    totalCostUsd: attempts.reduce((total, attempt) => total + (attempt.cost?.totalUsd ?? 0), 0),
+    credentialExpiresAt: provider === "codex" ? codexCredentialExpiry() : undefined,
+    logTail: last.logTail,
+  };
 }

--- a/scripts/e2e/harness.ts
+++ b/scripts/e2e/harness.ts
@@ -1,5 +1,6 @@
 import type { ApiClient } from "./http";
 import { asRecord, expect, expectStatus, pollUntil } from "./http";
+import { knownSecrets, redactSecrets } from "./redact";
 import type { HarnessAttempt, HarnessCost, HarnessFailureKind, HarnessResult } from "./report";
 import { usd } from "./report";
 import { minimalEnv, repoRoot, tailLog } from "./sut";
@@ -372,9 +373,12 @@ async function runHarnessAttempt(
     return { status: "pass", durationMs: Date.now() - started, cost };
   } catch (error) {
     writer?.flush();
-    const tail = await tailLog(logPath, 60);
+    // The tail and the message reach the job log, the step summary, the sticky
+    // issue, and the artifact. Mask credentials before any of that.
+    const secrets = knownSecrets([apiKey]);
+    const tail = redactSecrets(await tailLog(logPath, 60), secrets);
     if (tail) console.error(`Last 60 lines of ${logPath}:\n${tail}`);
-    const message = errorMessage(error);
+    const message = redactSecrets(errorMessage(error), secrets);
     return {
       status: "fail",
       durationMs: Date.now() - started,

--- a/scripts/e2e/nightly-report.ts
+++ b/scripts/e2e/nightly-report.ts
@@ -7,7 +7,9 @@
  * `ok=<bool>` to `$GITHUB_OUTPUT` when that file is set.
  *
  *   bun scripts/e2e/nightly-report.ts --results results --previous previous \
- *     --out summary.md --json nightly-report.json --run-url URL --sha SHA
+ *     --out summary.md --issue-out issue.md --json nightly-report.json --run-url URL --sha SHA
+ *
+ * `--issue-out` writes the same summary without worker-log tails, for the public issue.
  */
 import { parseArgs } from "node:util";
 import type { E2eResult, HarnessResult, ScenarioResult } from "./report";
@@ -146,10 +148,16 @@ function trendRows(current: NightlyReport, previous: NightlyReport[], providers:
   });
 }
 
+export type MarkdownOptions = {
+  /** Include the worker-log tails of failed attempts. Off for the public sticky issue. */
+  logTails: boolean;
+};
+
 export function nightlyMarkdown(
   report: NightlyReport,
   previous: NightlyReport[],
   providers: string[],
+  options: MarkdownOptions = { logTails: true },
 ): string {
   const passedLegs = report.harness.filter((leg) => leg.status === "pass").length;
   const shaLabel = report.sha ? `\`${report.sha.slice(0, 7)}\`` : "";
@@ -215,8 +223,14 @@ export function nightlyMarkdown(
     "",
     "</details>",
     "",
-    ...harnessFailureDetails(report.harness),
   );
+  if (options.logTails) lines.push(...harnessFailureDetails(report.harness));
+  else if (report.harness.some((leg) => leg.attempts.some((a) => a.status === "fail"))) {
+    lines.push(
+      `Worker log tails for the failed attempts are in the [run summary](${report.runUrl}).`,
+      "",
+    );
+  }
   return lines.join("\n");
 }
 
@@ -241,6 +255,7 @@ async function main(): Promise<void> {
       results: { type: "string" },
       previous: { type: "string" },
       out: { type: "string", default: "nightly-summary.md" },
+      "issue-out": { type: "string" },
       json: { type: "string", default: "nightly-report.json" },
       "run-id": { type: "string", default: process.env.GITHUB_RUN_ID ?? "" },
       "run-url": { type: "string", default: "" },
@@ -270,6 +285,12 @@ async function main(): Promise<void> {
   });
   const markdown = nightlyMarkdown(report, previous, providers);
   await Bun.write(values.out, markdown);
+  if (values["issue-out"]) {
+    await Bun.write(
+      values["issue-out"],
+      nightlyMarkdown(report, previous, providers, { logTails: false }),
+    );
+  }
   await Bun.write(values.json, `${JSON.stringify(report, null, 2)}\n`);
   if (process.env.GITHUB_OUTPUT) {
     await Bun.write(

--- a/scripts/e2e/nightly-report.ts
+++ b/scripts/e2e/nightly-report.ts
@@ -1,0 +1,288 @@
+/**
+ * Merges the per-job results of the Nightly E2E workflow into one report.
+ *
+ * Inputs are the downloaded artifacts: one `e2e-results.json` per job under
+ * `--results`, plus earlier `nightly-report.json` files under `--previous` for
+ * the cost trend. Writes a Markdown summary and a JSON report, and appends
+ * `ok=<bool>` to `$GITHUB_OUTPUT` when that file is set.
+ *
+ *   bun scripts/e2e/nightly-report.ts --results results --previous previous \
+ *     --out summary.md --json nightly-report.json --run-url URL --sha SHA
+ */
+import { parseArgs } from "node:util";
+import type { E2eResult, HarnessResult, ScenarioResult } from "./report";
+import { harnessFailureDetails, harnessTable, markdownCell, usd } from "./report";
+
+export const DEFAULT_PROVIDERS = ["claude", "codex", "pi", "opencode"];
+const TREND_LIMIT = 14;
+
+export type ContractSummary = {
+  ok: boolean;
+  scenarios: ScenarioResult[];
+  coverage: E2eResult["coverage"];
+  gates: E2eResult["gates"];
+};
+
+export type NightlyReport = {
+  version: 1;
+  generatedAt: string;
+  runId: string;
+  runUrl: string;
+  sha: string;
+  ok: boolean;
+  /** Null when the contract job produced no result file. */
+  contract: ContractSummary | null;
+  harness: HarnessResult[];
+  /** Providers with no result file, such as a leg that died before writing one. */
+  missingLegs: string[];
+  /** USD over every leg and attempt in this run. */
+  totalCostUsd: number;
+  warnings: string[];
+};
+
+export type ReportInputs = {
+  results: E2eResult[];
+  previous: NightlyReport[];
+  providers: string[];
+  runId: string;
+  runUrl: string;
+  sha: string;
+  generatedAt: string;
+  credentialWarnDays: number;
+};
+
+function normalizeLeg(leg: HarnessResult): HarnessResult {
+  return {
+    ...leg,
+    attempts: leg.attempts ?? [
+      { status: leg.status, durationMs: leg.durationMs, error: leg.error, cost: leg.cost },
+    ],
+    totalCostUsd: leg.totalCostUsd ?? leg.cost?.totalUsd ?? 0,
+  };
+}
+
+function daysUntil(iso: string, now: string): number {
+  return (new Date(iso).getTime() - new Date(now).getTime()) / 86_400_000;
+}
+
+export function buildNightlyReport(inputs: ReportInputs): NightlyReport {
+  const contractResult = inputs.results.find((result) => result.harness.length === 0);
+  const contract: ContractSummary | null = contractResult
+    ? {
+        ok: contractResult.ok,
+        scenarios: contractResult.scenarios,
+        coverage: contractResult.coverage,
+        gates: contractResult.gates,
+      }
+    : null;
+  const legs = new Map<string, HarnessResult>();
+  for (const result of inputs.results) {
+    for (const leg of result.harness) legs.set(leg.provider, normalizeLeg(leg));
+  }
+  const harness = inputs.providers
+    .filter((provider) => legs.has(provider))
+    .map((provider) => legs.get(provider)!);
+  const missingLegs = inputs.providers.filter((provider) => !legs.has(provider));
+
+  const warnings: string[] = [];
+  if (!contract) warnings.push("The contract job produced no result file.");
+  else if (!contract.gates.passed) warnings.push("Coverage gates failed in the contract job.");
+  for (const provider of missingLegs) warnings.push(`${provider}: no result file from the leg.`);
+  for (const leg of harness) {
+    if (leg.attempts.length > 1) {
+      warnings.push(`${leg.provider}: needed ${leg.attempts.length} attempts.`);
+    }
+    if (leg.status === "pass" && leg.cost && leg.cost.records === 0) {
+      warnings.push(`${leg.provider}: the task passed but the API stored no cost record.`);
+    }
+    if (leg.credentialExpiresAt) {
+      const days = daysUntil(leg.credentialExpiresAt, inputs.generatedAt);
+      if (days < 0) {
+        warnings.push(
+          `${leg.provider}: the seeded OAuth access token expired on ${leg.credentialExpiresAt.slice(0, 10)}. Re-seed the secret before the refresh token rotates.`,
+        );
+      } else if (days <= inputs.credentialWarnDays) {
+        warnings.push(
+          `${leg.provider}: the seeded OAuth access token expires in ${days.toFixed(1)} days (${leg.credentialExpiresAt.slice(0, 10)}). Re-seed the secret.`,
+        );
+      }
+    }
+  }
+
+  const ok =
+    contract?.ok === true &&
+    missingLegs.length === 0 &&
+    harness.every((leg) => leg.status === "pass");
+  return {
+    version: 1,
+    generatedAt: inputs.generatedAt,
+    runId: inputs.runId,
+    runUrl: inputs.runUrl,
+    sha: inputs.sha,
+    ok,
+    contract,
+    harness,
+    missingLegs,
+    totalCostUsd: harness.reduce((total, leg) => total + leg.totalCostUsd, 0),
+    warnings,
+  };
+}
+
+function trendRows(current: NightlyReport, previous: NightlyReport[], providers: string[]) {
+  const runs = [current, ...previous]
+    .sort((a, b) => b.generatedAt.localeCompare(a.generatedAt))
+    .slice(0, TREND_LIMIT);
+  return runs.map((run) => {
+    const cells = providers.map((provider) => {
+      const leg = run.harness.find((candidate) => candidate.provider === provider);
+      if (!leg) return "-";
+      if (leg.status === "fail") return `fail (${usd(leg.totalCostUsd)})`;
+      return leg.cost?.records ? usd(leg.totalCostUsd) : "no record";
+    });
+    const label = run.runUrl
+      ? `[${run.generatedAt.slice(0, 10)}](${run.runUrl})`
+      : run.generatedAt.slice(0, 10);
+    return `| ${label} | ${run.ok ? "PASS" : "FAIL"} | ${cells.join(" | ")} | ${usd(run.totalCostUsd)} |`;
+  });
+}
+
+export function nightlyMarkdown(
+  report: NightlyReport,
+  previous: NightlyReport[],
+  providers: string[],
+): string {
+  const passedLegs = report.harness.filter((leg) => leg.status === "pass").length;
+  const shaLabel = report.sha ? `\`${report.sha.slice(0, 7)}\`` : "";
+  const runLabel = report.runUrl ? `[run](${report.runUrl})` : "";
+  const headline = [
+    shaLabel,
+    runLabel,
+    `${passedLegs}/${providers.length} harness legs passed`,
+    `total cost ${usd(report.totalCostUsd)}`,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  const lines = [
+    `## Nightly E2E: ${report.ok ? "PASS" : "FAIL"}`,
+    "",
+    headline,
+    "",
+    "### Harness legs",
+    "",
+    ...harnessTable(report.harness),
+    ...report.missingLegs.map((provider) => `| ${provider} | | MISSING | | | | | no result file |`),
+    "",
+  ];
+
+  lines.push("### Contract scenarios", "");
+  if (report.contract) {
+    const { scenarios, coverage, gates } = report.contract;
+    const count = (status: string) => scenarios.filter((s) => s.status === status).length;
+    lines.push(
+      `${count("pass")} passed, ${count("fail")} failed, ${count("skip")} skipped · ` +
+        `routes ${coverage.routes.covered}/${coverage.routes.total} (${coverage.routes.percent.toFixed(1)}%) · ` +
+        `MCP tools ${coverage.mcpTools.covered}/${coverage.mcpTools.total} (${coverage.mcpTools.percent.toFixed(1)}%) · ` +
+        `gates ${gates.passed ? "PASS" : "FAIL"}`,
+      "",
+    );
+    const notPassed = scenarios.filter((scenario) => scenario.status !== "pass");
+    if (notPassed.length > 0) {
+      lines.push(
+        "| Scenario | Status | Error |",
+        "| --- | --- | --- |",
+        ...notPassed.map(
+          (scenario) =>
+            `| ${scenario.name} | ${scenario.status.toUpperCase()} | ${markdownCell(scenario.error ?? "")} |`,
+        ),
+        "",
+      );
+    }
+  } else {
+    lines.push("No result file from the contract job.", "");
+  }
+
+  if (report.warnings.length > 0) {
+    lines.push("### Warnings", "", ...report.warnings.map((warning) => `- ${warning}`), "");
+  }
+
+  lines.push(
+    "<details>",
+    `<summary>Cost per run, newest first (up to ${TREND_LIMIT})</summary>`,
+    "",
+    `| Run | Status | ${providers.join(" | ")} | Total |`,
+    `| --- | --- | ${providers.map(() => "---:").join(" | ")} | ---: |`,
+    ...trendRows(report, previous, providers),
+    "",
+    "</details>",
+    "",
+    ...harnessFailureDetails(report.harness),
+  );
+  return lines.join("\n");
+}
+
+async function readJsonFiles<T>(dir: string, pattern: string): Promise<T[]> {
+  const files: T[] = [];
+  const glob = new Bun.Glob(pattern);
+  const paths = [...glob.scanSync({ cwd: dir })].sort();
+  for (const path of paths) {
+    try {
+      files.push((await Bun.file(`${dir}/${path}`).json()) as T);
+    } catch (error) {
+      console.warn(`Skipping unreadable ${dir}/${path}: ${String(error)}`);
+    }
+  }
+  return files;
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      results: { type: "string" },
+      previous: { type: "string" },
+      out: { type: "string", default: "nightly-summary.md" },
+      json: { type: "string", default: "nightly-report.json" },
+      "run-id": { type: "string", default: process.env.GITHUB_RUN_ID ?? "" },
+      "run-url": { type: "string", default: "" },
+      sha: { type: "string", default: process.env.GITHUB_SHA ?? "" },
+      providers: { type: "string", default: DEFAULT_PROVIDERS.join(",") },
+      "credential-warn-days": { type: "string", default: "3" },
+    },
+  });
+  if (!values.results) throw new Error("--results is required");
+  const providers = values.providers
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const results = await readJsonFiles<E2eResult>(values.results, "**/e2e-results.json");
+  const previous = values.previous
+    ? await readJsonFiles<NightlyReport>(values.previous, "**/nightly-report.json")
+    : [];
+  const report = buildNightlyReport({
+    results,
+    previous: previous.filter((run) => run.runId !== values["run-id"]),
+    providers,
+    runId: values["run-id"],
+    runUrl: values["run-url"],
+    sha: values.sha,
+    generatedAt: new Date().toISOString(),
+    credentialWarnDays: Number(values["credential-warn-days"]),
+  });
+  const markdown = nightlyMarkdown(report, previous, providers);
+  await Bun.write(values.out, markdown);
+  await Bun.write(values.json, `${JSON.stringify(report, null, 2)}\n`);
+  if (process.env.GITHUB_OUTPUT) {
+    await Bun.write(
+      Bun.file(process.env.GITHUB_OUTPUT),
+      `${await Bun.file(process.env.GITHUB_OUTPUT)
+        .text()
+        .catch(() => "")}ok=${report.ok}\n`,
+    );
+  }
+  console.log(markdown);
+  console.log(`ok=${report.ok}`);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/e2e/redact.ts
+++ b/scripts/e2e/redact.ts
@@ -1,0 +1,84 @@
+/**
+ * Redaction for text the E2E runner publishes: worker-log tails, error
+ * messages, and the uploaded log files. The API and the worker scrub their own
+ * output at egress; this pass covers what third-party CLIs print straight to
+ * the captured stdout, and it masks the exact credential values this process
+ * was given. The job summary, the sticky issue, and the artifacts of a public
+ * repository are readable by anyone.
+ *
+ *   bun scripts/e2e/redact.ts --out <dir> <file>...   # writes redacted copies
+ */
+const REDACTED = "[REDACTED]";
+
+const PATTERNS: RegExp[] = [
+  /\bsk-ant-[A-Za-z0-9_-]{8,}/g,
+  /\bsk-[A-Za-z0-9_-]{16,}/g,
+  /\bgh[pousr]_[A-Za-z0-9]{16,}/g,
+  /\bgithub_pat_[A-Za-z0-9_]{16,}/g,
+  /\bxox[abposer]-[A-Za-z0-9-]{10,}/g,
+  /\bxapp-[A-Za-z0-9-]{10,}/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g,
+];
+const BEARER = /(Bearer\s+)[A-Za-z0-9._~+/=-]{16,}/gi;
+const KEY_VALUE =
+  /((?:api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|secret|password|authorization)["']?\s*[:=]\s*["']?)[^\s"',;]{8,}/gi;
+
+const CREDENTIAL_ENV_KEYS = [
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "CODEX_OAUTH",
+];
+
+/** Exact credential values this process holds: provider env values plus any extra strings. */
+export function knownSecrets(extra: Iterable<string> = []): string[] {
+  const values = new Set<string>();
+  for (const key of CREDENTIAL_ENV_KEYS) {
+    const value = process.env[key];
+    if (value) values.add(value);
+  }
+  const blob = process.env.CODEX_OAUTH;
+  if (blob) {
+    try {
+      const parsed = JSON.parse(blob) as Record<string, unknown>;
+      for (const field of ["access", "refresh"]) {
+        if (typeof parsed[field] === "string") values.add(parsed[field] as string);
+      }
+    } catch {}
+  }
+  for (const value of extra) values.add(value);
+  return [...values].filter((value) => value.length >= 8);
+}
+
+export function redactSecrets(text: string, known: Iterable<string> = []): string {
+  let result = text;
+  for (const secret of known) {
+    if (secret.length >= 8) result = result.split(secret).join(REDACTED);
+  }
+  for (const pattern of PATTERNS) result = result.replace(pattern, REDACTED);
+  result = result.replace(BEARER, `$1${REDACTED}`);
+  result = result.replace(KEY_VALUE, `$1${REDACTED}`);
+  return result;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const outIndex = args.indexOf("--out");
+  if (outIndex === -1 || !args[outIndex + 1]) throw new Error("--out <dir> is required");
+  const outDir = args[outIndex + 1]!;
+  const files = args.filter((_arg, index) => index !== outIndex && index !== outIndex + 1);
+  await Bun.$`mkdir -p ${outDir}`.quiet();
+  const known = knownSecrets();
+  for (const file of files) {
+    const name = file.split("/").pop()!;
+    const text = await Bun.file(file).text();
+    await Bun.write(`${outDir}/${name}`, redactSecrets(text, known));
+  }
+  console.log(`redacted ${files.length} file(s) into ${outDir}`);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/e2e/report.ts
+++ b/scripts/e2e/report.ts
@@ -9,12 +9,44 @@ export type ScenarioResult = {
   durationMs: number;
   error?: string;
 };
-export type HarnessResult = {
-  provider: string;
-  model: string;
+/** Session-cost rows the API stored for one harness attempt, summed. */
+export type HarnessCost = {
+  records: number;
+  totalUsd: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  /** Distinct `costSource` values, comma-joined (harness, pricing-table, unpriced). */
+  costSource: string;
+};
+export type HarnessFailureKind = "setup" | "timeout" | "credential" | "task";
+export type HarnessAttempt = {
   status: "pass" | "fail";
   durationMs: number;
   error?: string;
+  failureKind?: HarnessFailureKind;
+  cost?: HarnessCost;
+  /** Last lines of the worker log, present on failure only. */
+  logTail?: string;
+};
+export type HarnessResult = {
+  provider: string;
+  model: string;
+  /** Status of the final attempt. */
+  status: "pass" | "fail";
+  /** Wall-clock over every attempt. */
+  durationMs: number;
+  error?: string;
+  failureKind?: HarnessFailureKind;
+  attempts: HarnessAttempt[];
+  /** Cost of the final attempt. */
+  cost?: HarnessCost;
+  /** USD summed over every attempt, retries included. */
+  totalCostUsd: number;
+  /** Access-token expiry of the seeded OAuth blob. Codex only. */
+  credentialExpiresAt?: string;
+  logTail?: string;
 };
 
 export type E2eResult = {
@@ -30,6 +62,7 @@ export type E2eResult = {
 
 export type Options = {
   harness: string[];
+  harnessAttempts: number;
   only?: Set<string>;
   skip: Set<string>;
   list: boolean;
@@ -48,6 +81,8 @@ export const helpText = `Usage: bun run e2e [options]
 Options:
   --harness p1,p2               Run real harness legs after the contract scenarios
                                 (claude, codex, pi, opencode)
+  --harness-attempts N          Run a failed harness leg again, N attempts in total
+                                (1 through 5, default: 1)
   --only name,name              Run only named contract scenarios
   --skip name,name              Skip named contract scenarios
   --list                        Print contract scenario names and exit
@@ -81,6 +116,14 @@ function coverageValue(value: string, flag: string): number {
   return number;
 }
 
+function attemptsValue(value: string): number {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < 1 || number > 5) {
+    throw new Error("--harness-attempts must be an integer from 1 through 5");
+  }
+  return number;
+}
+
 function sutEnvValue(value: string): [string, string] {
   const separator = value.indexOf("=");
   if (separator < 1) throw new Error("--sut-env requires KEY=VALUE");
@@ -90,6 +133,7 @@ function sutEnvValue(value: string): [string, string] {
 export function parseOptions(args: string[], scenarioNames: string[]): Options {
   const options: Options = {
     harness: [],
+    harnessAttempts: 1,
     skip: new Set(),
     list: false,
     help: false,
@@ -103,6 +147,7 @@ export function parseOptions(args: string[], scenarioNames: string[]): Options {
     const arg = args[index]!;
     const value = () => optionValue(args, index++, arg);
     if (arg === "--harness") options.harness = listValue(value());
+    else if (arg === "--harness-attempts") options.harnessAttempts = attemptsValue(value());
     else if (arg === "--only") options.only = new Set(listValue(value()));
     else if (arg === "--skip") options.skip = new Set(listValue(value()));
     else if (arg === "--json") options.jsonPath = value();
@@ -146,17 +191,66 @@ export function printScenario(result: ScenarioResult): void {
   console.log(`${colors[result.status]}${label}${colors.reset} ${result.name}${duration}${detail}`);
 }
 
+export function usd(amount: number): string {
+  return `$${amount.toFixed(4)}`;
+}
+
+/** One cell for a harness cost: the USD figure, or "no record" when the API stored nothing. */
+export function costCell(cost: HarnessCost | undefined): string {
+  if (!cost) return "";
+  if (cost.records === 0) return "no record";
+  return `${usd(cost.totalUsd)} (${cost.costSource})`;
+}
+
 export function printHarness(result: HarnessResult): void {
   const color = colors[result.status];
   const detail = result.error ? `: ${result.error}` : "";
+  const attempts = result.attempts.length > 1 ? `, ${result.attempts.length} attempts` : "";
+  const cost = result.cost ? `, ${costCell(result.cost)}` : "";
   console.log(
     `${color}${result.status.toUpperCase()}${colors.reset} harness ${result.provider} ` +
-      `(${result.model}, ${seconds(result.durationMs)})${detail}`,
+      `(${result.model}, ${seconds(result.durationMs)}${attempts}${cost})${detail}`,
   );
 }
 
-function markdownCell(value: string): string {
+export function markdownCell(value: string): string {
   return value.replaceAll("|", "\\|").replaceAll("\n", "<br>");
+}
+
+export function harnessTable(legs: HarnessResult[]): string[] {
+  return [
+    "| Provider | Model | Status | Attempts | Duration | Cost | Tokens in+cache / out | Error |",
+    "| --- | --- | --- | ---: | ---: | --- | ---: | --- |",
+    ...legs.map((leg) => {
+      // Input counts cache reads and writes, the same unified formula the cost pages use.
+      const tokens = leg.cost?.records
+        ? `${leg.cost.inputTokens + leg.cost.cacheReadTokens + leg.cost.cacheWriteTokens} / ${leg.cost.outputTokens}`
+        : "";
+      return `| ${leg.provider} | ${markdownCell(leg.model)} | ${leg.status.toUpperCase()} | ${leg.attempts.length} | ${seconds(leg.durationMs)} | ${costCell(leg.cost)} | ${tokens} | ${markdownCell(leg.error ?? "")} |`;
+    }),
+  ];
+}
+
+/** Collapsed worker-log tails for every failed attempt, so the raw job log is never required. */
+export function harnessFailureDetails(legs: HarnessResult[]): string[] {
+  const lines: string[] = [];
+  for (const leg of legs) {
+    leg.attempts.forEach((attempt, index) => {
+      if (attempt.status !== "fail") return;
+      lines.push(
+        "<details>",
+        `<summary>${leg.provider} attempt ${index + 1}: ${markdownCell(attempt.error ?? "failed")}${attempt.failureKind ? ` (${attempt.failureKind})` : ""}</summary>`,
+        "",
+        "```text",
+        attempt.logTail?.replaceAll("```", "` ` `") ?? "(no worker log)",
+        "```",
+        "",
+        "</details>",
+        "",
+      );
+    });
+  }
+  return lines;
 }
 
 export function markdownSummary(result: E2eResult): string {
@@ -179,12 +273,9 @@ export function markdownSummary(result: E2eResult): string {
       "",
       "### Harness",
       "",
-      "| Provider | Model | Status | Duration | Error |",
-      "| --- | --- | --- | ---: | --- |",
-      ...result.harness.map(
-        (leg) =>
-          `| ${leg.provider} | ${leg.model} | ${leg.status.toUpperCase()} | ${seconds(leg.durationMs)} | ${markdownCell(leg.error ?? "")} |`,
-      ),
+      ...harnessTable(result.harness),
+      "",
+      ...harnessFailureDetails(result.harness),
     );
   }
   lines.push(

--- a/scripts/e2e/run.ts
+++ b/scripts/e2e/run.ts
@@ -174,6 +174,7 @@ async function main(): Promise<number> {
       activeSut.baseUrl,
       activeSut.apiKey,
       ctx.nonce,
+      options.harnessAttempts,
     );
     harnessResults.push(result);
     printHarness(result);

--- a/src/tests/e2e-nightly-report.test.ts
+++ b/src/tests/e2e-nightly-report.test.ts
@@ -131,6 +131,9 @@ describe("nightly report", () => {
     expect(markdown).toContain("| pi | | MISSING |");
     expect(markdown).toContain("codex attempt 1: codex task finished with status failed (task)");
     expect(markdown).toContain("EACCES: permission denied");
+    const issue = nightlyMarkdown(report, [], DEFAULT_PROVIDERS, { logTails: false });
+    expect(issue).not.toContain("EACCES");
+    expect(issue).toContain("Worker log tails for the failed attempts are in the [run summary]");
   });
 
   test("warns on a missing cost record, an expiring credential, and a failed contract", () => {

--- a/src/tests/e2e-nightly-report.test.ts
+++ b/src/tests/e2e-nightly-report.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildNightlyReport,
+  DEFAULT_PROVIDERS,
+  type NightlyReport,
+  nightlyMarkdown,
+} from "../../scripts/e2e/nightly-report";
+import type { E2eResult, HarnessResult } from "../../scripts/e2e/report";
+
+const coverage: E2eResult["coverage"] = {
+  routes: { total: 352, covered: 16, percent: 4.5, byGroup: {}, uncovered: [], unknown: [] },
+  mcpTools: { total: 114, covered: 4, percent: 3.5, uncovered: [] },
+};
+
+function contractResult(ok = true): E2eResult {
+  return {
+    startedAt: "2026-09-04T03:23:00.000Z",
+    durationMs: 5_000,
+    sut: { port: 1, dbPath: "/tmp/db", logPath: "/tmp/log" },
+    scenarios: [
+      { name: "health", status: "pass", durationMs: 2 },
+      {
+        name: "auth",
+        status: ok ? "pass" : "fail",
+        durationMs: 17,
+        error: ok ? undefined : "boom",
+      },
+    ],
+    harness: [],
+    coverage,
+    gates: { minRouteCoverage: 3, minToolCoverage: 2, passed: true },
+    ok,
+  };
+}
+
+function leg(provider: string, overrides: Partial<HarnessResult> = {}): HarnessResult {
+  const cost = {
+    records: 1,
+    totalUsd: 0.0123,
+    inputTokens: 1000,
+    outputTokens: 20,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    costSource: "harness",
+  };
+  return {
+    provider,
+    model: `${provider}-model`,
+    status: "pass",
+    durationMs: 9_000,
+    attempts: [{ status: "pass", durationMs: 9_000, cost }],
+    cost,
+    totalCostUsd: cost.totalUsd,
+    ...overrides,
+  };
+}
+
+function harnessResult(legs: HarnessResult[]): E2eResult {
+  return {
+    ...contractResult(),
+    scenarios: [{ name: "health", status: "pass", durationMs: 2 }],
+    harness: legs,
+  };
+}
+
+const base = {
+  providers: DEFAULT_PROVIDERS,
+  previous: [] as NightlyReport[],
+  runId: "42",
+  runUrl: "https://example.test/runs/42",
+  sha: "abcdef1234567890",
+  generatedAt: "2026-09-04T03:30:00.000Z",
+  credentialWarnDays: 3,
+};
+
+describe("nightly report", () => {
+  test("passes when the contract and every leg pass", () => {
+    const report = buildNightlyReport({
+      ...base,
+      results: [
+        contractResult(),
+        ...DEFAULT_PROVIDERS.map((provider) => harnessResult([leg(provider)])),
+      ],
+    });
+    expect(report.ok).toBe(true);
+    expect(report.missingLegs).toEqual([]);
+    expect(report.totalCostUsd).toBeCloseTo(0.0492, 6);
+    expect(report.warnings).toEqual([]);
+    const markdown = nightlyMarkdown(report, [], DEFAULT_PROVIDERS);
+    expect(markdown).toContain("## Nightly E2E: PASS");
+    expect(markdown).toContain("4/4 harness legs passed");
+    expect(markdown).toContain("| claude | claude-model | PASS | 1 |");
+    expect(markdown).not.toContain("### Warnings");
+  });
+
+  test("fails on a missing leg and on a failed leg, with the log tail in details", () => {
+    const failed = leg("codex", {
+      status: "fail",
+      error: "codex task finished with status failed",
+      failureKind: "task",
+      attempts: [
+        {
+          status: "fail",
+          durationMs: 3_000,
+          error: "codex task finished with status failed",
+          failureKind: "task",
+          logTail: "EACCES: permission denied, open 'AGENTS.md'",
+        },
+        {
+          status: "fail",
+          durationMs: 3_000,
+          error: "codex task finished with status failed",
+          failureKind: "task",
+          logTail: "EACCES again",
+        },
+      ],
+      cost: undefined,
+      totalCostUsd: 0,
+    });
+    const report = buildNightlyReport({
+      ...base,
+      results: [contractResult(), harnessResult([leg("claude")]), harnessResult([failed])],
+    });
+    expect(report.ok).toBe(false);
+    expect(report.missingLegs).toEqual(["pi", "opencode"]);
+    expect(report.warnings).toContain("pi: no result file from the leg.");
+    expect(report.warnings).toContain("codex: needed 2 attempts.");
+    const markdown = nightlyMarkdown(report, [], DEFAULT_PROVIDERS);
+    expect(markdown).toContain("## Nightly E2E: FAIL");
+    expect(markdown).toContain("| codex | codex-model | FAIL | 2 |");
+    expect(markdown).toContain("| pi | | MISSING |");
+    expect(markdown).toContain("codex attempt 1: codex task finished with status failed (task)");
+    expect(markdown).toContain("EACCES: permission denied");
+  });
+
+  test("warns on a missing cost record, an expiring credential, and a failed contract", () => {
+    const codex = leg("codex", { credentialExpiresAt: "2026-09-06T00:00:00.000Z" });
+    const opencode = leg("opencode", {
+      cost: { ...leg("opencode").cost!, records: 0, totalUsd: 0 },
+      totalCostUsd: 0,
+    });
+    const report = buildNightlyReport({
+      ...base,
+      results: [contractResult(false), harnessResult([leg("claude"), codex, leg("pi"), opencode])],
+    });
+    expect(report.ok).toBe(false);
+    expect(report.warnings).toContainEqual(
+      expect.stringContaining("codex: the seeded OAuth access token expires in 1.9 days"),
+    );
+    expect(report.warnings).toContain(
+      "opencode: the task passed but the API stored no cost record.",
+    );
+    const markdown = nightlyMarkdown(report, [], DEFAULT_PROVIDERS);
+    expect(markdown).toContain("| auth | FAIL | boom |");
+    expect(markdown).toContain("| opencode | opencode-model | PASS | 1 | 9.0s | no record |");
+  });
+
+  test("normalizes a legacy leg without attempts and orders the trend newest first", () => {
+    const legacy = {
+      provider: "claude",
+      model: "m",
+      status: "pass",
+      durationMs: 1,
+    } as HarnessResult;
+    const older: NightlyReport = {
+      ...buildNightlyReport({
+        ...base,
+        results: [contractResult(), harnessResult([leg("claude")])],
+      }),
+      runId: "41",
+      runUrl: "https://example.test/runs/41",
+      generatedAt: "2026-09-03T03:30:00.000Z",
+    };
+    const report = buildNightlyReport({
+      ...base,
+      previous: [older],
+      results: [contractResult(), harnessResult([legacy])],
+    });
+    expect(report.harness[0]?.attempts).toHaveLength(1);
+    expect(report.harness[0]?.totalCostUsd).toBe(0);
+    const markdown = nightlyMarkdown(report, [older], DEFAULT_PROVIDERS);
+    const rows = markdown.split("\n").filter((line) => line.startsWith("| [2026-09-0"));
+    expect(rows[0]).toContain("[2026-09-04](https://example.test/runs/42)");
+    expect(rows[1]).toContain("[2026-09-03](https://example.test/runs/41)");
+    expect(rows[1]).toContain("$0.0123");
+  });
+});

--- a/src/tests/e2e-redact.test.ts
+++ b/src/tests/e2e-redact.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { knownSecrets, redactSecrets } from "../../scripts/e2e/redact";
+
+describe("e2e redaction", () => {
+  test("masks exact known values and common token shapes", () => {
+    const text = [
+      "Authorization: Bearer 0123456789abcdef0123456789abcdef",
+      "OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz0123",
+      "anthropic sk-ant-api03-abcdefghijklmnop",
+      "github ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+      "slack xoxb-1234567890-abcdefghijk",
+      'auth.json {"refresh_token":"rt-abcdefghijklmnop","id_token":"x.y.z"}',
+      "jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+      "my-secret-run-key-value appears here",
+    ].join("\n");
+    const out = redactSecrets(text, ["my-secret-run-key-value"]);
+    expect(out).not.toContain("0123456789abcdef0123456789abcdef");
+    expect(out).not.toContain("sk-proj-");
+    expect(out).not.toContain("sk-ant-");
+    expect(out).not.toContain("ghp_");
+    expect(out).not.toContain("xoxb-");
+    expect(out).not.toContain("rt-abcdefghijklmnop");
+    expect(out).not.toContain("eyJhbGciOiJIUzI1NiJ9");
+    expect(out).not.toContain("my-secret-run-key-value");
+    expect(out).toContain("Authorization: Bearer [REDACTED]");
+    expect(out).toContain("OPENAI_API_KEY=[REDACTED]");
+    expect(out).toContain("[REDACTED] appears here");
+  });
+
+  test("leaves ordinary worker log lines alone", () => {
+    const text = [
+      "[worker] Trigger received: task_assigned",
+      "[worker] Loaded 47 skills for system prompt",
+      "INFO harness claude cost records: 1 ($0.1513, pricing-table)",
+      "inputTokens: 217652, outputTokens: 1609",
+      "[credentials] Selected OPENROUTER_API_KEY credential 1/1 (1 available of 1) [...daec4]",
+      "createSession failed: EACCES: permission denied, open '/__w/agent-swarm/AGENTS.md'",
+    ].join("\n");
+    expect(redactSecrets(text, ["short"])).toBe(text);
+  });
+
+  test("knownSecrets reads provider env values and the codex blob fields", () => {
+    const saved = { ...process.env };
+    try {
+      process.env.OPENROUTER_API_KEY = "sk-or-v1-known-value-1234";
+      process.env.CODEX_OAUTH = JSON.stringify({
+        access: "access-token-value-1234",
+        refresh: "refresh-token-value-1234",
+        expires: 1,
+        accountId: "acct",
+      });
+      const known = knownSecrets(["extra-secret-value"]);
+      expect(known).toContain("sk-or-v1-known-value-1234");
+      expect(known).toContain("access-token-value-1234");
+      expect(known).toContain("refresh-token-value-1234");
+      expect(known).toContain("extra-secret-value");
+    } finally {
+      for (const key of Object.keys(process.env)) {
+        if (!(key in saved)) delete process.env[key];
+      }
+      Object.assign(process.env, saved);
+    }
+  });
+});


### PR DESCRIPTION
## Why

The first scheduled run, [33848846343](https://github.com/desplega-ai/agent-swarm/actions/runs/33848846343), showed four problems:

- **Codex failed on permissions, both attempts.** The worker runs as `worker` via gosu, `actions/checkout` writes the repo as root, and the codex adapter writes `AGENTS.md` into the session cwd, which was the checkout. EACCES is deterministic, so the retry bought nothing.
- **The whole-suite retry hid a 300 s opencode hang** and overwrote the first result file. The contract scenarios also ran four times.
- **Opencode reported zero cost records.** The leg read costs once, right after the task turned terminal, before the worker had posted its row.
- **The step summary was four copies of the coverage tables** plus 336 uncovered routes each.

## What changed

**Runner (`scripts/e2e/`)**

- Harness tasks run in a workspace directory under the leg's temp HOME (passed as the task `dir`), never in the checkout. Fixes the codex EACCES and matches production, where workers never run inside the repo.
- Claude default model is `claude-sonnet-5` (was haiku 4.5). Override stays `E2E_MODEL_CLAUDE`.
- `--harness-attempts N` retries inside the runner. Every attempt lands in the JSON with duration, cost, failure kind (`setup` / `timeout` / `credential` / `task`), and the last 60 worker-log lines.
- After the task turns terminal the leg polls `/api/session-costs` for up to 15 s and records USD, tokens, and `costSource`. A passing task with no row reads as `no record`, never as `$0`.
- Codex legs record the seeded access-token expiry so the report can warn before the blob goes stale.
- New `scripts/e2e/nightly-report.ts` merges every job's `e2e-results.json` into one Markdown summary plus `nightly-report.json`, with a cost trend over earlier runs and a warnings section (retries, missing cost rows, missing legs, expiring credential, failed gates).

**Workflow (`.github/workflows/nightly-e2e.yml`)**

- `contract`: scenarios once on plain Ubuntu with coverage floors (routes ≥ 3 %, tools ≥ 2 %). The floors guard the recorder, not the scenarios.
- `harness` × 4: `--only health --harness <p> --harness-attempts 2 --keep`, uploads results and `/tmp/e2e-*.log`.
- `report` (`needs` both, `!cancelled()`): downloads the artifacts, pulls up to 14 earlier `nightly-e2e-report` artifacts for the trend, writes one step summary, uploads the report with 90-day retention, upserts one sticky issue (body starts with `<!-- nightly-e2e -->`) while failing and closes it on green, then fails the run when anything failed. Only this job has `issues: write` and `actions: read`.
- Cron moved to `23 3 * * *` (the 03:00 run started at 07:27), `concurrency: nightly-e2e` without cancel.

Docs: `LOCAL_TESTING.md` § Harness legs and § Nightly E2E workflow.

## Verification

```bash
bun run e2e:tsc
bash scripts/check-e2e-boundary.sh
actionlint .github/workflows/nightly-e2e.yml
bun test src/tests/e2e-nightly-report.test.ts          # 4 pass
bun run e2e --json /tmp/n/contract/e2e-results.json --min-route-coverage 3 --min-tool-coverage 2   # 9 pass, gates PASS
bun run e2e --only health --harness claude,codex,pi,opencode --harness-attempts 2 --keep --json /tmp/n/harness/e2e-results.json
bun scripts/e2e/nightly-report.ts --results /tmp/n --previous /tmp/n/previous --out /tmp/n/summary.md --json /tmp/n/report.json
```

Local harness legs, all four passed on the first attempt (codex via `codex login --with-api-key`):

| Provider | Model | Duration | Cost | Tokens in+cache / out |
| --- | --- | ---: | --- | ---: |
| claude | claude-sonnet-5 | 34.9s | $0.1513 (pricing-table) | 240573 / 1609 |
| codex | gpt-5.6-luna | 10.1s | $0.0042 (pricing-table) | 20495 / 49 |
| pi | openrouter/deepseek/deepseek-v4-flash | 19.0s | $0.0064 (pricing-table) | 152445 / 290 |
| opencode | openrouter/deepseek/deepseek-v4-flash | 24.5s | $0.0070 (pricing-table) | 130586 / 143 |

The report job, sticky issue, and trend download only run on the schedule or `workflow_dispatch`, so the first real exercise is the next nightly. Older runs have no `nightly-e2e-report` artifact, so the first trend table has one row.

## Notes

- Sonnet 5 costs about $0.15 per night for the one-line task because the worker's system prompt is about 240k cached tokens. Haiku was about a third of that. Flagging, not blocking.
- Opencode stored a cost row locally once the leg polled for it, which supports the race explanation for the zero in CI.
