### PR TITLE
fix(runner): retry agent-fs provisioning after boot registration

### DIFF
--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -752,12 +752,31 @@ export async function fetchResolvedEnv(
   return { env, credentialSelections, resolvedProvider, scriptsOnlyConfigValue };
 }
 
-async function ensureAgentFsCredentials(
+/**
+ * Ask the API to provision this agent's agent-fs credentials.
+ *
+ * Returns true when the API reached a verdict: the agent-scoped
+ * `AGENT_FS_API_KEY` row (plus the global `AGENT_FS_DEFAULT_*` rows) now
+ * exist, or agent-fs is not configured for this deployment
+ * (`enabled: false`). Both outcomes are terminal, so a retry cannot help.
+ *
+ * Returns false when the attempt reached no verdict (HTTP error, network
+ * failure, or no agent identity yet). The common case is a brand-new
+ * `AGENT_ID` against a fresh API database: this call runs before
+ * `registerAgent` (the boot `fetchResolvedEnv` right after it resolves the
+ * provider that registration needs), so the agent row does not exist yet and
+ * the route answers `500 Agent not found`. Nothing gets written, and every
+ * later `agent-fs` call in that container fails with "Not logged in".
+ * {@link provisionAgentFsAfterRegistration} retries once after registration.
+ *
+ * Never throws: provisioning is best-effort and must not wedge boot.
+ */
+export async function ensureAgentFsCredentials(
   apiUrl: string,
   apiKey: string,
   agentId: string,
-): Promise<void> {
-  if (!apiUrl || !apiKey || !agentId || agentId === "unknown") return;
+): Promise<boolean> {
+  if (!apiUrl || !apiKey || !agentId || agentId === "unknown") return false;
 
   try {
     const response = await fetch(`${apiUrl}/api/fs/agent-credentials`, {
@@ -777,7 +796,7 @@ async function ensureAgentFsCredentials(
           `[agent-fs] credential provisioning skipped: HTTP ${response.status}${text ? ` ${text}` : ""}`,
         ),
       );
-      return;
+      return false;
     }
     const result = (await response.json().catch(() => ({}))) as {
       enabled?: boolean;
@@ -788,9 +807,54 @@ async function ensureAgentFsCredentials(
         `[agent-fs] ${result.created ? "created" : "confirmed"} agent-scoped credentials`,
       );
     }
+    return true;
   } catch (error) {
     console.warn(scrubSecrets(`[agent-fs] credential provisioning skipped: ${error}`));
+    return false;
   }
+}
+
+/**
+ * Second and final agent-fs provisioning attempt, run right after the boot
+ * registration succeeds.
+ *
+ * `alreadyProvisioned` carries the result of the pre-registration attempt.
+ * When it is true this is a no-op. When it is false the agent row exists by
+ * now, so the same request that failed with `500 Agent not found` can
+ * succeed. One retry, no polling loop: registration is the only precondition
+ * the first attempt was missing.
+ *
+ * On success the resolved env is fetched again and re-applied, because the
+ * boot snapshot was taken before provisioning wrote its rows. Only the
+ * live-apply allowlist (`RELOADABLE_ENV_KEYS`, which carries
+ * `AGENT_FS_SHARED_ORG_ID`) is mutated. The harness does not depend on this
+ * refresh: every task spawn re-resolves the env, so the first task already
+ * receives `AGENT_FS_API_KEY`, `AGENT_FS_DEFAULT_ORG_ID`, and
+ * `AGENT_FS_DEFAULT_DRIVE_ID` once the rows exist.
+ *
+ * Never throws. Returns whether credentials are settled.
+ */
+export async function provisionAgentFsAfterRegistration(opts: {
+  apiUrl: string;
+  apiKey: string;
+  agentId: string;
+  alreadyProvisioned: boolean;
+}): Promise<boolean> {
+  if (opts.alreadyProvisioned) return true;
+
+  const provisioned = await ensureAgentFsCredentials(opts.apiUrl, opts.apiKey, opts.agentId);
+  if (!provisioned) return false;
+
+  try {
+    const refreshed = await fetchResolvedEnv(opts.apiUrl, opts.apiKey, opts.agentId);
+    const changed = applyResolvedEnvToProcessEnv(refreshed.env);
+    if (changed.length > 0) {
+      console.log(`[agent-fs] Applied resolved swarm config after retry: ${changed.join(", ")}`);
+    }
+  } catch (error) {
+    console.warn(scrubSecrets(`[agent-fs] post-provisioning env refresh skipped: ${error}`));
+  }
+  return true;
 }
 
 /**
@@ -2648,8 +2712,8 @@ export async function buildRequesterProfilePrompt(
   return result.skipped ? "" : result.text.trim();
 }
 
-/** Register agent via HTTP API */
-async function registerAgent(opts: {
+/** Register agent via HTTP API. Exported so tests can exercise the real boot ordering. */
+export async function registerAgent(opts: {
   apiUrl: string;
   apiKey: string;
   agentId: string;
@@ -4474,8 +4538,13 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
   // boot-fetch failure it stays at the default. Reconciled live thereafter by
   // `applySwarmConfigDrift`.
   let bootCooldownMs = resolveCodexCreditsExhaustedCooldownMs(undefined);
+  // Tracks whether agent-fs credentials are settled. A brand-new AGENT_ID has
+  // no agent row yet at this point, so this first attempt gets
+  // `500 Agent not found` and returns false. The retry runs right after
+  // registration below.
+  let agentFsProvisioned = false;
   try {
-    await ensureAgentFsCredentials(apiUrl, apiKey, agentId);
+    agentFsProvisioned = await ensureAgentFsCredentials(apiUrl, apiKey, agentId);
     const bootEnv = await fetchResolvedEnv(apiUrl, apiKey, agentId);
     bootProvider = bootEnv.resolvedProvider;
     resolvedScriptsOnly = resolveScriptsOnlyMode({
@@ -4939,6 +5008,16 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
     console.error(`[${role}] Failed to register: ${error}`);
     process.exit(1);
   }
+
+  // The agent row exists now, so a first attempt that failed with
+  // `500 Agent not found` can succeed. Still best-effort: a failure here only
+  // means agent-fs stays unavailable, it must not stop the worker.
+  await provisionAgentFsAfterRegistration({
+    apiUrl,
+    apiKey,
+    agentId,
+    alreadyProvisioned: agentFsProvisioned,
+  });
 
   // Block until harness credentials are present in env. This loop replaces
   // the old bash-level fail-fast in `docker-entrypoint.sh` — the worker is

--- a/src/tests/runner-agent-fs-provision-retry.test.ts
+++ b/src/tests/runner-agent-fs-provision-retry.test.ts
@@ -1,0 +1,198 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { createServer, type Server } from "node:http";
+import {
+  ensureAgentFsCredentials,
+  fetchResolvedEnv,
+  provisionAgentFsAfterRegistration,
+  registerAgent,
+} from "../commands/runner";
+import { listenOnFreePort } from "./test-net";
+
+/**
+ * A worker booting with a brand-new AGENT_ID against a fresh API database
+ * used to lose agent-fs entirely. `ensureAgentFsCredentials` runs before
+ * `registerAgent` (the boot `fetchResolvedEnv` next to it resolves the
+ * provider registration needs), so `POST /api/fs/agent-credentials` answered
+ * `500 Agent not found`, nothing was written, and every `agent-fs` call in
+ * that container failed with "Not logged in" until a restart.
+ *
+ * These tests drive the real exported boot functions against a fake API and
+ * assert the second provisioning attempt happens after registration.
+ */
+
+const AGENT_ID = "9b2c4a1e-6d3f-4a55-8f27-1c0e7b5a4d90";
+const API_KEY = "test-swarm-key";
+const AGENT_FS_KEY = "af_live_key";
+
+type FakeApiState = {
+  registered: boolean;
+  provisioned: boolean;
+  /** Forces the credential route to fail even after registration. */
+  forceCredentialFailure: boolean;
+};
+
+let server: Server;
+let baseUrl: string;
+let state: FakeApiState;
+let requestLog: string[];
+
+/** Paths the boot sequence is asserted on. Credential-pool probes are noise. */
+const TRACKED_PATHS = new Set(["/api/fs/agent-credentials", "/api/agents", "/api/config/resolved"]);
+
+const savedSharedOrgId = process.env.AGENT_FS_SHARED_ORG_ID;
+
+function resetState(): void {
+  state = { registered: false, provisioned: false, forceCredentialFailure: false };
+  requestLog = [];
+}
+
+beforeAll(async () => {
+  resetState();
+
+  server = createServer((req, res) => {
+    req.resume();
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const method = req.method ?? "GET";
+    if (TRACKED_PATHS.has(url.pathname)) requestLog.push(`${method} ${url.pathname}`);
+
+    const send = (status: number, body: unknown) => {
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+    };
+
+    if (method === "POST" && url.pathname === "/api/fs/agent-credentials") {
+      // Mirrors the real route: it resolves the caller's agent row first.
+      if (!state.registered || state.forceCredentialFailure) {
+        send(500, {
+          error: `Failed to provision agent-fs credentials: Agent not found: ${AGENT_ID}`,
+        });
+        return;
+      }
+      state.provisioned = true;
+      send(200, { enabled: true, created: true, agentId: AGENT_ID });
+      return;
+    }
+
+    if (method === "POST" && url.pathname === "/api/agents") {
+      state.registered = true;
+      send(200, { id: AGENT_ID, enabledCapabilities: [] });
+      return;
+    }
+
+    if (method === "GET" && url.pathname === "/api/config/resolved") {
+      // The AGENT_FS_* rows only exist once provisioning succeeded.
+      const configs = state.provisioned
+        ? [
+            { key: "AGENT_FS_API_KEY", value: AGENT_FS_KEY },
+            { key: "AGENT_FS_DEFAULT_ORG_ID", value: "org-late" },
+            { key: "AGENT_FS_DEFAULT_DRIVE_ID", value: "drive-late" },
+            { key: "AGENT_FS_SHARED_ORG_ID", value: "org-late" },
+          ]
+        : [];
+      send(200, { configs });
+      return;
+    }
+
+    send(404, { error: "not found" });
+  });
+
+  const port = await listenOnFreePort(server);
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(() => {
+  server.close();
+  if (savedSharedOrgId === undefined) delete process.env.AGENT_FS_SHARED_ORG_ID;
+  else process.env.AGENT_FS_SHARED_ORG_ID = savedSharedOrgId;
+});
+
+beforeEach(() => {
+  resetState();
+});
+
+describe("agent-fs boot provisioning retry", () => {
+  test("retries after registration when the pre-registration attempt failed", async () => {
+    const beforeRegistration = await ensureAgentFsCredentials(baseUrl, API_KEY, AGENT_ID);
+    expect(beforeRegistration).toBe(false);
+
+    await registerAgent({
+      apiUrl: baseUrl,
+      apiKey: API_KEY,
+      agentId: AGENT_ID,
+      name: "worker-cb82b832",
+      isLead: false,
+    });
+
+    const settled = await provisionAgentFsAfterRegistration({
+      apiUrl: baseUrl,
+      apiKey: API_KEY,
+      agentId: AGENT_ID,
+      alreadyProvisioned: beforeRegistration,
+    });
+
+    expect(settled).toBe(true);
+    expect(state.provisioned).toBe(true);
+    expect(requestLog).toEqual([
+      "POST /api/fs/agent-credentials",
+      "POST /api/agents",
+      "POST /api/fs/agent-credentials",
+      "GET /api/config/resolved",
+    ]);
+    // The refresh applies the live-apply allowlist to process.env.
+    expect(process.env.AGENT_FS_SHARED_ORG_ID).toBe("org-late");
+  });
+
+  test("the per-task env fetch carries the freshly written rows to the harness", async () => {
+    await registerAgent({
+      apiUrl: baseUrl,
+      apiKey: API_KEY,
+      agentId: AGENT_ID,
+      name: "worker-cb82b832",
+      isLead: false,
+    });
+    await provisionAgentFsAfterRegistration({
+      apiUrl: baseUrl,
+      apiKey: API_KEY,
+      agentId: AGENT_ID,
+      alreadyProvisioned: false,
+    });
+
+    // Same call `spawnTask` makes per task before it builds the harness env.
+    const perTask = await fetchResolvedEnv(baseUrl, API_KEY, AGENT_ID, { PATH: "/usr/bin" });
+    expect(perTask.env.AGENT_FS_API_KEY).toBe(AGENT_FS_KEY);
+    expect(perTask.env.AGENT_FS_DEFAULT_ORG_ID).toBe("org-late");
+    expect(perTask.env.AGENT_FS_DEFAULT_DRIVE_ID).toBe("drive-late");
+  });
+
+  test("does nothing when the pre-registration attempt already succeeded", async () => {
+    state.registered = true;
+    const beforeRegistration = await ensureAgentFsCredentials(baseUrl, API_KEY, AGENT_ID);
+    expect(beforeRegistration).toBe(true);
+    requestLog = [];
+
+    const settled = await provisionAgentFsAfterRegistration({
+      apiUrl: baseUrl,
+      apiKey: API_KEY,
+      agentId: AGENT_ID,
+      alreadyProvisioned: beforeRegistration,
+    });
+
+    expect(settled).toBe(true);
+    expect(requestLog).toEqual([]);
+  });
+
+  test("a failing retry stays non-fatal and skips the env refresh", async () => {
+    state.registered = true;
+    state.forceCredentialFailure = true;
+
+    const settled = await provisionAgentFsAfterRegistration({
+      apiUrl: baseUrl,
+      apiKey: API_KEY,
+      agentId: AGENT_ID,
+      alreadyProvisioned: false,
+    });
+
+    expect(settled).toBe(false);
+    expect(requestLog).toEqual(["POST /api/fs/agent-credentials"]);
+  });
+});


### PR DESCRIPTION
## Bug

A worker container booted with a brand-new `AGENT_ID` against a fresh API database never gets agent-fs credentials.

At boot, `src/commands/runner.ts` calls `ensureAgentFsCredentials(apiUrl, apiKey, agentId)` **before** `registerAgent(...)`. That order is forced: the `fetchResolvedEnv` call right next to it resolves the `bootProvider` that registration needs.

On a first boot the agent row does not exist yet, so `POST /api/fs/agent-credentials` (`src/http/fs.ts`, which resolves the caller's agent row via `ensureAgentFsCredentialsForAgent` in `src/be/seed/agent-fs-provision.ts`) answers:

```
500 {"error":"Failed to provision agent-fs credentials: Agent not found: <id>"}
```

The old helper only logged `[agent-fs] credential provisioning skipped: HTTP 500 ...` and returned. No retry existed, so the agent-scoped `AGENT_FS_API_KEY` row and the global `AGENT_FS_DEFAULT_ORG_ID` / `AGENT_FS_DEFAULT_DRIVE_ID` rows were never written. Every `agent-fs` call inside that worker's tasks then failed with "Not logged in" until the container was restarted (on restart the agent row exists, provisioning succeeds, everything works).

### Repro

Boot a worker with an `AGENT_ID` that has no row in the API database. The worker log shows, in this order:

```
[agent-fs] credential provisioning skipped: HTTP 500 {"error":"Failed to provision agent-fs credentials: Agent not found: ..."}
[worker] Registered as "worker-cb82b832" (ID: ...)
```

## Fix

Runner-side only. The API route is untouched.

- `ensureAgentFsCredentials` now returns whether the API reached a verdict. `true` means the rows exist or agent-fs is not configured for this deployment (`enabled: false`), both terminal. `false` means HTTP error, network failure, or no agent identity, so a retry is worth it.
- New `provisionAgentFsAfterRegistration({ apiUrl, apiKey, agentId, alreadyProvisioned })` runs immediately after the boot `registerAgent` that logs `Registered as`. When the first attempt already succeeded it is a no-op. Otherwise it makes exactly one more `POST /api/fs/agent-credentials`, which now succeeds because the agent row exists.
- On success it re-fetches the resolved env and re-applies it through `applyResolvedEnvToProcessEnv`, so the boot-time snapshot is not stale. Only the live-apply allowlist is mutated (`RELOADABLE_ENV_KEYS`, which carries `AGENT_FS_SHARED_ORG_ID`).
- Both attempts stay non-fatal: warn and continue, exactly like today. No polling loop, no sleeps. Registration was the only missing precondition, so one retry is enough.
- `registerAgent` is now exported so the test can exercise the real boot ordering. No behavior change.

## What the per-task env fetch already covers

Verified, and it matters for the shape of the fix:

- `spawnTask` (`src/commands/runner.ts`) calls `fetchResolvedEnv(...)` per task and passes the merged result straight into the provider session config (`env: freshEnv`). That fetch hits `GET /api/config/resolved?includeSecrets=true`, and `src/http/config.ts` strips only `API_AGENT_FS_API_KEY`.
- So once the rows exist, the agent-scoped `AGENT_FS_API_KEY` plus the global `AGENT_FS_DEFAULT_ORG_ID` / `AGENT_FS_DEFAULT_DRIVE_ID` reach the harness env on the **first** task with no container restart. The per-task fetch was never the problem: the rows simply did not exist, because provisioning never retried.
- What the per-task fetch does **not** cover is the runner's own `process.env`. `AGENT_FS_API_KEY` and `AGENT_FS_DEFAULT_*` are deliberately not in `RELOADABLE_ENV_KEYS`, and only `AGENT_FS_SHARED_ORG_ID` is. That is why the retry does one post-provisioning env refresh instead of relying on the per-task path alone.

## Test

`src/tests/runner-agent-fs-provision-retry.test.ts` (new). It stands up a fake API with `node:http` on a free port via `listenOnFreePort` and drives the real exported boot functions, so nothing is stubbed:

1. `ensureAgentFsCredentials` before registration gets `500 Agent not found` and reports `false`.
2. `registerAgent` creates the agent row on the fake API.
3. `provisionAgentFsAfterRegistration` makes the second credential call and reports `true`; the request log asserts the exact ordering `POST /api/fs/agent-credentials`, `POST /api/agents`, `POST /api/fs/agent-credentials`, `GET /api/config/resolved`.
4. A per-task-style `fetchResolvedEnv` then carries `AGENT_FS_API_KEY` / `AGENT_FS_DEFAULT_ORG_ID` / `AGENT_FS_DEFAULT_DRIVE_ID` into the harness env.
5. Plus a no-op case (first attempt already succeeded) and a still-failing retry that stays non-fatal.

No helper extraction beyond `provisionAgentFsAfterRegistration` was needed. The whole `runAgent` boot is not unit-testable end to end, so the test covers the two real functions plus the ordering seam.

## Verification

```
$ bun run tsc:check
$ bun tsc --noEmit
(clean)

$ bun run test:root -- src/tests/runner-agent-fs-provision-retry.test.ts src/tests/agent-fs-provision-seeder.test.ts
 13 pass
 0 fail
 64 expect() calls
Ran 13 tests across 2 files. [436.00ms]

$ bun scripts/check-floating-promises.ts
floating promise statements (non-test src/): 0
  of which callee declared in src/be|src/http (db layer): 0

$ bun scripts/check-promise-sinks.ts
promise-in-unsafe-sink findings: 0

$ bash scripts/check-db-boundary.sh
Worker/API DB boundary check passed.

$ bash scripts/check-api-key-boundary.sh
API_KEY boundary check passed.

$ bash scripts/check-test-spawn-sync.sh
Test spawnSync boundary check passed.
```

Also green: the other 10 test files that import `src/commands/runner` (186 pass, 0 fail), and the pre-push hook suite (typecheck, scoped unit tests, DB boundary, spawnSync boundary).

Lint: `bun run lint` crashes locally (known Biome stack overflow on this machine, exits 0 with no summary). Both changed files were linted in a scratch git dir with the repo `biome.json`: `Checked 3 files in 78ms`, no findings.

`runbooks/heartbeat-crash-recovery.md` does not describe agent-fs provisioning, so no runbook update is needed.

https://claude.ai/code/session_01ThMN7VhJoM1C6DbgXfRuh5
