### PR TITLE
fix(heartbeat): reboot sweep skips tasks claimed after boot, session registered before spawn, bounded opencode session create

### DIFF
--- a/runbooks/heartbeat-crash-recovery.md
+++ b/runbooks/heartbeat-crash-recovery.md
@@ -20,10 +20,14 @@ flowchart TD
   health --> cleanup["cleanupStaleResources()<br/>stale sessions (30m), reviewing,<br/>inbox, mentions, workflow runs,<br/>+ reaper: escalate unreclaimed pinned resumes (§3)<br/>+ escalateStarvedPoolTasks: zero-eligible-agent pool tasks (§4)"]
   cleanup --> assign["autoAssignPoolTasks()<br/>per-task: first idle worker satisfying<br/>isAgentEligibleForTask (§4) — else leave queued"]
 
-  boot["Server boot (once)"] --> reboot["runRebootSweep()<br/>in_progress w/ no session<br/>OR pre-boot stale session<br/>→ failTask + retry child<br/>(pinned to original agent when recoverable, §4)"]
+  boot["Server boot (once)"] --> reboot["runRebootSweep()<br/>in_progress claimed after boot → skip<br/>else: no session OR pre-boot stale session<br/>→ failTask + retry child<br/>(pinned to original agent when recoverable, §4)"]
 ```
 
-- **Reboot sweep liveness predicate** (`runRebootSweep`): a session is considered "live, skip" only if `lastHeartbeatAt >= bootEpoch - 5s` (boot epoch parsed from `globalThis.__runId` = `run_<epochMs>`). Sessions with pre-boot heartbeats are stale artifacts that survived the WAL-mode SQLite restart and are treated as absent → auto-fail + retry child. If `__runId` is missing/unparseable, falls back to the legacy behavior (session exists → skip) — never more aggressive than before. This is **concurrency-safe**: a worker with N concurrent tasks keeps fresh (post-boot) heartbeats on its live sessions; only genuinely stale ones get classified.
+- **Reboot sweep liveness predicate** (`runRebootSweep`, boot epoch parsed from `globalThis.__runId` = `run_<epochMs>`), evaluated per `in_progress` task in this order:
+  1. **Claimed after boot → skip.** A task with `lastUpdatedAt >= bootEpoch - 5s` is skipped before any session lookup. `claimTask` / `startTask` stamp `lastUpdatedAt` at the `in_progress` transition and the API is the sole DB writer, so a post-boot value proves the claim (or a live worker's write) happened after this process started. It cannot be a pre-boot orphan. This is what keeps a task alive when its worker is still inside a slow provider spawn (opencode cold start exceeds the 5s sweep delay). If the task later goes quiet, the regular stalled-task sweep still covers it.
+  2. **Session live → skip.** A session is considered "live, skip" only if `lastHeartbeatAt >= bootEpoch - 5s`. Sessions with pre-boot heartbeats are stale artifacts that survived the WAL-mode SQLite restart and are treated as absent → auto-fail + retry child. This is **concurrency-safe**: a worker with N concurrent tasks keeps fresh (post-boot) heartbeats on its live sessions; only genuinely stale ones get classified.
+  3. If `__runId` is missing/unparseable, both checks fall back to the legacy behavior (session exists → skip, no claim-time check). Never more aggressive than before.
+- **Worker side** (`src/commands/runner.ts`): the worker registers its active session (POST `/api/active-sessions`, keyed on the per-task runner session id) *before* it starts the provider spawn, and fills in the provider session id on `session_init`. So the window in which an `in_progress` task has no session row is one HTTP round trip, not the whole spawn. On spawn failure the worker fails the task and then removes the row.
 - The **boot-triage seed script** (`src/be/seed-scripts/catalog/boot-triage.ts`) mirrors this logic: it flags `in_progress` tasks that are on an offline agent OR whose session's `lastHeartbeatAt` is older than `stuckMinutes` ago (no fresh session heartbeat).
 - `autoAssignPoolTasks` and `claimTask`/`assignUnassignedTaskPending` are gated by the **routing-affinity eligibility check** (§4, `isAgentEligibleForTask`) — a pooled task tagged with a `routingAffinity` snapshot (from a resume/retry, or an explicit `requiredCapabilities` on a fresh `send-task`) can only go to a role/capability-matching agent. Untagged tasks are unaffected — assignment stays open to any idle (non-lead) worker, exactly as before. `autoAssignPoolTasks` **does** skip idle workers whose `emptyPollCount >= MAX_EMPTY_POLLS` (the poll gate) — assigning to them would just have them exit on their next poll. The filter reads `emptyPollCount` off the rows `getIdleWorkersWithCapacity()` already returns (no per-worker re-query). Note the poll gate is cleared on a genuine `waiting_for_credentials -> ready` recovery (`updateAgentCredentialState`) and on re-register, but **not** by routine post-task `ready:true` credential reports.
 - `checkWorkerHealth` only flips `busy↔idle` (it pre-filters `offline`) and never sets `offline`. A successful `/api/poll` dispatch updates the agent to `busy` in the same transaction that starts a pre-assigned task or claims a pool task; the worker-only `poll-task` tool does the same for its direct pending-task path. The heartbeat sweep remains the reconciliation backstop for any other task-state transition that leaves `agents.status` stale. Leads can become `busy` while running a directly assigned task, but remain structurally excluded from pool assignment (`getIdleWorkersWithCapacity` and the pool dispatch query filter `isLead=0`). `offline` has two writers: the graceful `POST /close` handler (`src/http/core.ts`), and — only when `MULTI_RUNTIME_ENABLED` is set — the stale-runtime expiry in §1a. With the flag off (the default), a hard-crashed (SIGKILL) worker is still never auto-offlined.
@@ -212,7 +216,14 @@ isAgentEligibleForTask(agent, task):
     if a.capabilities not ⊆ agent.capabilities: return false
     return true
 
-# reboot-sweep retry child (runRebootSweep, on each auto-failed in_progress task):
+# reboot sweep (runRebootSweep, once, 5s after boot), per in_progress task:
+bootEpoch = parse(globalThis.__runId)                        # run_<epochMs>; null → legacy session-exists check only
+if bootEpoch and task.lastUpdatedAt >= bootEpoch - 5s: skip   # claimed after boot: not an orphan
+session = getActiveSessionForTask(task.id)
+if session and (bootEpoch is null or session.lastHeartbeatAt >= bootEpoch - 5s): skip
+failTask(task.id)                                             # then create the retry child below
+
+# reboot-sweep retry child (on each auto-failed in_progress task):
 preferredAgentId = undefined
 cand = getPinCandidateAgent(task.agentId)                   # row exists, not offline
 if cand and activeCount(cand) < cand.maxTasks:

--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -5513,6 +5513,16 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
         // Per-task runner session ID so session logs are scoped to this task
         const resumeRunnerSessionId = crypto.randomUUID();
 
+        // Register the active session BEFORE the provider spawn so the API's
+        // sweeps never see this in_progress task without a session row (see
+        // the main task path for the full rationale).
+        await registerActiveSession(apiConfig, {
+          taskId: task.id,
+          triggerType: "task_resumed",
+          taskDescription: task.task?.slice(0, 200),
+          runnerSessionId: resumeRunnerSessionId,
+        });
+
         let runningTask: RunningTask;
         try {
           runningTask = await spawnProviderProcess(
@@ -5558,21 +5568,11 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
             undefined,
             state.harnessProvider,
           );
+          await removeActiveSession(apiConfig, task.id);
           continue;
         }
 
         state.activeTasks.set(task.id, runningTask);
-        registerActiveSession(apiConfig, {
-          taskId: task.id,
-          triggerType: "task_resumed",
-          taskDescription: task.task?.slice(0, 200),
-          runnerSessionId: resumeRunnerSessionId,
-        }).catch((err) =>
-          console.error(
-            "[runner] active-session registration failed:",
-            scrubSecrets(err instanceof Error ? err.message : String(err)),
-          ),
-        );
         console.log(
           `[${role}] Resumed task ${task.id.slice(0, 8)} (${state.activeTasks.size}/${state.maxConcurrent} active)`,
         );
@@ -6061,6 +6061,25 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
         // Per-task runner session ID so session logs are scoped to this task
         const taskRunnerSessionId = crypto.randomUUID();
 
+        // Register the active session BEFORE the provider spawn. The API's
+        // reboot sweep and stalled-task sweeps treat an in_progress task with
+        // no session row as orphaned, and a cold opencode spawn can take
+        // longer than the 5s post-boot sweep delay. The provider session id is
+        // filled in on `session_init` (saveProviderSessionId). Pool triggers
+        // with no task id get their synthetic session after the spawn below.
+        const taskDesc =
+          trigger.task && typeof trigger.task === "object" && "task" in trigger.task
+            ? String((trigger.task as { task: string }).task).slice(0, 200)
+            : undefined;
+        if (trigger.taskId) {
+          await registerActiveSession(apiConfig, {
+            taskId: trigger.taskId,
+            triggerType: trigger.type,
+            taskDescription: taskDesc,
+            runnerSessionId: taskRunnerSessionId,
+          });
+        }
+
         // Spawn without blocking (await to set up session, but process runs async)
         let runningTask: RunningTask;
         try {
@@ -6105,6 +6124,7 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
               undefined,
               state.harnessProvider,
             );
+            await removeActiveSession(apiConfig, trigger.taskId);
           }
           continue;
         }
@@ -6139,22 +6159,21 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
 
         state.activeTasks.set(runningTask.taskId, runningTask);
 
-        // Register active session for concurrency awareness
-        const taskDesc =
-          trigger.task && typeof trigger.task === "object" && "task" in trigger.task
-            ? String((trigger.task as { task: string }).task).slice(0, 200)
-            : undefined;
-        registerActiveSession(apiConfig, {
-          taskId: runningTask.taskId,
-          triggerType: trigger.type,
-          taskDescription: taskDesc,
-          runnerSessionId: taskRunnerSessionId,
-        }).catch((err) =>
-          console.error(
-            "[runner] active-session registration failed:",
-            scrubSecrets(err instanceof Error ? err.message : String(err)),
-          ),
-        );
+        // Pool triggers have no task id before the spawn; their session is
+        // keyed on the synthetic id `spawnProviderProcess` minted.
+        if (!trigger.taskId) {
+          registerActiveSession(apiConfig, {
+            taskId: runningTask.taskId,
+            triggerType: trigger.type,
+            taskDescription: taskDesc,
+            runnerSessionId: taskRunnerSessionId,
+          }).catch((err) =>
+            console.error(
+              "[runner] active-session registration failed:",
+              scrubSecrets(err instanceof Error ? err.message : String(err)),
+            ),
+          );
+        }
 
         console.log(
           `[${role}] Started task ${runningTask.taskId.slice(0, 8)} (${state.activeTasks.size}/${state.maxConcurrent} active, trigger: ${trigger.type})`,

--- a/src/heartbeat/heartbeat.ts
+++ b/src/heartbeat/heartbeat.ts
@@ -601,7 +601,15 @@ const BOOT_EPOCH_SKEW_MS = 5_000;
 
 /**
  * Aggressive sweep that runs once after server restart.
- * Ignores age thresholds — any in_progress task with no active session is auto-failed.
+ * Ignores age thresholds: any in_progress task claimed before this boot that has
+ * no active session is auto-failed.
+ * A task whose `lastUpdatedAt` is at or after the boot epoch (minus skew) is
+ * skipped outright: `claimTask` / `startTask` stamp that column at the
+ * in_progress transition and the API is the sole DB writer, so a post-boot value
+ * proves the claim (or a live worker's write) happened after this process
+ * started. It cannot be a pre-boot orphan. Workers register their active session
+ * only after the provider spawn returns, which can exceed the 5s sweep delay
+ * (opencode cold start), so this check is what keeps a freshly claimed task alive.
  * A session is only considered "live" if it heartbeated AFTER the current API boot
  * (concurrency-safe: workers with multiple tasks keep fresh heartbeats on live ones).
  * Creates exactly one retry task per failed task via parentTaskId.
@@ -638,6 +646,19 @@ export async function runRebootSweep(): Promise<void> {
           `[Heartbeat] Reboot sweep: skipping task ${task.id} — in_progress with no agentId`,
         );
         continue;
+      }
+
+      if (bootEpoch !== null) {
+        // Claimed at or after this boot (see the doc comment above): not a
+        // pre-boot orphan. The regular stalled-task sweep still covers it if
+        // it goes quiet later.
+        const lastUpdated = new Date(task.lastUpdatedAt).getTime();
+        if (Number.isFinite(lastUpdated) && lastUpdated >= bootEpoch - BOOT_EPOCH_SKEW_MS) {
+          console.log(
+            `[Heartbeat] Reboot sweep: skipping task ${task.id.slice(0, 8)}: claimed after boot (lastUpdatedAt=${task.lastUpdatedAt})`,
+          );
+          continue;
+        }
       }
 
       const session = await getActiveSessionForTask(task.id);

--- a/src/providers/opencode-adapter.ts
+++ b/src/providers/opencode-adapter.ts
@@ -131,6 +131,28 @@ const MODEL_CACHE_REFRESH_TIMEOUT_MS = 15_000;
 // OPENCODE_SERVER_TIMEOUT_MS.
 const DEFAULT_SERVER_START_TIMEOUT_MS = 30_000;
 
+function serverStartTimeoutMs(): number {
+  return Number(process.env.OPENCODE_SERVER_TIMEOUT_MS) || DEFAULT_SERVER_START_TIMEOUT_MS;
+}
+
+/** Reject with `message` if `promise` has not settled within `ms`. */
+async function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      // The abandoned promise may still settle later; keep it from surfacing
+      // as an unhandled rejection.
+      promise.catch(() => {});
+      reject(new Error(message));
+    }, ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 function isOpenRouterModel(model: string | undefined): boolean {
   return Boolean(model?.toLowerCase().startsWith("openrouter/"));
 }
@@ -872,7 +894,7 @@ export class OpencodeAdapter implements ProviderAdapter {
       ({ client, server } = await createOpencode({
         hostname: "127.0.0.1",
         port: 0,
-        timeout: Number(process.env.OPENCODE_SERVER_TIMEOUT_MS) || DEFAULT_SERVER_START_TIMEOUT_MS,
+        timeout: serverStartTimeoutMs(),
         config: opencodeConfig,
       }));
     } finally {
@@ -892,8 +914,23 @@ export class OpencodeAdapter implements ProviderAdapter {
       }
     }
 
-    // Create the opencode session (project directory = config.cwd)
-    const createResult = await client.session.create({ query: { directory: config.cwd } });
+    // Create the opencode session (project directory = config.cwd). The first
+    // session in a fresh data home installs plugins and fetches the models
+    // list, and on a cold container that call has hung with no opencode events
+    // at all. Bound it with the same budget as the server start so a hang
+    // fails fast as a spawn failure instead of stalling the worker.
+    const sessionCreateTimeoutMs = serverStartTimeoutMs();
+    let createResult: Awaited<ReturnType<typeof client.session.create>>;
+    try {
+      createResult = await withTimeout(
+        client.session.create({ query: { directory: config.cwd } }),
+        sessionCreateTimeoutMs,
+        `opencode session create timed out after ${sessionCreateTimeoutMs}ms`,
+      );
+    } catch (err) {
+      server.close();
+      throw err;
+    }
     if (!createResult.data) {
       server.close();
       throw new Error("Failed to create opencode session");

--- a/src/tests/heartbeat.test.ts
+++ b/src/tests/heartbeat.test.ts
@@ -1226,6 +1226,74 @@ describe("Heartbeat Triage", () => {
       }
     });
 
+    test("skips in_progress task claimed after boot even with no session", async () => {
+      const bootTime = Date.now() - 10_000; // booted 10s ago
+      const original = gs.__runId;
+      gs.__runId = `run_${bootTime}`;
+
+      try {
+        const agent = await createAgent({ name: "worker-postboot", isLead: false, status: "busy" });
+        const task = await createTaskExtended("Task claimed after boot", { agentId: agent.id });
+        await startTask(task.id);
+
+        // Claimed 1s ago: after boot, and backdated past the same-ms cutoff of
+        // getStalledInProgressTasks(0). No active session yet: the worker is
+        // still inside the provider spawn.
+        const claimedAt = new Date(Date.now() - 1000).toISOString();
+        await getDbClient().run("UPDATE agent_tasks SET lastUpdatedAt = ? WHERE id = ?", [
+          claimedAt,
+          task.id,
+        ]);
+
+        await runRebootSweep();
+
+        const updated = await getTaskById(task.id);
+        expect(updated?.status).toBe("in_progress");
+        const retries = await getDbClient().query(
+          "SELECT * FROM agent_tasks WHERE parentTaskId = ?",
+          [task.id],
+        );
+        expect(retries.length).toBe(0);
+        expect(getRebootAffectedTasks().length).toBe(0);
+      } finally {
+        gs.__runId = original;
+      }
+    });
+
+    test("auto-fails in_progress task claimed before boot with no session", async () => {
+      const bootTime = Date.now();
+      const original = gs.__runId;
+      gs.__runId = `run_${bootTime}`;
+
+      try {
+        const agent = await createAgent({
+          name: "worker-preboot-nosession",
+          isLead: false,
+          status: "busy",
+        });
+        const task = await createTaskExtended("Task claimed before boot", { agentId: agent.id });
+        await startTask(task.id);
+
+        const claimedAt = new Date(bootTime - 60_000).toISOString();
+        await getDbClient().run("UPDATE agent_tasks SET lastUpdatedAt = ? WHERE id = ?", [
+          claimedAt,
+          task.id,
+        ]);
+
+        await runRebootSweep();
+
+        const updated = await getTaskById(task.id);
+        expect(updated?.status).toBe("failed");
+        expect(updated?.failureReason).toContain("reboot sweep");
+        const affected = getRebootAffectedTasks();
+        expect(affected.length).toBe(1);
+        expect(affected[0]!.original.id).toBe(task.id);
+        expect(affected[0]!.retryTaskId).not.toBeNull();
+      } finally {
+        gs.__runId = original;
+      }
+    });
+
     test("falls back to legacy skip-when-session-exists when __runId is missing", async () => {
       const original = gs.__runId;
       delete gs.__runId;

--- a/src/tests/opencode-adapter.test.ts
+++ b/src/tests/opencode-adapter.test.ts
@@ -1244,3 +1244,43 @@ describe("OpencodeAdapter — context-mode plugin wiring (phase 4)", () => {
     expect(built.mcp?.["context-mode"]).toBeUndefined();
   });
 });
+
+describe("OpencodeAdapter: session create timeout", () => {
+  let prevTimeout: string | undefined;
+
+  beforeEach(() => {
+    prevTimeout = process.env.OPENCODE_SERVER_TIMEOUT_MS;
+    mock.restore();
+  });
+
+  afterEach(() => {
+    if (prevTimeout === undefined) delete process.env.OPENCODE_SERVER_TIMEOUT_MS;
+    else process.env.OPENCODE_SERVER_TIMEOUT_MS = prevTimeout;
+    Bun.$`rm -rf /tmp/opencode-task-timeout.json /tmp/opencode-data-task-timeout`.quiet().nothrow();
+    Bun.$`rm -rf /tmp/test/.opencode`.quiet().nothrow();
+  });
+
+  test("a hung session.create fails the spawn after OPENCODE_SERVER_TIMEOUT_MS and closes the server", async () => {
+    process.env.OPENCODE_SERVER_TIMEOUT_MS = "50";
+    const closeServer = mock(() => {});
+    const fakeServer = { url: "http://127.0.0.1:12345", close: closeServer };
+    const fakeClient = {
+      session: {
+        create: () => new Promise<never>(() => {}),
+        prompt: async () => ({ data: {}, error: undefined }),
+      },
+      event: { subscribe: async () => ({ stream: makeStream([]) }) },
+    };
+    mock.module("@opencode-ai/sdk", () => ({
+      createOpencode: async () => ({ client: fakeClient, server: fakeServer }),
+    }));
+
+    const { OpencodeAdapter } = await import("../providers/opencode-adapter");
+    const adapter = new OpencodeAdapter();
+
+    await expect(adapter.createSession(testConfig({ taskId: "task-timeout" }))).rejects.toThrow(
+      "opencode session create timed out after 50ms",
+    );
+    expect(closeServer).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Root cause

The Nightly E2E opencode leg failed attempt 1 and passed attempt 2 in every run so far (33879242444, 33889575597). From the API log of run 33889575597:

1. `startHeartbeat()` schedules `runRebootSweep()` 5 seconds after API boot.
2. `runRebootSweep()` auto-fails every `in_progress` task that has no active-session row (or whose session heartbeated before the boot epoch). It never checked when the task itself was claimed.
3. The worker registered its active session only after the provider spawn returned. For claude, codex and pi that is about one second. For opencode it includes `opencode models --refresh`, an `opencode serve` boot, plugin loading and `client.session.create`, which is well over 5 seconds on a cold container.
4. The sweep failed the freshly claimed opencode task and created a retry child. The worker finished the model turn later and its finish call got a 409 ("Discarded write for already-failed task").

A task claimed after the boot epoch cannot be a pre-boot orphan.

Secondary finding: run 33848846343 hung 300 seconds inside the opencode spawn with no opencode events. The SDK bounds the server start (`OPENCODE_SERVER_TIMEOUT_MS`, default 30s) but `client.session.create` had no timeout, and the first session in a fresh data home installs plugins and fetches the models list.

## Changes

1. **Reboot sweep skips tasks claimed after boot** (`src/heartbeat/heartbeat.ts`). `runRebootSweep()` now skips any `in_progress` task whose `lastUpdatedAt` is at or after `bootEpoch - BOOT_EPOCH_SKEW_MS`, before any session lookup, and logs one line per skipped task. `agent_tasks` has no dedicated claim column (`startedAt` exists only on `agents` and `active_sessions`). Both `claimTask` and `startTask` stamp `lastUpdatedAt` at the `in_progress` transition, every later write only moves it forward, and the API is the sole DB writer, so a post-boot value proves the claim (or a live worker's write) happened after this process started. The legacy fallback when the boot epoch cannot be parsed is unchanged (session exists → skip, no claim-time check).
2. **Active session registered before the provider spawn** (`src/commands/runner.ts`). Both the task path and the paused-task resume path now `await registerActiveSession(...)` (POST `/api/active-sessions`, keyed on the per-task runner session id) before `spawnProviderProcess`. The provider session id still lands on `session_init` via the existing PUT `/api/tasks/:id/session`. On spawn failure the worker fails the task and then removes the row. Pool triggers with no task id keep the post-spawn registration on the synthetic id.
3. **Bounded opencode session create** (`src/providers/opencode-adapter.ts`). `client.session.create` is wrapped with the same `OPENCODE_SERVER_TIMEOUT_MS` budget as the server start. On timeout (or any rejection) the server is closed and the spawn throws `opencode session create timed out after Nms`, so a cold-start hang is classified as a spawn failure instead of stalling the worker.

Runbook: `runbooks/heartbeat-crash-recovery.md` diagram, liveness predicate and reboot-sweep pseudocode updated to the new behavior.

Tests added:
- `src/tests/heartbeat.test.ts`: "skips in_progress task claimed after boot even with no session" and "auto-fails in_progress task claimed before boot with no session".
- `src/tests/opencode-adapter.test.ts`: "a hung session.create fails the spawn after OPENCODE_SERVER_TIMEOUT_MS and closes the server".

## Verification

```
bun run tsc:check                                             exit 0
bun run e2e:tsc                                               exit 0
bash scripts/check-e2e-boundary.sh                            passed
bun scripts/check-floating-promises.ts                        0 findings
bun scripts/check-promise-sinks.ts                            0 findings
bash scripts/check-db-boundary.sh / check-api-key-boundary.sh ok
biome check (changed files)                                   Checked 5 files. No fixes applied.

