### PR TITLE
docs: switch browser automation from qa-use to agent-browser

### DIFF
--- a/.claude/skills/swarm-local-e2e/SKILL.md
+++ b/.claude/skills/swarm-local-e2e/SKILL.md
@@ -17,7 +17,7 @@ This skill should be invoked in two modes:
    - **Task lifecycle changes** (poll, runner, store-progress): Create assigned + pool tasks, verify they complete and have correct logs
    - **Session log changes**: Run two sequential tasks on the same agent, verify log isolation (unique sessionIds, no cross-contamination)
    - **Docker / entrypoint changes**: Build image, start containers, verify boot logs and registration
-   - **UI changes**: Start the dashboard, use agent-browser/qa-use to verify rendering
+   - **UI changes**: Start the dashboard, use agent-browser to verify rendering
    - **API endpoint changes**: Call the endpoint directly and verify the response
 
 You do not need to run every step — pick the subset relevant to the changes being tested.
@@ -199,16 +199,15 @@ cd apps/ui && bun run dev --port 5276
 
 The UI connects to the API via `VITE_API_URL` (check `apps/ui/.env` or defaults to `http://localhost:$PORT`).
 
-### Visual verification with agent-browser / qa-use
+### Visual verification with agent-browser
 
-Use `agent-browser` or `qa-use` to automate UI checks:
+Use `agent-browser` to automate UI checks (never `qa-use` unless explicitly asked):
 
 ```bash
 # Quick visual gut-check with agent-browser
-agent-browser --url http://localhost:5175 snapshot
-
-# Or use qa-use to verify specific flows
-qa-use explore http://localhost:5175
+agent-browser open http://localhost:5175
+agent-browser snapshot
+agent-browser screenshot /tmp/e2e-dashboard.png
 ```
 
 Things to verify in the UI:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,12 +273,12 @@ Operator-tunable env vars are surfaced on the dashboard **Settings → Configura
 
 <important if="you are writing or running tests, drafting a plan with verification / E2E / QA steps, or preparing a frontend PR (apps/ui/, apps/templates-ui/)">
 
-Hub: [runbooks/testing.md](./runbooks/testing.md) — routes to LOCAL_TESTING.md, qa-use, swarm-local-e2e skill, memory tests, Slack E2E.
+Hub: [runbooks/testing.md](./runbooks/testing.md) — routes to LOCAL_TESTING.md, agent-browser UI verification, swarm-local-e2e skill, memory tests, Slack E2E.
 
 Hard rules:
 - Plan-mode verification steps MUST copy real commands from LOCAL_TESTING.md; don't paraphrase.
 - The black-box runner and optional `--harness` legs are documented in `LOCAL_TESTING.md` under `Black-box E2E`.
-- Frontend PRs (`apps/ui/`, `apps/templates-ui/`) MUST include a `qa-use` session with screenshots — enforced by merge gate.
+- Frontend PRs (`apps/ui/`, `apps/templates-ui/`) MUST include screenshots of the change running locally, captured with `agent-browser` and uploaded to agent-fs (signed URL in the PR body). Never `qa-use` unless explicitly asked. This is a reviewer convention; no CI job enforces it. Recipe: LOCAL_TESTING.md § When you need to verify a UI change.
 - E2E/test agents MUST use valid UUID agent IDs (e.g. `AGENT_ID=$(uuidgen)`), never slugs like `e2e-lead` — several MCP tool *output* schemas pin `yourAgentId`/`task.agentId` to UUID, so slug-ID agents get `MCP error -32602: Output validation error` on `get-tasks`/`get-task-details`/`store-progress`/`memory-search` **after the write already landed** (retrying double-writes).
 - Tests MUST NOT hard-code ports. CI runs `bun test --parallel=4` (one worker process per file), so two files with the same literal collide. Use `src/tests/test-net.ts`: `listenOnFreePort(server)` for in-process `node:http` servers, `port: 0` + `server.port` for `Bun.serve`, `getFreePort()` + `waitForServer()` for spawned `src/http.ts` children. No global test retry: a timing-sensitive test opts in with `test(name, fn, { retry: 2 })` plus a comment.
 
