### PR TITLE
fix(entrypoint): unlink stale worker bootstrap so container restarts do not crash-loop

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -913,6 +913,12 @@ if [ "${SWARM_DEP_REDIS_ENABLED:-false}" = "true" ]; then
 fi
 
 WORKER_BOOTSTRAP="/tmp/agent-swarm-worker-entrypoint.sh"
+# Remove a stale copy from a previous start of this container first. The file is
+# chowned to `worker` below, and /tmp is a sticky world-writable directory, so on
+# hosts with fs.protected_regular=2 (Ubuntu 24.04 default, not namespaced) even
+# root cannot O_CREAT-open it again: the restart loops on "Permission denied".
+# Unlink is allowed, so regenerate from scratch on every start.
+rm -f "$WORKER_BOOTSTRAP"
 cat > "$WORKER_BOOTSTRAP" <<'EOF'
 #!/bin/bash
 set -e


### PR DESCRIPTION
## Summary

A worker container that is **restarted** (host reboot, `docker restart`, `docker compose restart`, OOM restart policy) crash-loops forever:

```
/docker-entrypoint.sh: line 916: /tmp/agent-swarm-worker-entrypoint.sh: Permission denied
```

Only a **recreate** (`docker compose up -d --force-recreate`) recovers it. Every cloud swarm box hits this after a reboot (seen 2026-09-04 on the demo swarm after a Hetzner resize: lead + 2 workers looped with restart count 14 until recreated).

## Root cause

`docker-entrypoint.sh` writes the worker bootstrap to `/tmp/agent-swarm-worker-entrypoint.sh` (`cat > "$WORKER_BOOTSTRAP"`), then `chown worker:worker` on it and `exec tini -- gosu worker "$WORKER_BOOTSTRAP"`.

On the next start of the SAME container the file still exists in the container layer, owned by `worker`. `/tmp` is a sticky world-writable directory owned by root. Ubuntu 24.04 hosts (kernel 6.8, our Hetzner images) ship `fs.protected_regular = 2`, and that sysctl is not namespaced: the kernel refuses `O_CREAT` opens of a regular file in a sticky world-writable directory when the file is owned by neither the opener nor the directory owner. Root and `CAP_DAC_OVERRIDE` do not bypass it. So the second `cat >` as root fails with `EACCES`, `set -e` exits, and the container restarts into the same state.

Reproduced inside a booted worker container as root:

```
$ cp -p /tmp/agent-swarm-worker-entrypoint.sh /tmp/probe2.sh   # owner worker, like the real file
$ : > /tmp/probe2.sh
sh: 1: cannot create /tmp/probe2.sh: Permission denied
$ rm -f /tmp/probe2.sh && echo unlink-ok                          # unlink is allowed
unlink-ok
$ cp /tmp/agent-swarm-worker-entrypoint.sh /tmp/probe3.sh && : > /tmp/probe3.sh && echo ok   # root-owned copy
ok
```

Host: `fs.protected_regular = 2`, `fs.protected_fifos = 1`, Ubuntu 24.04.4, kernel 6.8.0-138.

## Fix

Unlink the stale file before writing it (unlink in a sticky dir is allowed for root), so restarts regenerate it cleanly:

```bash
WORKER_BOOTSTRAP="/tmp/agent-swarm-worker-entrypoint.sh"
rm -f "$WORKER_BOOTSTRAP"
cat > "$WORKER_BOOTSTRAP" <<'EOF'
```

Alternative: keep the file outside a sticky directory (for example `/var/lib/agent-swarm/worker-entrypoint.sh`), which also avoids the issue.

## Verification

- Demo box: `docker compose restart worker-worker-5` with the patched image starts cleanly instead of looping.
- Before the patch, the same command reproduces the loop on any Ubuntu 24.04 host.


https://claude.ai/code/session_016iBgCe9GuoPsyTbCF2rvqj