bun run test:root -- src/tests/heartbeat.test.ts                  60 pass, 0 fail
bun run test:root -- src/tests/heartbeat-reroute-decision.test.ts 16 pass, 0 fail
bun run test:root -- src/tests/heartbeat-supersede-resume.test.ts 12 pass, 0 fail
bun run test:root -- src/tests/opencode-adapter.test.ts           41 pass, 0 fail
```

`bun run lint` is not a usable gate on this Mac (Biome worker stack overflow, exits 0), so the changed files were linted directly with `node_modules/.bin/biome check`.

Manual E2E, opencode leg (`bun run e2e --only health --harness opencode --harness-attempts 1 --keep`). The race reproduced locally and the sweep skipped the task:

```
PASS health (0.0s)
PASS harness opencode (openrouter/deepseek/deepseek-v4-flash, 26.7s, $0.0116 (pricing-table))
PASS: 2 passed, 0 failed, 0 skipped

$ grep -n "Reboot" /tmp/e2e-api-1788538634741-8b2acc2f.log
398:[Heartbeat] Reboot sweep: skipping task 9f78e340: claimed after boot (lastUpdatedAt=2026-09-04T16:17:19.669Z)
399:[Heartbeat] Reboot sweep complete: 0 task(s) auto-failed and retried
```

API log order for that task: `GET /api/poll` (claim) → `POST /api/active-sessions 201` → reboot sweep skip → `PUT /api/tasks/:id/session` (session_init) → task finished, `DELETE /api/active-sessions/by-task/:id`.

All four legs at one attempt (`bun run e2e --only health --harness claude,codex,pi,opencode --harness-attempts 1`):

```
PASS health (0.0s)
PASS harness claude (claude-sonnet-5, 12.8s, $0.0425 (pricing-table))
PASS harness codex (gpt-5.6-luna, 18.6s, $0.0042 (pricing-table))
PASS harness pi (openrouter/deepseek/deepseek-v4-flash, 13.6s, $0.0044 (pricing-table))
PASS harness opencode (openrouter/deepseek/deepseek-v4-flash, 26.6s, $0.0070 (pricing-table))
PASS: 5 passed, 0 failed, 0 skipped
```

After merge: `gh workflow run nightly-e2e.yml --ref main` should report attempts = 1 for opencode and no warnings.

Drift checks: no routes, migrations, skills or Dockerfiles touched, so no regenerated artifacts.

https://claude.ai/code/session_019gNcW5WUiFjd4dwQybZdZr