@@ -322,7 +322,7 @@ Drift checks — run only if you touched the trigger files, MUST commit any rege
 - Touched `apps/ui/` — or root `bun.lock`/`package.json`/`bunfig.toml` (ui deps resolve from the root lock)? → `cd apps/ui && bun install --frozen-lockfile && bun run lint && bunx tsc -b` (CI uses `tsc -b`, not `--noEmit`)
 - Touched `Dockerfile` / `Dockerfile.worker` / `apps/evals/Dockerfile` / files they COPY (incl. `bunfig.toml`, member `package.json`s, `.dockerignore`)? → `docker build -f <Dockerfile> .` — CI builds all three images
 
-Frontend (`apps/ui/`, `apps/templates-ui/`) PRs additionally require a `qa-use` session with screenshots.
+Frontend (`apps/ui/`, `apps/templates-ui/`) PRs additionally require `agent-browser` screenshots uploaded to agent-fs (recipe: LOCAL_TESTING.md § When you need to verify a UI change).
 
 </important>
 

--- a/LOCAL_TESTING.md
+++ b/LOCAL_TESTING.md
@@ -218,13 +218,27 @@ cd apps/ui && bun run dev --port 5275   # if 5274 is taken
 
 ### When you need to verify a UI change
 
-Use the `qa-use` tool family:
+Use `agent-browser` (never `qa-use` unless explicitly asked):
 
-- `/qa-use:explore <url>` — quick walkthrough, AI-powered element discovery
-- `/qa-use:verify` — verify a defined feature
-- `/qa-use:test-run` — run existing E2E tests
+```bash
+agent-browser skills get core                 # version-matched usage guide, once per session
+agent-browser open http://localhost:5274/tasks
+agent-browser snapshot                        # accessibility tree with @eN refs
+agent-browser click @e12                      # act on refs from the snapshot
+agent-browser screenshot /tmp/ui-tasks.png
+agent-browser close
+```
 
-**PR requirement**: any PR touching `apps/ui/` or `apps/templates-ui/` must include a `qa-use` session with screenshots of the change running locally. Merge-gate enforces this.
+To share a screenshot (PR body, review comment, Slack), upload it to agent-fs and paste the signed URL:
+
+```bash
+agent-fs write qa/agent-swarm/$(date +%F)-<topic>/ui-tasks.png --file /tmp/ui-tasks.png -m "<what it shows>"
+agent-fs signed-url qa/agent-swarm/$(date +%F)-<topic>/ui-tasks.png --json   # 24h default, --expires-in up to 7d
+```
+
+`agent-fs write --file` (or piped stdin) is the binary-safe path (CLI >= 0.7.1). `--content` is text-only and mangles PNGs.
+
+**PR requirement**: any PR touching `apps/ui/` or `apps/templates-ui/` must include `agent-browser` screenshots of the change running locally, embedded as `![caption](<signed-url>)`. This is a reviewer convention. No job in `.github/workflows/merge-gate.yml` checks it.
 
 ### Port-conflict resolution
 

--- a/apps/ui/CLAUDE.md
+++ b/apps/ui/CLAUDE.md
@@ -288,8 +288,8 @@ A handful of detail pages are exempt because their identity is an editor or spli
 
 <important if="you are preparing a PR that touches ui/, or running automated UI tests against ui">
 
-## qa-use & PR screenshot requirement
+## agent-browser & PR screenshot requirement
 
