### PR TITLE
fix(nightly-e2e): POSIX log-collection step, keep the CODEX_OAUTH blob whole

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -96,10 +96,10 @@ jobs:
 
       # The artifact is readable by anyone with read access to this public repository, so the
       # copies are redacted: the provider credential this leg holds, plus common token shapes.
+      # The container job runs `sh -e`, not bash: keep this POSIX (no pipefail).
       - name: Collect redacted logs
         if: always()
         run: |
-          set -euo pipefail
           mkdir -p out/logs
           ls /tmp/e2e-*.log >/dev/null 2>&1 || exit 0
           bun scripts/e2e/redact.ts --out out/logs /tmp/e2e-*.log

--- a/LOCAL_TESTING.md
+++ b/LOCAL_TESTING.md
@@ -83,6 +83,10 @@ bun run e2e --only health --harness claude,pi --harness-attempts 2
 E2E_MODEL_CLAUDE=claude-haiku-4-5 bun run e2e --only health --harness claude
 ```
 
+When the runner is root and `gosu` exists (the nightly container job), the worker starts as `gosu worker env HOME=<temp HOME> ...`.
+gosu resets HOME to `/home/worker`, which would hide the seeded auth.json and skills; file-based credentials such as the
+chatgpt-mode codex auth.json then fail with `401 Missing bearer or basic authentication in header`.
+
 `--harness-attempts N` runs a failed leg again, N attempts in total. Every attempt lands in the JSON
 result with its duration, its cost, and the last 60 lines of the worker log on failure. After the task
 turns terminal the leg polls `/api/session-costs` for up to 15 seconds (`E2E_COST_TIMEOUT_MS`) and records

--- a/scripts/e2e/harness.ts
+++ b/scripts/e2e/harness.ts
@@ -203,9 +203,17 @@ async function prepareHarnessHome(homeDir: string, provider: string): Promise<st
   return workspaceDir;
 }
 
-function workerCommand(): string[] {
+/**
+ * gosu resets HOME to the target user's passwd entry (/home/worker), which
+ * hides the temp HOME this leg seeded: auth.json, skills, logs. Re-apply HOME
+ * after the user switch so file-based credentials such as the chatgpt-mode
+ * codex auth.json are found.
+ */
+function workerCommand(homeDir: string): string[] {
   const command = ["bun", "run", "src/cli.tsx", "worker", "--yolo"];
-  return process.getuid?.() === 0 && Bun.which("gosu") ? ["gosu", "worker", ...command] : command;
+  return process.getuid?.() === 0 && Bun.which("gosu")
+    ? ["gosu", "worker", "env", `HOME=${homeDir}`, ...command]
+    : command;
 }
 
 function codexCredentialExpiry(): string | undefined {
@@ -220,7 +228,7 @@ function codexCredentialExpiry(): string | undefined {
 }
 
 const CREDENTIAL_FAILURE =
-  /status (401|403)|http (401|403)|\b(401|403) (unauthorized|forbidden)|invalid_grant|unauthorized|authentication failed|token (has )?expired|refresh token/i;
+  /status (401|403)|http (401|403)|\b(401|403) (unauthorized|forbidden)|invalid_grant|unauthorized|authentication failed|token (has )?expired|refresh token|could not be refreshed|log out and sign in/i;
 
 function classifyFailure(
   message: string,
@@ -321,7 +329,7 @@ async function runHarnessAttempt(
     expect(typeof taskId === "string", `${provider} task response has no id`);
 
     writer = Bun.file(logPath).writer();
-    child = Bun.spawn(workerCommand(), {
+    child = Bun.spawn(workerCommand(homeDir), {
       cwd: repoRoot,
       env: workerEnv(provider, agentId, baseUrl, apiKey, model, homeDir),
       stdout: "pipe",

--- a/src/utils/credentials.test.ts
+++ b/src/utils/credentials.test.ts
@@ -99,6 +99,21 @@ describe("resolveCredentialPools", () => {
     expect(env.SOME_OTHER_VAR).toBe("value");
   });
 
+  it("keeps a CODEX_OAUTH JSON blob whole despite its commas", async () => {
+    const blob = JSON.stringify({
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: 1_800_000_000_000,
+      accountId: "acct-12345",
+    });
+    const env: Record<string, string | undefined> = { CODEX_OAUTH: blob };
+    const selections = await resolveCredentialPools(env, { provider: "codex" });
+    expect(env.CODEX_OAUTH).toBe(blob);
+    expect(selections).toHaveLength(1);
+    expect(selections[0]?.total).toBe(1);
+    expect(selections[0]?.keySuffix).toBe(blob.slice(-5));
+  });
+
   it("resolves both credential vars independently", async () => {
     const env: Record<string, string | undefined> = {
       CLAUDE_CODE_OAUTH_TOKEN: "oauth1,oauth2",

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -102,20 +102,39 @@ export interface CredentialSelection {
   isRateLimitFallback: boolean;
 }
 
+function isJsonObject(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return false;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * If a value contains commas, split and select one credential.
  * When availableIndices is provided, only those indices are considered (rate-limit aware).
  * Falls back to random selection from all credentials if no available indices match.
+ * A JSON object value (the CODEX_OAUTH blob) is always one credential.
  */
 export function selectCredential(
   value: string,
   availableIndices?: number[],
   keyType = "ANTHROPIC_API_KEY",
 ): CredentialSelection {
-  const credentials = value
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
+  // A CODEX_OAUTH value is one JSON blob ({access, refresh, expires, accountId}),
+  // never a comma-separated pool: its commas are field separators. Splitting it
+  // handed out fragments such as `"accountId":"..."}` as the selected credential
+  // and stamped `965"}` as the key suffix on task records. Codex pools live in
+  // config-store slots (codex_oauth_<n>), resolved by the runner instead.
+  const credentials = isJsonObject(value)
+    ? [value.trim()]
+    : value
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
   if (credentials.length <= 1) {
     const selected = value.trim();
     const isRateLimitFallback = availableIndices !== undefined && availableIndices.length === 0;


### PR DESCRIPTION
## Why

The first dispatched run of the new nightly ([33879242444](https://github.com/desplega-ai/agent-swarm/actions/runs/33879242444)) exercised the whole pipeline. The report job, cost capture, trend, and sticky issue (#1346) all worked. Three things did not.

**Every harness job went red although three legs passed.** The new "Collect redacted logs" step used `set -o pipefail`, and container jobs run `sh -e`, not bash. The step is now POSIX.

**The codex leg failed with `401 Missing bearer or basic authentication in header`.** This is the codex-in-container gotcha that the MVP notes left unbisected. Root cause: `gosu worker` resets HOME to the passwd entry (`/home/worker`). The harness seeds auth.json, skills, and logs into a temp HOME, so under gosu the codex CLI never saw the chatgpt-mode auth.json, ran in api-key mode with no key, and OpenAI rejected the request at `wss://api.openai.com/v1/responses`. Env-injected credentials (the Claude OAuth token, OpenRouter, `OPENAI_API_KEY`) were unaffected, which is why only codex failed. The worker now starts as `gosu worker env HOME=<temp HOME> ...`.

Reproduced in the slim image as root with a fake chatgpt-mode blob, so no real login was touched:

| | boot log | task outcome |
| --- | --- | --- |
| before | `credentials ready (satisfiedBy=side-effect-pending)` | `401 Missing bearer or basic authentication in header` |
| after | `credentials ready (satisfiedBy=file)` | `Your access token could not be refreshed` (the fake token, as expected) |

**The codex leg logged `Selected CODEX_OAUTH credential 4/4`.** The worker's credential pool splits env values on commas, and the CODEX_OAUTH value is a JSON blob whose commas are field separators. It handed out `"accountId":"..."}` as the selected credential and stamped `965"}` as the key suffix on the task record. `selectCredential` now treats a JSON object as one credential. Codex pools live in config-store slots (`codex_oauth_<n>`), never in a comma-separated env value, so nothing loses a feature.

Also: "access token could not be refreshed" now classifies as a credential failure in the report, and LOCAL_TESTING.md documents the gosu HOME reset.

## Verification

```bash
bun test src/utils/credentials.test.ts      # 31 pass, includes the new JSON-blob case
bun run tsc:check
bun run e2e:tsc
actionlint .github/workflows/nightly-e2e.yml
```

Container reproduction (slim image, root, gosu, fake chatgpt-mode blob) before and after the HOME fix as in the table above. The real blob only exists as the repository secret, so the first full confirmation is the next nightly or a `workflow_dispatch` after merge.
