### PR TITLE
chore: bump agent-fs pins to 0.13.5

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -220,7 +220,7 @@ ARG SKILLS_CLI_VERSION
 # agent-fs version pins BOTH the skill source tag (here) and the CLI in
 # /opt/global-deps (below). Bump with `bun run bump:agent-fs` so the chart,
 # Compose, and docs pins move in lockstep with this ARG.
-ARG AGENT_FS_VERSION=0.13.3
+ARG AGENT_FS_VERSION=0.13.5
 RUN npx -y skills@${SKILLS_CLI_VERSION} add desplega-ai/agent-fs@v${AGENT_FS_VERSION} --skill agent-fs -g -a claude-code -y \
     && test -e /home/worker/.claude/skills/agent-fs/SKILL.md \
     && rm -rf /home/worker/.npm

--- a/charts/agent-swarm/README.md
+++ b/charts/agent-swarm/README.md
@@ -78,7 +78,7 @@ Deploys the [agent-fs](https://github.com/desplega-ai/agent-fs) HTTP service alo
 agentFs:
   enabled: true
   image:
-    tag: 0.13.3
+    tag: 0.13.5
   bucket: my-agent-fs-bucket
   # Optional. When blank, the API boot seeder registers a service user with
   # agent-fs and stores the generated bootstrap key in encrypted swarm_config.

--- a/charts/agent-swarm/values.yaml
+++ b/charts/agent-swarm/values.yaml
@@ -227,7 +227,7 @@ agentFs:
     registry: ghcr.io
     repository: desplega-ai/agent-fs
     pullPolicy: IfNotPresent
-    tag: 0.13.3
+    tag: 0.13.5
   port: 7433
   # -- Optional API-owned bootstrap key for agent-fs. When blank, the swarm API
   # boot seeder registers a service user and persists its generated key in

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -51,7 +51,7 @@ services:
       "
 
   agent-fs:
-    image: ghcr.io/desplega-ai/agent-fs:0.13.3
+    image: ghcr.io/desplega-ai/agent-fs:0.13.5
     platform: linux/amd64
     pull_policy: always
     depends_on:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -45,7 +45,7 @@ services:
 
   agent-fs:
     container_name: swarm-agent-fs
-    image: ghcr.io/desplega-ai/agent-fs:0.13.3
+    image: ghcr.io/desplega-ai/agent-fs:0.13.5
     platform: linux/amd64
     depends_on:
       minio-init:

--- a/docker-compose.scripts-only.yml
+++ b/docker-compose.scripts-only.yml
@@ -45,7 +45,7 @@ services:
 
   agent-fs:
     container_name: so-agent-fs
-    image: ghcr.io/desplega-ai/agent-fs:0.13.3
+    image: ghcr.io/desplega-ai/agent-fs:0.13.5
     platform: linux/amd64
     depends_on:
       minio-init:

--- a/docs-site/content/docs/(documentation)/guides/agent-fs-co-deployment.mdx
+++ b/docs-site/content/docs/(documentation)/guides/agent-fs-co-deployment.mdx
@@ -75,7 +75,7 @@ Enable the co-deployed service with `agentFs.enabled=true`:
 agentFs:
   enabled: true
   image:
-    tag: 0.13.3
+    tag: 0.13.5
   bucket: agentfs
   s3:
     existingSecret: agent-fs-s3


### PR DESCRIPTION
## What

`bun run bump:agent-fs` moved every agent-fs pin from 0.13.3 to 0.13.5: `Dockerfile.worker` ARG, the three compose files, chart `values.yaml` + README, and the co-deployment docs page. The script validated the GHCR manifest, the npm package, and the skill file at `v0.13.5` before writing.

## Why 0.13.5 and not 0.13.4

v0.13.4 published to npm but its Docker image never built: a stale `bun.lock` plus a floating `oven/bun:1.4` tag that resolved to the stricter bun 1.4.1. Fixed in desplega-ai/agent-fs#40, released as 0.13.5. That release also carries the server-side fix for nested-path `PUT /raw` uploads (agent-fs #39), which the `agent-fs write --file` screenshot recipe from #1345 depends on.

## Verification

- `bun scripts/sync-chart-version.ts --check`: chart tag matches GHCR 0.13.5 (manifest HTTP 200), so the deploy gate stays green.
- Worker-slim image build running locally at PR-open time; CI builds it too.

Follow-up for DES-781.