-Use `qa-use` for browser automation: `/qa-use:test-run`, `/qa-use:verify`, `/qa-use:explore`. Any PR touching `ui/` MUST include a `qa-use` session with screenshots of the changes running locally — enforced by the merge gate. Port-conflict handling: [../LOCAL_TESTING.md § Dashboard UI](../LOCAL_TESTING.md#dashboard-ui).
+Use `agent-browser` for browser automation (`agent-browser open <url>`, `snapshot`, `screenshot <path>`). Never `qa-use` unless explicitly asked. Any PR touching `ui/` MUST include screenshots of the changes running locally, uploaded to agent-fs with the signed URL in the PR body. This is a reviewer convention; no CI job enforces it. Recipe: [../LOCAL_TESTING.md § When you need to verify a UI change](../LOCAL_TESTING.md#when-you-need-to-verify-a-ui-change). Port-conflict handling: [../LOCAL_TESTING.md § Dashboard UI](../LOCAL_TESTING.md#dashboard-ui).
 
 </important>

--- a/runbooks/ci.md
+++ b/runbooks/ci.md
@@ -123,4 +123,4 @@ CI uses `bun install --frozen-lockfile`. A single root install now covers `apps/
 - **`docs-site/`** deploys via Vercel — `pnpm build` in `docs-site/` must pass. See [docs-site/CLAUDE.md](../docs-site/CLAUDE.md).
 - **`apps/templates-ui/`** — same Vercel pattern.
 
-Frontend-touching PRs additionally need a `qa-use` session with screenshots — see [testing.md](./testing.md).
+Frontend-touching PRs additionally need `agent-browser` screenshots uploaded to agent-fs (reviewer convention, not a CI job). See [testing.md](./testing.md).

--- a/runbooks/testing.md
+++ b/runbooks/testing.md
@@ -9,15 +9,15 @@ Hub for everything test-shaped in this repo. The canonical, up-to-date testing r
 | Writing or running unit tests (`bun run test:root` from the workspace root), the Docker smoke-test, the entrypoint round-trip checklist, the MCP handshake sequence | [LOCAL_TESTING.md](../LOCAL_TESTING.md) |
 | Running the **full guided E2E flow** (tasks, session logs, UI verification) | Invoke the `swarm-local-e2e` skill |
 | Drafting a plan with verification / E2E / QA steps | [LOCAL_TESTING.md](../LOCAL_TESTING.md) — copy command forms verbatim, don't paraphrase |
-| Preparing a frontend PR (`apps/ui/`, `apps/templates-ui/`) | qa-use session + screenshots required (merge gate). Per-package conventions in `apps/ui/CLAUDE.md` |
+| Preparing a frontend PR (`apps/ui/`, `apps/templates-ui/`) | `agent-browser` screenshots uploaded to agent-fs, signed URL in the PR body (reviewer convention, not a CI gate). Recipe in [LOCAL_TESTING.md § When you need to verify a UI change](../LOCAL_TESTING.md#when-you-need-to-verify-a-ui-change). Per-package conventions in `apps/ui/CLAUDE.md` |
 | Modifying memory-system code | [memory-system.md](./memory-system.md) — runs all four memory test files |
 | Testing Slack integration / driving the **LOCAL** dev swarm | Dev channel `#swarm-dev-2` (`C0AR967K0KZ`), bot `@dev-swarm` (`U0ALZGQCF96`). Send via `slack_send_message` MCP tool to trigger task-assignment flow |
 | Sending a task to the **PRODUCTION / deployed** swarm | Use the swarm-user MCP `mcp__agent-swarm-user__send-task` (creates an unassigned task in the production pool; read back with `mcp__agent-swarm-user__get-tasks`). **Not** the dev Slack channel. MCP may not be enabled every session — check for `mcp__agent-swarm-user__*` first |
-| Picking which qa-use slash command | `/qa-use:test-run` (run), `/qa-use:verify` (feature works), `/qa-use:explore` (open page) |
+| Driving a browser to verify UI | `agent-browser` only (`open`, `snapshot`, `screenshot`). Load the guide with `agent-browser skills get core`. Never `qa-use` unless explicitly asked |
 
 ## Hard rules
 
-1. **Frontend PRs require a qa-use session with screenshots.** Enforced by `.github/workflows/merge-gate.yml`.
+1. **Frontend PRs require `agent-browser` screenshots uploaded to agent-fs.** Reviewer convention. `.github/workflows/merge-gate.yml` does not check it.
 2. **Plan-mode verification steps must reference real commands** from `LOCAL_TESTING.md` — invented commands break agent runs.
 3. **Memory tests are not optional** when touching memory code — all four files in [memory-system.md](./memory-system.md).
 4. **Never hard-code a test port.** CI runs `bun test --parallel=4` (one worker process per file), so two files with the same literal collide. Use `listenOnFreePort(server)` / `getFreePort()` / `waitForServer()` from `src/tests/test-net.ts`. Commands, the preload template cache, and the `--changed` pre-push hook are in [LOCAL_TESTING.md](../LOCAL_TESTING.md).

--- a/templates/skills/artifacts/content.md
+++ b/templates/skills/artifacts/content.md
@@ -88,13 +88,24 @@ session goes to agent-fs.
 
 ## Binary artifacts (PNG, MP4)
 
-**`agent-fs write` is text-only and mangles binaries** (it inserts UTF-8
-replacement characters). Use a binary-safe upload path instead:
+`agent-fs write --content` is text-only and mangles binaries. Upload binaries
+with `--file` (or piped stdin), which uses the binary-safe raw route
+(agent-fs CLI >= 0.7.1):
 
-- QA screenshots → use `qa-use`'s built-in screenshot capture, which uploads
-  correctly on your behalf.
-- Custom captures → Playwright, ffmpeg, or a system screenshot tool, then
-  upload via the binary path rather than `agent-fs write`.
+```bash
+agent-fs write thoughts/<agent-id>/qa/<topic>-screenshots/login.png \
+  --file /tmp/login.png -m "login page after fix"
+agent-fs stat thoughts/<agent-id>/qa/<topic>-screenshots/login.png --json | jq '.size'
+```
+
+Capture with `agent-browser screenshot <path>` when it is installed, otherwise
+Playwright, ffmpeg, or a system screenshot tool. For an image that must render
+inside a PR body or a Slack message without a login, use a presigned URL
+instead of the viewer link:
+
+```bash
+agent-fs signed-url thoughts/<agent-id>/qa/<topic>-screenshots/login.png --json   # 24h default, --expires-in up to 7d
+```
 
 ## Naming conventions
 


### PR DESCRIPTION
## Why

Every instruction surface in this repo told agents to use `qa-use` for UI verification and claimed the merge gate enforces a qa-use screenshot session. Nothing in `.github/workflows/merge-gate.yml` checks that. The decision (2026-09-04) is: `agent-browser` always, and share screenshots through `agent-fs` (`write --file` + `signed-url`) when they need to land on a PR, an issue, or Slack.

## What changed

- `CLAUDE.md`, `runbooks/testing.md`, `runbooks/ci.md`, `apps/ui/CLAUDE.md`, `LOCAL_TESTING.md`: agent-browser recipe (`skills get core`, `open`, `snapshot`, `screenshot`) plus the agent-fs upload recipe. The frontend-PR screenshot rule now reads "reviewer convention, no CI job checks it", which is the truth.
- `.claude/skills/swarm-local-e2e/SKILL.md`: qa-use branch removed. The old `agent-browser --url ... snapshot` invocation was wrong for the current CLI and is now `open` then `snapshot`.
- `templates/skills/artifacts/content.md` (seeded skill): the binary section said `agent-fs write` mangles binaries and pointed at qa-use capture. Since agent-fs 0.7.1, `write --file` (or piped stdin) uses the binary-safe raw route, so the recipe is now `write --file` + `signed-url`. `bun run check:skill-sources && bun run check:skill-md && bun run check:seed-skill-files` all pass.

## agent-fs version bump: not in this PR (blocked)

`bun run bump:agent-fs` refuses 0.13.4 because `ghcr.io/desplega-ai/agent-fs:0.13.4` does not exist. The agent-fs v0.13.4 release published to npm, but its "Publish Docker Image" and "Deploy to Fly.io" runs failed on `bun install --frozen-lockfile`. Root cause reproduced locally: `bun.lock` on agent-fs main still records workspace versions 0.13.2 and fuse deps `^0.8.1`; bun 1.4.1 (what `oven/bun:1.4` resolves to now) treats that as drift, bun 1.4.0 does not. The lockfile needs regenerating in the agent-fs repo and the image republished before the pins here can move. Tracked with the worker-side work in DES-781.

## Verification

- Seeded-skill checks: green (see above).
- Pre-push hook: full unit suite green (8183 tests) once `ANTHROPIC_API_KEY` is blanked; three `resolveWorkflowLlmConfig` tests fail whenever `.env` supplies that key, unrelated to this change.
- Smoke test of the documented recipe: `agent-browser screenshot` produced a real PNG, `agent-fs write --file` uploaded it byte-exact to a root-level path and `signed-url` returned a link. Nested paths 404 against servers older than 0.13.4 (server-side fix in agent-fs #39).

Docs only. No runtime code touched.