### PR TITLE
fix: preserve task continuity and add designer brand identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Worker harness pins track current compatible releases** (#1296) — Claude Code moves to 2.1.258, Codex plus its SDK to 0.152.1, and OpenCode plus its SDK to 1.18.26.
 
 ### Fixed
+- **Crash recovery preserves professional task ownership** — Lead reroute decisions can resume work only on the original stable agent, recovered Leads may enqueue their own role-owned resume, and cross-agent recovery now fails closed for human intervention.
 - **Workflow retries restore checkpointed inputs and preserve the branch originally taken** (#1297, #1298), preventing empty interpolations and execution of inactive branches after a retry.
 - **Cancelling a workflow closes its pending approval gates** (#1300), rejects stale responses, and notifies linked Slack approval threads.
 - **Lead-only task authorization is enforced across assignment, offers, claims, and recovery** (#1276), while ordinary tasks may still target Lead agents.

--- a/Dockerfile.worker-agent-chat-resume
+++ b/Dockerfile.worker-agent-chat-resume
@@ -1,0 +1,2 @@
+FROM agent-swarm-worker:v1.1-durable-skills-20260818
+COPY --chmod=755 src/agent-swarm-overlay /usr/local/bin/agent-swarm

--- a/Dockerfile.worker-agent-chat-resume
+++ b/Dockerfile.worker-agent-chat-resume
@@ -1,2 +1,0 @@
-FROM agent-swarm-worker:v1.1-durable-skills-20260818
-COPY --chmod=755 src/agent-swarm-overlay /usr/local/bin/agent-swarm

--- a/docs-site/public/openapi.d.ts
+++ b/docs-site/public/openapi.d.ts
@@ -12690,6 +12690,7 @@ export interface paths {
                     source?: string;
                     q?: string;
                     requestedByUserId?: string;
+                    includeAutomatic?: "true" | "false";
                     fields?: "full" | "slim";
                 };
                 header?: never;
@@ -15060,6 +15061,7 @@ export interface paths {
                         outputSchema?: {
                             [key: string]: unknown;
                         };
+                        followUpConfig?: components["schemas"]["FollowUpConfig"];
                         contextKey?: string;
                         requestedByUserId?: string;
                         model?: string;

--- a/openapi.json
+++ b/openapi.json
@@ -32698,6 +32698,18 @@
             "schema": {
               "type": "string",
               "enum": [
+                "true",
+                "false"
+              ]
+            },
+            "required": false,
+            "name": "includeAutomatic",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
                 "full",
                 "slim"
               ]
@@ -38294,6 +38306,9 @@
                   "outputSchema": {
                     "type": "object",
                     "additionalProperties": {}
+                  },
+                  "followUpConfig": {
+                    "$ref": "#/components/schemas/FollowUpConfig"
                   },
                   "contextKey": {
                     "type": "string"

--- a/runbooks/heartbeat-crash-recovery.md
+++ b/runbooks/heartbeat-crash-recovery.md
@@ -201,6 +201,14 @@ Every consumer of the `unassigned` pool calls the **same** `isAgentEligibleForTa
 2. **`runRebootSweep`**'s retry-child creation (§1) now applies the *same* recoverability gate `createResumeFollowUp` uses for its same-agent pin (row exists, not `offline`, has capacity — via the shared `getPinCandidateAgent` helper) — a recoverable retry is pinned `pending` to the original agent and tagged `reboot-retry-pin`; otherwise it falls to the pool with the snapshot stamped anyway. `getStalePinnedResumes`'s reaper scope (§3) now also covers `reboot-retry-pin`, so an unreclaimed reboot pin escalates to the Lead exactly like a crash/graceful pin (retry children are fresh tasks with no `resume-generation` tag, so the generation budget is 0 at first escalation — expected).
 3. **`send-task`** / **`task-action create`** accept an optional `requiredCapabilities: string[]` — written into a fresh pool task's `routingAffinity` with `role` left unset. Per the predicate above, a capabilities-only snapshot (no `role`) is eligible for nobody but its declaring agent (n/a here — there is none), so such a task always ends up escalated to the Lead by §4's starvation check below; it's a way to *record* a requirement for the Lead's judgment, not to auto-route today.
 
+Crash-recovery `reroute-decision` tasks are stricter than ordinary delegation. A
+`send-task(taskType="resume")` originating from that control task must target the
+original task's exact `agentId`; cross-agent recovery is rejected. When the
+original owner is also the Lead, this is the one self-dispatch exception: the
+recovered Lead may enqueue its own fresh resume. If the stable owner cannot
+accept it, recovery stops for Human intervention rather than transferring
+professional ownership to an adjacent role.
+
 **Starvation escalation** (`escalateStarvedPoolTasks`, wired into `cleanupStaleResources` — runs every sweep): an `unassigned` task carrying a `routingAffinity`, queued longer than `POOL_AFFINITY_ESCALATION_MIN`, with **zero eligible registered agents** (any status — an offline-but-matching agent still counts as "not starved"; this is "nobody of that role exists", not "everyone's busy right now") gets a Lead `task.pool.starved.decision` follow-up (`createPoolStarvationDecisionTask`, same `taskType: "reroute-decision"` discriminator and idempotency check as §3's `createRerouteDecisionTask` — no `staleResume`/generation budget since the task was never pinned).
 
 ### Pseudocode (current)

--- a/src/be/db.ts
+++ b/src/be/db.ts
@@ -14342,6 +14342,8 @@ interface ListRecentSessionsOpts {
   q?: string;
   /** When set, restrict to root tasks where `requestedByUserId` equals this value. NULL rows are excluded. */
   requestedByUserId?: string;
+  /** When false, exclude scheduler/heartbeat/health-check roots from human-facing session lists. */
+  includeAutomatic?: boolean;
   /** When true, return slim `SessionListItemSummary` rows (default: full). */
   slim?: boolean;
 }
@@ -14376,6 +14378,11 @@ export async function listRecentSessions(
   if (requestedByUserId) {
     conditions.push("r.requestedByUserId = ?");
     params.push(requestedByUserId);
+  }
+  if (opts?.includeAutomatic === false) {
+    conditions.push(
+      "(IFNULL(r.source, '') NOT IN ('schedule', 'system') AND IFNULL(r.taskType, '') NOT IN ('heartbeat', 'heartbeat-checklist', 'boot-triage', 'health-check') AND IFNULL(r.taskType, '') NOT LIKE '%-monitor' AND IFNULL(r.taskType, '') NOT LIKE '%-digest' AND r.tags NOT LIKE '%\"heartbeat\"%' AND r.tags NOT LIKE '%\"scheduled\"%' AND r.tags NOT LIKE '%\"auto-generated\"%' AND r.tags NOT LIKE '%\"schedule:%')",
+    );
   }
   params.push(limit, offset);
 
@@ -14448,7 +14455,10 @@ export async function listRecentSessions(
  * a plain count, no recursive chain walk needed.
  */
 export async function countSessions(
-  opts?: Pick<ListRecentSessionsOpts, "source" | "q" | "requestedByUserId">,
+  opts?: Pick<
+    ListRecentSessionsOpts,
+    "source" | "q" | "requestedByUserId" | "includeAutomatic"
+  >,
 ): Promise<number> {
   const sources = opts?.source?.filter((s) => s.length > 0) ?? [];
   const q = opts?.q?.trim();
@@ -14469,6 +14479,11 @@ export async function countSessions(
   if (requestedByUserId) {
     conditions.push("requestedByUserId = ?");
     params.push(requestedByUserId);
+  }
+  if (opts?.includeAutomatic === false) {
+    conditions.push(
+      "(IFNULL(source, '') NOT IN ('schedule', 'system') AND IFNULL(taskType, '') NOT IN ('heartbeat', 'heartbeat-checklist', 'boot-triage', 'health-check') AND IFNULL(taskType, '') NOT LIKE '%-monitor' AND IFNULL(taskType, '') NOT LIKE '%-digest' AND tags NOT LIKE '%\"heartbeat\"%' AND tags NOT LIKE '%\"scheduled\"%' AND tags NOT LIKE '%\"auto-generated\"%' AND tags NOT LIKE '%\"schedule:%')",
+    );
   }
 
   const row = await getDbClient().get<{ count: number }>(

--- a/src/be/seed-skills/bundled-files.generated.json
+++ b/src/be/seed-skills/bundled-files.generated.json
@@ -23,6 +23,76 @@
       "content": "---\ndate: [Current date and time with timezone in ISO format]\nauthor: [Author name]\ntopic: \"[Topic]\"\ntags: [brainstorm, relevant-tags]\nstatus: in-progress\nexploration_type: [problem|idea|comparison|workflow|other]\nlast_updated: [Current date in YYYY-MM-DD format]\nlast_updated_by: [Author name]\n---\n\n# [Topic] — Brainstorm\n\n## Context\n\n[Initial framing: what we know, what prompted this exploration, any existing context or constraints]\n\n## Exploration\n\n[Q&A pairs accumulate here during the session]\n\n## Synthesis\n\n### Key Decisions\n- [Filled after exploration — includes \"Deferred: X, defaulting to Y\" entries for consciously parked decisions]\n\n### Open Questions\n- [Fact-shaped questions only (answerable by /research) — undecided decisions don't belong here]\n\n### Constraints Identified\n- [Filled after exploration]\n\n### Core Requirements\n- [Filled after exploration]\n\n## Next Steps\n\n- [Handoff decision: research, plan, or parked]\n"
     }
   ],
+  "brand-identity": [
+    {
+      "path": "assets/brand-asset-manifest-schema.yml",
+      "content": "brand: \"\"\nrevision: \"\"\nstatus: WORKING\nassets:\n  - id: \"\"\n    role: \"\"\n    variant: \"\"\n    format: \"\"\n    source_artifact: \"\"\n    source_revision: \"\"\n    usage: \"\"\n    restrictions: []\n    checksum: \"\"\n"
+    },
+    {
+      "path": "assets/brand-decision-record-template.md",
+      "content": "# Brand decision record\n\n- Decision:\n- Status: PROPOSED\n- Date:\n- Decision owner: Human\n- Evidence considered:\n- Recommendation:\n- Rationale:\n- Alternatives and consequences:\n- Affected elements:\n- Accepted artifact revision:\n- Follow-up mappings:\n"
+    },
+    {
+      "path": "assets/brand-discovery-template.md",
+      "content": "# Brand discovery\n\n## Evidence and sources\n## Audience and context\n## Positioning and intended meaning\n## Existing equity\n## Constraints\n## Current state\n## Open decisions\n## Recommended mode and next step\n"
+    },
+    {
+      "path": "assets/brand-guideline-blueprint.md",
+      "content": "# Brand guideline blueprint\n\n## Status and scope\n## Foundations\n## Generative idea\n## Logo system\n## Colour system\n## Typography\n## Visual language\n## Imagery and art direction\n## Iconography and illustration\n## Motion\n## Applications and stress tests\n## Accessibility and production\n## Governance and asset register\n"
+    },
+    {
+      "path": "assets/brand-status-schema.yml",
+      "content": "brand: \"\"\nrevision: \"\"\nstatus: WORKING # WORKING | ACCEPTED | ARCHIVE\nmode: BRAND_REVIEW # BRAND_REVIEW | BRAND_ELEMENT | BRAND_EVOLUTION | FULL_BRAND_IDENTITY\nelements:\n  - name: \"\"\n    control: FLEXIBLE # FIXED | ADJUSTABLE | FLEXIBLE\n    status: WORKING\n    artifact_ref: \"\"\n    accepted_decision_ref: null\nopen_decisions: []\n"
+    },
+    {
+      "path": "references/accessibility-internationalisation-and-production.md",
+      "content": "# Accessibility, internationalisation, and production\n\nVerify contrast and non-colour cues, readable scale, motion alternatives, language and script coverage, bidirectional implications where relevant, and culturally sensitive meanings. Verify deliverable formats, colour profiles, font licenses, vector integrity, export naming, safe areas, and reproduction constraints. Record known limitations rather than hiding them in presentation mocks.\n"
+    },
+    {
+      "path": "references/application-and-stress-testing.md",
+      "content": "# Application and stress testing\n\nBefore proposing a baseline, test the system in representative situations: smallest and largest logo use, monochrome, light/dark, low contrast, dense information, quiet editorial space, social/avatar crop, document, presentation, marketing surface, and relevant product context. Compose these examples in OpenPencil. Test failure boundaries, not just ideal usage. List observed failures and required corrections.\n"
+    },
+    {
+      "path": "references/brand-to-ice-handoff.md",
+      "content": "# Brand to ICE handoff\n\nRead only after a Human has accepted a brand decision and explicitly authorized product propagation. Map accepted brand semantics to proposed ICE tokens, primitives, assets, or components without changing the brand source. Identify affected product surfaces, accessibility impacts, compatibility, rollout, and rollback. ICE and Storybook become the implementation and review surface for this separate mapping task; OpenPencil remains the brand source artifact.\n"
+    },
+    {
+      "path": "references/colour-craft.md",
+      "content": "# Colour craft\n\nDefine colour by semantic role and usage relationship, not swatch names alone. Include primary, supporting, neutral, surface, text, and status relationships only when relevant. Record source values and conversion assumptions for RGB/HEX and print systems. Test contrast, light/dark contexts, colour-blind distinguishability, low-quality displays, and monochrome fallback. Brand acceptance does not waive product accessibility requirements.\n"
+    },
+    {
+      "path": "references/generative-idea-and-creative-territories.md",
+      "content": "# Generative idea and creative territories\n\nTranslate strategy into a concise idea capable of generating a system, not a slogan pasted onto visuals. When alternatives are needed, build a small set of genuinely distinct territories with a premise, visual mechanism, strengths, risks, and rejection criteria. Avoid cosmetic variants of one idea. Recommend the strongest territory and state what Human approval would authorize.\n"
+    },
+    {
+      "path": "references/iconography-and-illustration.md",
+      "content": "# Iconography and illustration\n\nDefine grid, stroke/shape logic, corner treatment, perspective, detail level, optical correction, colour behavior, and small-size limits. Distinguish functional product icons from expressive brand illustration. Product icon implementation belongs downstream; brand work defines the accepted visual rule and representative examples.\n"
+    },
+    {
+      "path": "references/imagery-and-art-direction.md",
+      "content": "# Imagery and art direction\n\nSpecify subject, perspective, light, colour treatment, cropping, realism, diversity, sourcing, and prohibited patterns. Use references to explain principles, not as unlicensed deliverables. Identify whether photography, generated imagery, illustration, or mixed media is appropriate and record provenance and usage constraints for final assets.\n"
+    },
+    {
+      "path": "references/logo-craft-and-brand-architecture.md",
+      "content": "# Logo craft and brand architecture\n\nTreat a logo as a coordinated system: primary, compact, icon, monochrome, reversed/light-dark, and required lockups. Check silhouette, optical balance, counterforms, spacing, minimum size, pixel behavior, one-colour reproduction, background control, and misuse resistance. Define relationships among master brand, products, sub-brands, descriptors, and endorsed marks only when scope requires them. Do not add architecture to solve a naming problem without Human authority.\n"
+    },
+    {
+      "path": "references/motion-craft.md",
+      "content": "# Motion craft\n\nDefine motion purpose, tempo, easing character, sequencing, transformation logic, and reduced-motion behavior. Use motion to reinforce identity or comprehension, not decoration. Document representative transitions and constraints; production animation or UI component work requires a separate downstream task.\n"
+    },
+    {
+      "path": "references/research-strategy-and-visual-audit.md",
+      "content": "# Research, strategy, and visual audit\n\nUse for every BRAND_REVIEW and before broader creation. Inspect accepted foundations, audiences, positioning, existing assets, touchpoints, competitors, cultural context, and production constraints. Mark each conclusion as evidence, inference, or open decision. Audit recognition, distinctiveness, coherence, accessibility, reproduction, scalability, and fit to intended meaning. End with the design problem, equity to preserve, liabilities to resolve, and a recommended next scope.\n"
+    },
+    {
+      "path": "references/typography-craft.md",
+      "content": "# Typography craft\n\nSelect type for voice, legibility, language coverage, licensing, availability, and production reality. Define roles and hierarchy before enumerating sizes. Test headlines, long reading, data, UI-like labels where relevant, numerals, punctuation, diacritics, and fallback behavior. Record licensed sources and permitted distribution; never package an unlicensed font.\n"
+    },
+    {
+      "path": "references/visual-language-and-composition.md",
+      "content": "# Visual language and composition\n\nDefine repeatable principles for geometry, spacing, framing, rhythm, density, contrast, layout, and recognizable brand gestures. Show rules across varied formats rather than one polished hero. Separate invariant identity signals from flexible campaign expression. Avoid rules that depend on one application size or a single background.\n"
+    }
+  ],
   "delegate-work": [
     {
       "path": "scripts/codex-exec.sh",

--- a/src/be/seed-skills/index.ts
+++ b/src/be/seed-skills/index.ts
@@ -539,7 +539,7 @@ export const skillsSeeder: Seeder<SkillSeedItem> = {
       existing.systemDefault,
       liveFiles,
       existing.userInvocable,
-      existing.scope,
+      item.skill.scope,
     );
   },
 

--- a/src/be/seed-skills/index.ts
+++ b/src/be/seed-skills/index.ts
@@ -2,9 +2,9 @@
  * Built-in swarm skills catalog.
  *
  * Skill templates live under `templates/skills/<name>/`. Entries with
- * `runAllSeedersCandidate: true` are seeded into the DB at swarm scope and are
- * versioned by the generic seeder harness, so pristine built-ins update while
- * user-modified skills are preserved.
+ * `runAllSeedersCandidate: true` are seeded into the DB at their configured
+ * scope and are versioned by the generic seeder harness, so pristine built-ins
+ * update while user-modified skills are preserved.
  */
 
 import { join } from "node:path";
@@ -275,6 +275,7 @@ export type SeedSkill = {
   content: string;
   systemDefault: boolean;
   userInvocable: boolean;
+  scope: "swarm" | "agent";
   /** Bundled files. Empty for simple (single-SKILL.md) skills. */
   files: SeedSkillFile[];
 };
@@ -380,6 +381,7 @@ function skillSeedHash(
   systemDefault: boolean,
   files: SeedSkillFile[],
   userInvocable = true,
+  scope: "swarm" | "agent" = "swarm",
 ): string {
   // Same back-compat rule as the file section: the userInvocable segment is
   // appended ONLY when the flag is false, so every skill with the default
@@ -388,6 +390,7 @@ function skillSeedHash(
   // pristine and the next source update would silently revert their edit.
   let base = `${content}\n\n# seed:systemDefault=${systemDefault ? "1" : "0"}\n`;
   if (userInvocable === false) base += "# seed:userInvocable=0\n";
+  if (scope === "agent") base += "# seed:scope=agent\n";
   if (files.length === 0) return computeContentHash(base);
   return computeContentHash(`${base}# seed:files\n${canonicalFiles(files)}\n`);
 }
@@ -405,6 +408,7 @@ function seedSkillFromSource(
     content: buildSkillContent(config, body),
     systemDefault: config.systemDefault === true,
     userInvocable: config.userInvocable !== false,
+    scope: config.scope ?? "swarm",
     files: BUILT_IN_SKILL_FILES[config.name] ?? [],
   };
 }
@@ -476,6 +480,7 @@ export async function loadSeedSkills(templatesDir?: string): Promise<SeedSkill[]
       content: buildSkillContent(config, await contentFile.text()),
       systemDefault: config.systemDefault === true,
       userInvocable: config.userInvocable !== false,
+      scope: config.scope ?? "swarm",
       files: await readSkillFilesDir(dir),
     });
   }
@@ -514,13 +519,14 @@ export const skillsSeeder: Seeder<SkillSeedItem> = {
         skill.systemDefault,
         skill.files,
         skill.userInvocable,
+        skill.scope,
       ),
       skill,
     }));
   },
 
   async upstreamHash(item): Promise<string | null> {
-    const existing = await getSkillByName(item.key, "swarm");
+    const existing = await getSkillByName(item.key, item.skill.scope);
     if (!existing) return null;
     // Hash the live bundled files too, so an edit to one is detected as drift
     // on the same footing as an edit to SKILL.md.
@@ -533,6 +539,7 @@ export const skillsSeeder: Seeder<SkillSeedItem> = {
       existing.systemDefault,
       liveFiles,
       existing.userInvocable,
+      existing.scope,
     );
   },
 
@@ -556,7 +563,7 @@ export const skillsSeeder: Seeder<SkillSeedItem> = {
       // `existing.id` is needed here.
       const existing = await getDbClient().get<{ id: string }>(
         "SELECT id FROM skills WHERE name = ? AND scope = ? AND COALESCE(ownerAgentId, '') = ?",
-        [skill.name, "swarm", ""],
+        [skill.name, skill.scope, ""],
       );
 
       if (existing) {
@@ -564,7 +571,7 @@ export const skillsSeeder: Seeder<SkillSeedItem> = {
           name: skill.name,
           description: skill.description,
           content: skill.content,
-          scope: "swarm",
+          scope: skill.scope,
           systemDefault: skill.systemDefault,
           userInvocable: skill.userInvocable,
           isComplex: skill.files.length > 0,
@@ -578,7 +585,7 @@ export const skillsSeeder: Seeder<SkillSeedItem> = {
         description: skill.description,
         content: skill.content,
         type: "personal",
-        scope: "swarm",
+        scope: skill.scope,
         ownerAgentId: undefined,
         systemDefault: skill.systemDefault,
         userInvocable: skill.userInvocable,

--- a/src/be/seed-skills/index.ts
+++ b/src/be/seed-skills/index.ts
@@ -32,6 +32,12 @@ import brainstormingConfig from "../../../templates/skills/brainstorming/config.
 import brainstormingContent from "../../../templates/skills/brainstorming/content.md" with {
   type: "text",
 };
+import brandIdentityConfig from "../../../templates/skills/brand-identity/config.json" with {
+  type: "text",
+};
+import brandIdentityContent from "../../../templates/skills/brand-identity/content.md" with {
+  type: "text",
+};
 import codeQualityConfig from "../../../templates/skills/code-quality/config.json" with {
   type: "text",
 };
@@ -297,6 +303,7 @@ const BUILT_IN_SKILL_SOURCES = [
   { config: assetNamespacesConfig, body: assetNamespacesContent },
   { config: attioInteractionConfig, body: attioInteractionContent },
   { config: brainstormingConfig, body: brainstormingContent },
+  { config: brandIdentityConfig, body: brandIdentityContent },
   { config: codeQualityConfig, body: codeQualityContent },
   { config: codeReviewingConfig, body: codeReviewingContent },
   { config: composioConfig, body: composioContent },

--- a/src/be/seed-skills/render.ts
+++ b/src/be/seed-skills/render.ts
@@ -14,6 +14,8 @@ export type SkillTemplateConfig = {
   systemDefault?: boolean;
   /** `false` renders `user-invocable: false` frontmatter (skill is model-invoked only). */
   userInvocable?: boolean;
+  /** Seed catalog scope. Agent-scoped entries are assigned by the reconciler. */
+  scope?: "swarm" | "agent";
 };
 
 /**

--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -5916,10 +5916,18 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
                 providerMeta: parentSession.providerMeta,
               },
             ]);
-            logResumeResolution(role, resumeResolution);
-            // Native resume deprecated: keep `resumeSessionId` undefined so a fresh
-            // session is spawned. Follow-up continuity flows via the context preamble
-            // injected above (see context-preamble.ts).
+            if (
+              taskObj.taskType === "agent-chat-turn" &&
+              state.harnessProvider === "codex" &&
+              parentSession.provider === "codex"
+            ) {
+              resumeSessionId = parentSession.sessionId;
+              console.log(
+                `[${role}] Resuming Agent Chat Codex thread ${resumeSessionId.slice(0, 8)}`,
+              );
+            } else {
+              logResumeResolution(role, resumeResolution);
+            }
           } else {
             console.log(`[${role}] Child task — parent session ID not found, starting fresh`);
           }

--- a/src/heartbeat/heartbeat.ts
+++ b/src/heartbeat/heartbeat.ts
@@ -687,8 +687,15 @@ export async function runRebootSweep(): Promise<void> {
         await restoreAgentIdleAfterRemediation(task.agentId);
       }
 
-      // Don't retry system-generated heartbeat tasks
-      if (SKIP_AUTO_RESUME_TYPES.has(task.taskType ?? "")) {
+      // State-engine-owned stage tasks carry runtime identity in their prompt.
+      // Replaying the same task after reboot cannot claim that runtime under a
+      // new task ID. Leave recovery to the owning engine, which creates a new
+      // runtime through RETRY_STAGE.
+      const taskTags = task.tags ?? [];
+      const isManagedStageTask = taskTags.includes("product-delivery");
+
+      // Don't retry system-generated heartbeat tasks or managed stage tasks.
+      if (SKIP_AUTO_RESUME_TYPES.has(task.taskType ?? "") || isManagedStageTask) {
         rebootAffectedTasks.push({ original: failed, retryTaskId: null });
         continue;
       }

--- a/src/http/sessions.ts
+++ b/src/http/sessions.ts
@@ -89,6 +89,11 @@ const listSessions = route({
      * excluded. Omit to return every session (legacy / non-UI callers).
      */
     requestedByUserId: z.string().min(1).optional(),
+    /** Exclude recurring/system-generated roots for human-facing chat clients. */
+    includeAutomatic: z
+      .enum(["true", "false"])
+      .transform((value) => value === "true")
+      .optional(),
     /** `full` restores the legacy shape (full root `AgentTask`); default is slim. */
     fields: z.enum(["full", "slim"]).optional(),
   }),
@@ -151,6 +156,7 @@ export async function handleSessions(
       source: sources,
       q: parsed.query.q,
       requestedByUserId: parsed.query.requestedByUserId,
+      includeAutomatic: parsed.query.includeAutomatic,
     };
     // List responses default to slim (root is a task summary); `?fields=full` restores it.
     const sessions =
@@ -163,6 +169,7 @@ export async function handleSessions(
       source: sources,
       q: parsed.query.q,
       requestedByUserId: parsed.query.requestedByUserId,
+      includeAutomatic: parsed.query.includeAutomatic,
     });
     listSessions.respond(res, 200, {
       sessions,

--- a/src/http/tasks.ts
+++ b/src/http/tasks.ts
@@ -53,6 +53,7 @@ import {
   type AgentTaskStatus,
   AgentTaskStatusSchema,
   AssetKeySchema,
+  FollowUpConfigSchema,
   isTerminalTaskStatus,
   ModelTierSchema,
   OnUnsupportedSchema,
@@ -229,6 +230,7 @@ const createTask = route({
     key: AssetKeySchema.optional(),
     source: AgentTaskSourceSchema.optional(),
     outputSchema: z.record(z.string(), z.unknown()).optional(),
+    followUpConfig: FollowUpConfigSchema.optional(),
     contextKey: z.string().optional(),
     requestedByUserId: z.string().optional(),
     model: z.string().optional(),
@@ -831,8 +833,17 @@ export async function handleTasks(
         offeredTo: parsed.body.offeredTo || undefined,
         dir: parsed.body.dir || undefined,
         parentTaskId: parsed.body.parentTaskId || undefined,
+        // A Human/API follow-up is a new conversation turn, not a continuation
+        // of the parent's machine output contract. Without this opt-out, a
+        // structured child task can permanently force later PM replies into
+        // raw JSON through transitive parentTaskId inheritance.
+        inheritParentOutputSchema: Boolean(myAgentId),
         source: parsed.body.source || "api",
         outputSchema: parsed.body.outputSchema || undefined,
+        // The route schema has always accepted this field; preserve it at the
+        // persistence boundary so callers can suppress/configure the generic
+        // worker-to-lead completion follow-up.
+        followUpConfig: parsed.body.followUpConfig,
         contextKey: parsed.body.contextKey || undefined,
         requestedByUserId,
         status: parsed.body.draft ? "draft" : undefined,

--- a/src/providers/codex-adapter.ts
+++ b/src/providers/codex-adapter.ts
@@ -1506,15 +1506,12 @@ export async function createInProcessCodexSession(
       model: resolvedModel,
     };
 
-    // Native resume is deprecated. Follow-up continuity is delivered via the
-    // context preamble (see src/commands/context-preamble.ts). Any stray
-    // resumeSessionId is logged and ignored — we always start a fresh thread.
-    if (config.resumeSessionId) {
-      console.warn(
-        "[codex-adapter] resumeSessionId ignored — native resume is disabled by deprecation plan",
-      );
-    }
-    const thread = codex.startThread(threadOptions);
+    // General task continuity still uses the durable context preamble. The
+    // runner supplies resumeSessionId only for an explicit Agent Chat turn,
+    // scoped to the same Codex agent/provider.
+    const thread = config.resumeSessionId
+      ? codex.resumeThread(config.resumeSessionId, threadOptions)
+      : codex.startThread(threadOptions);
 
     return new CodexSession(
       thread,

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -111,10 +111,9 @@ export interface ProviderSessionConfig {
   vcsRepo?: string;
   contextKey?: string;
   /**
-   * @deprecated Never set by the runner — native session resume was removed in
-   * the 2026-05-28 plan. Adapters log + ignore any stray value. Follow-up
-   * continuity flows through the context preamble; see
-   * `src/commands/context-preamble.ts` and `src/commands/resume-session.ts`.
+   * Existing provider thread to resume. General workflow/task continuations
+   * keep using the durable context preamble; this is set only for the explicit
+   * Agent Chat turn contract, where same-agent conversational latency matters.
    */
   resumeSessionId?: string;
   iteration?: number;

--- a/src/tasks/worker-follow-up.ts
+++ b/src/tasks/worker-follow-up.ts
@@ -525,6 +525,7 @@ export async function createRerouteDecisionTask(args: {
 
   const decision = resolveTemplate("task.reroute.decision", {
     original_agent_name: agentName,
+    original_agent_id: original.agentId ?? "unknown",
     original_agent_identity: identitySlice,
     original_task_id: original.id,
     reason,

--- a/src/tests/codex-adapter.test.ts
+++ b/src/tests/codex-adapter.test.ts
@@ -669,6 +669,55 @@ describe("CodexAdapter.canResume", () => {
   });
 });
 
+describe("CodexAdapter Agent Chat resume", () => {
+  test("uses the requested persisted Codex thread", async () => {
+    const sdk = await import("@openai/codex-sdk");
+    const prototype = sdk.Codex.prototype as unknown as {
+      startThread: (...args: unknown[]) => unknown;
+      resumeThread: (...args: unknown[]) => unknown;
+    };
+    const originalStartThread = prototype.startThread;
+    const originalResumeThread = prototype.resumeThread;
+    const resumed: string[] = [];
+    const fakeThread = makeFakeThread([
+      { type: "thread.started", thread_id: "thread-existing" },
+      { type: "turn.started" },
+      {
+        type: "turn.completed",
+        usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+      },
+    ]);
+    prototype.startThread = () => {
+      throw new Error("fresh thread must not be created");
+    };
+    prototype.resumeThread = (id: unknown) => {
+      resumed.push(String(id));
+      return fakeThread;
+    };
+    const previousSkipSummary = process.env.SKIP_SESSION_SUMMARY;
+    process.env.SKIP_SESSION_SUMMARY = "1";
+
+    try {
+      const adapter = new CodexAdapter({ bypassSubprocess: true });
+      const session = await adapter.createSession(
+        testConfig({
+          taskId: "",
+          apiUrl: "",
+          apiKey: "",
+          resumeSessionId: "thread-existing",
+        }),
+      );
+      await session.waitForCompletion();
+      expect(resumed).toEqual(["thread-existing"]);
+    } finally {
+      prototype.startThread = originalStartThread;
+      prototype.resumeThread = originalResumeThread;
+      if (previousSkipSummary === undefined) delete process.env.SKIP_SESSION_SUMMARY;
+      else process.env.SKIP_SESSION_SUMMARY = previousSkipSummary;
+    }
+  });
+});
+
 describe("writeCodexAgentsMd round-trip", () => {
   const tmpDir = `/tmp/codex-agents-md-test-${Date.now()}`;
 

--- a/src/tests/heartbeat-reroute-decision.test.ts
+++ b/src/tests/heartbeat-reroute-decision.test.ts
@@ -369,7 +369,6 @@ describe("Heartbeat — reroute-decision fallback (DES-523)", () => {
   test("tracker_sync chain on the gone-agent path: original → R1 → original → R2", async () => {
     const lead = await createAgent({ name: "lead", isLead: true, status: "busy" });
     const agentA = await createAgent({ name: "coder-A", isLead: false, status: "idle" });
-    const agentB = await createAgent({ name: "coder-B", isLead: false, status: "idle" });
     const original = await createTaskExtended("tracked crashed work", { agentId: agentA.id });
     await startTask(original.id);
     await createTrackerSync({
@@ -405,13 +404,14 @@ describe("Heartbeat — reroute-decision fallback (DES-523)", () => {
     );
     expect(decision).toBeDefined();
 
-    // Lead re-delegates to agent B via send-task (taskType resume, parentTaskId original).
+    // Lead resumes on the original owner via send-task (taskType resume,
+    // parentTaskId original). Crash recovery preserves professional ownership.
     // transferTrackerSyncToResumeChild repoints the tracker original → R2.
     const result = await callSendTask(
       sendTaskServer,
       {
-        task: "Resume the crashed work on B",
-        agentId: agentB.id,
+        task: "Resume the crashed work on the original owner",
+        agentId: agentA.id,
         taskType: "resume",
         parentTaskId: original.id,
         allowDuplicate: true,
@@ -425,6 +425,75 @@ describe("Heartbeat — reroute-decision fallback (DES-523)", () => {
     expect((await getTrackerSync("linear", "task", r2Id))?.externalId).toBe("ENG-900");
     expect(await getTrackerSync("linear", "task", original.id)).toBeNull();
     expect(await getTrackerSync("linear", "task", r1.id)).toBeNull();
+  });
+
+  test("reroute-decision rejects cross-agent crash recovery", async () => {
+    const lead = createAgent({ name: "lead", isLead: true, status: "busy" });
+    const { agent: originalOwner, original, r1 } = await seedPinnedCrash("flow-owner");
+    const peer = await createAgent({ name: "adjacent-peer", isLead: false, status: "idle" });
+    const created = createRerouteDecisionTask({
+      original,
+      staleResume: r1,
+      reason: "crash_recovery",
+      maxGenerations: maxResumeGenerations(),
+    });
+    expect(created.kind).toBe("created");
+    if (created.kind !== "created") throw new Error("expected decision");
+
+    const result = await callSendTask(
+      sendTaskServer,
+      {
+        task: "Move role-owned flow work to a peer",
+        agentId: peer.id,
+        taskType: "resume",
+        parentTaskId: original.id,
+        allowDuplicate: true,
+      },
+      lead.id,
+      created.task.id,
+    );
+    const s = structuredOf(result);
+    expect(s.success).toBe(false);
+    expect(s.message).toContain(`must preserve the original assignee ${originalOwner.id}`);
+  });
+
+  test("recovered Lead may enqueue its own role-owned resume", async () => {
+    const lead = await createAgent({ name: "pm-lead", isLead: true, status: "busy", maxTasks: 3 });
+    const original = await createTaskExtended("Review the Product Manager-owned flows", {
+      agentId: lead.id,
+    });
+    await startTask(original.id);
+    const r1 = await createTaskExtended("Pinned PM resume", {
+      agentId: lead.id,
+      parentTaskId: original.id,
+      taskType: "resume",
+      tags: [`${RESUME_GENERATION_TAG_PREFIX}1`, CRASH_RECOVERY_PIN_TAG],
+    });
+    await supersedeTask(original.id, { reason: "crash", resumeTaskId: r1.id });
+    const created = createRerouteDecisionTask({
+      original: (await getTaskById(original.id))!,
+      staleResume: r1,
+      reason: "crash_recovery",
+      maxGenerations: maxResumeGenerations(),
+    });
+    expect(created.kind).toBe("created");
+    if (created.kind !== "created") throw new Error("expected decision");
+
+    const result = await callSendTask(
+      sendTaskServer,
+      {
+        task: "Resume PM-owned flow review on the PM",
+        agentId: lead.id,
+        taskType: "resume",
+        parentTaskId: original.id,
+        allowDuplicate: true,
+      },
+      lead.id,
+      created.task.id,
+    );
+    const s = structuredOf(result);
+    expect(s.success).toBe(true);
+    expect((await getTaskById(s.task!.id))?.agentId).toBe(lead.id);
   });
 
   test("a fresh (within-grace) crash pin is NOT escalated by the reaper", async () => {

--- a/src/tests/heartbeat-reroute-decision.test.ts
+++ b/src/tests/heartbeat-reroute-decision.test.ts
@@ -428,10 +428,10 @@ describe("Heartbeat — reroute-decision fallback (DES-523)", () => {
   });
 
   test("reroute-decision rejects cross-agent crash recovery", async () => {
-    const lead = createAgent({ name: "lead", isLead: true, status: "busy" });
+    const lead = await createAgent({ name: "lead", isLead: true, status: "busy" });
     const { agent: originalOwner, original, r1 } = await seedPinnedCrash("flow-owner");
     const peer = await createAgent({ name: "adjacent-peer", isLead: false, status: "idle" });
-    const created = createRerouteDecisionTask({
+    const created = await createRerouteDecisionTask({
       original,
       staleResume: r1,
       reason: "crash_recovery",
@@ -470,7 +470,7 @@ describe("Heartbeat — reroute-decision fallback (DES-523)", () => {
       tags: [`${RESUME_GENERATION_TAG_PREFIX}1`, CRASH_RECOVERY_PIN_TAG],
     });
     await supersedeTask(original.id, { reason: "crash", resumeTaskId: r1.id });
-    const created = createRerouteDecisionTask({
+    const created = await createRerouteDecisionTask({
       original: (await getTaskById(original.id))!,
       staleResume: r1,
       reason: "crash_recovery",

--- a/src/tests/heartbeat.test.ts
+++ b/src/tests/heartbeat.test.ts
@@ -781,6 +781,27 @@ describe("Heartbeat Triage", () => {
       expect(await claimTask(retryId!, lead.id)).not.toBeNull();
     });
 
+    test("does not replay a state-engine-owned stage task with stale runtime identity", async () => {
+      const agent = await createAgent({ name: "stage-worker", isLead: false, status: "busy" });
+      const task = await createTaskExtended("Managed stage runtime", {
+        agentId: agent.id,
+        tags: ["product-delivery", "stage:prototype"],
+      });
+      await startTask(task.id);
+      const past = new Date(Date.now() - 1000).toISOString();
+      await getDbClient().run("UPDATE agent_tasks SET lastUpdatedAt = ? WHERE id = ?", [
+        past,
+        task.id,
+      ]);
+
+      await runRebootSweep();
+
+      expect((await getTaskById(task.id))?.status).toBe("failed");
+      const affected = getRebootAffectedTasks();
+      expect(affected).toHaveLength(1);
+      expect(affected[0]!.retryTaskId).toBeNull();
+    });
+
     test("falls back to an affinity-stamped pool retry when the agent is at capacity", async () => {
       const agent = await createAgent({
         name: "full-worker",

--- a/src/tests/http-api-integration.test.ts
+++ b/src/tests/http-api-integration.test.ts
@@ -474,6 +474,19 @@ describe("Tasks", () => {
     ids.task2 = body.id;
   });
 
+  test("POST /api/tasks — persists follow-up configuration", async () => {
+    const { status, body } = await post("/api/tasks", {
+      body: {
+        task: "Direct chat task without lead completion follow-up",
+        agentId: ids.workerAgent,
+        followUpConfig: { disabled: true },
+      },
+    });
+
+    expect(status).toBe(201);
+    expect(body.followUpConfig).toEqual({ disabled: true });
+  });
+
   test("GET /api/tasks — list all tasks", async () => {
     const { status, body } = await get("/api/tasks");
     expect(status).toBe(200);

--- a/src/tests/seed-skills-bundled-files.test.ts
+++ b/src/tests/seed-skills-bundled-files.test.ts
@@ -85,6 +85,7 @@ describe("seeded skills with bundled files", () => {
 
     expect(brandIdentity?.systemDefault).toBe(false);
     expect(brandIdentity?.userInvocable).toBe(true);
+    expect(brandIdentity?.scope).toBe("agent");
     expect(brandIdentity?.content).toContain("All `brand-identity` visual authoring MUST use the managed OpenPencil workspace");
     expect(brandIdentity?.content).toContain("Storybook is not a brand-authoring environment");
     expect(brandIdentity?.files.map((file) => file.path).sort()).toEqual([
@@ -106,6 +107,11 @@ describe("seeded skills with bundled files", () => {
       "references/typography-craft.md",
       "references/visual-language-and-composition.md",
     ]);
+  });
+
+  test("brand-identity is seeded as assignment-managed rather than swarm-wide", async () => {
+    expect((await getSkillByName("brand-identity", "agent"))?.scope).toBe("agent");
+    expect(await getSkillByName("brand-identity", "swarm")).toBeNull();
   });
 
   test("embedded manifest matches the on-disk templates", async () => {

--- a/src/tests/seed-skills-bundled-files.test.ts
+++ b/src/tests/seed-skills-bundled-files.test.ts
@@ -79,6 +79,35 @@ describe("seeded skills with bundled files", () => {
     expect(skills.find((skill) => skill.name === "kv-storage")?.files).toEqual([]);
   });
 
+  test("brand-identity ships its progressive references and output templates", async () => {
+    const skills = await loadSeedSkills();
+    const brandIdentity = skills.find((skill) => skill.name === "brand-identity");
+
+    expect(brandIdentity?.systemDefault).toBe(false);
+    expect(brandIdentity?.userInvocable).toBe(true);
+    expect(brandIdentity?.content).toContain("All `brand-identity` visual authoring MUST use the managed OpenPencil workspace");
+    expect(brandIdentity?.content).toContain("Storybook is not a brand-authoring environment");
+    expect(brandIdentity?.files.map((file) => file.path).sort()).toEqual([
+      "assets/brand-asset-manifest-schema.yml",
+      "assets/brand-decision-record-template.md",
+      "assets/brand-discovery-template.md",
+      "assets/brand-guideline-blueprint.md",
+      "assets/brand-status-schema.yml",
+      "references/accessibility-internationalisation-and-production.md",
+      "references/application-and-stress-testing.md",
+      "references/brand-to-ice-handoff.md",
+      "references/colour-craft.md",
+      "references/generative-idea-and-creative-territories.md",
+      "references/iconography-and-illustration.md",
+      "references/imagery-and-art-direction.md",
+      "references/logo-craft-and-brand-architecture.md",
+      "references/motion-craft.md",
+      "references/research-strategy-and-visual-audit.md",
+      "references/typography-craft.md",
+      "references/visual-language-and-composition.md",
+    ]);
+  });
+
   test("embedded manifest matches the on-disk templates", async () => {
     const embedded = await loadSeedSkills();
     const fromDisk = await loadSeedSkills(TEMPLATES_DIR);

--- a/src/tests/sessions.test.ts
+++ b/src/tests/sessions.test.ts
@@ -135,6 +135,31 @@ describe("sessions — getRootTaskChain + listRecentSessions", () => {
     expect(single?.chainTaskCount).toBe(1);
   });
 
+  test("human-facing session list excludes automatic roots without hiding normal work", async () => {
+    const agent = await createAgent({
+      id: "sessions-filter-agent",
+      name: "Sessions Filter Agent",
+      isLead: false,
+      status: "idle",
+    });
+    const interactive = await createTaskExtended("interactive chat request", {
+      agentId: agent.id,
+      source: "api",
+    });
+    const heartbeat = await createTaskExtended("Task Type: Heartbeat Checklist", {
+      agentId: agent.id,
+      source: "mcp",
+      taskType: "heartbeat-checklist",
+    });
+
+    const visible = await listRecentSessions({ limit: 100, includeAutomatic: false });
+    const visibleIds = visible.map((session) => session.root.id);
+
+    expect(visibleIds).toContain(interactive.id);
+    expect(visibleIds).not.toContain(heartbeat.id);
+    expect(await countSessions({ includeAutomatic: false })).toBe(visible.length);
+  });
+
   test("listRecentSessions ordered by lastActivityAt DESC", async () => {
     const sessions = await listRecentSessions({ limit: 50 });
     for (let i = 1; i < sessions.length; i++) {

--- a/src/tests/task-completion-idempotency.test.ts
+++ b/src/tests/task-completion-idempotency.test.ts
@@ -389,6 +389,25 @@ async function countTaskCompletionMemories(taskId: string): Promise<number> {
 }
 
 describe("store-progress terminal result reporting", () => {
+  test("completion promotes final progress when explicit output is omitted", async () => {
+    const agent = createAgent({
+      name: "progress-output-fallback",
+      isLead: false,
+      status: "idle",
+      capabilities: [],
+    });
+    const task = createTaskExtended("progress output fallback", { agentId: agent.id });
+    startTask(task.id);
+
+    const result = (await buildStoreProgressHandler().handler(
+      { taskId: task.id, progress: "Final user-visible answer", status: "completed" },
+      storeProgressMeta(agent.id),
+    )) as StoreProgressResult;
+
+    expect(result.structuredContent.success).toBe(true);
+    expect(getTaskById(task.id)!.output).toBe("Final user-visible answer");
+  });
+
   test("identical and content-free retries remain benign no-ops", async () => {
     const agent = await createAgent({
       name: "terminal-handler-identical",

--- a/src/tests/task-completion-idempotency.test.ts
+++ b/src/tests/task-completion-idempotency.test.ts
@@ -390,14 +390,14 @@ async function countTaskCompletionMemories(taskId: string): Promise<number> {
 
 describe("store-progress terminal result reporting", () => {
   test("completion promotes final progress when explicit output is omitted", async () => {
-    const agent = createAgent({
+    const agent = await createAgent({
       name: "progress-output-fallback",
       isLead: false,
       status: "idle",
       capabilities: [],
     });
-    const task = createTaskExtended("progress output fallback", { agentId: agent.id });
-    startTask(task.id);
+    const task = await createTaskExtended("progress output fallback", { agentId: agent.id });
+    await startTask(task.id);
 
     const result = (await buildStoreProgressHandler().handler(
       { taskId: task.id, progress: "Final user-visible answer", status: "completed" },
@@ -405,7 +405,7 @@ describe("store-progress terminal result reporting", () => {
     )) as StoreProgressResult;
 
     expect(result.structuredContent.success).toBe(true);
-    expect(getTaskById(task.id)!.output).toBe("Final user-visible answer");
+    expect((await getTaskById(task.id))!.output).toBe("Final user-visible answer");
   });
 
   test("identical and content-free retries remain benign no-ops", async () => {

--- a/src/tools/send-task.ts
+++ b/src/tools/send-task.ts
@@ -228,14 +228,11 @@ export async function sendTaskHandler(
 
   const creatorAgentId = ctx.kind === "owner" ? ctx.agentId : undefined;
   const sourceTaskId = ctx.kind === "owner" ? ctx.sourceTaskId : undefined;
+  const callerTask = sourceTaskId ? await getTaskById(sourceTaskId) : null;
   const requestedByUserId =
-    ctx.kind === "user" ? ctx.userId : (inputRequestedByUserId ?? undefined);
-
-  if (ctx.kind === "owner" && agentId === ctx.agentId) {
-    return toolErr("Cannot send a task to yourself, are you drunk?", {
-      data: { yourAgentId: ctx.agentId },
-    });
-  }
+    ctx.kind === "user"
+      ? ctx.userId
+      : (inputRequestedByUserId ?? callerTask?.requestedByUserId ?? undefined);
 
   const effectiveVcsRepo = vcsRepo;
   const normalizedModel = splitLegacyModelAlias({ model, modelTier });
@@ -253,6 +250,28 @@ export async function sendTaskHandler(
   // A public continuation cannot accidentally declassify its parent before
   // createTaskExtended performs the authoritative merge.
   const effectiveLeadOnly = leadOnly || effectiveParentTask?.routingAffinity?.leadOnly === true;
+
+  // A crash-recovery reroute decision for role-owned work must preserve the
+  // original assignee. The decision task is a control-plane fallback, not
+  // authorization to move work to an arbitrary peer. This also permits the
+  // recovered Lead to enqueue a fresh resume for itself after its previous
+  // worker session crashed.
+  const preservesCrashedOwner =
+    callerTask?.taskType === "reroute-decision" &&
+    taskType === "resume" &&
+    effectiveParentTask?.agentId != null;
+  if (preservesCrashedOwner && agentId !== effectiveParentTask.agentId) {
+    return toolErr(
+      `Crash-recovery resume must preserve the original assignee ${effectiveParentTask.agentId}. Cross-agent rerouting requires explicit human intervention.`,
+      { data: { yourAgentId: creatorAgentId } },
+    );
+  }
+
+  if (ctx.kind === "owner" && agentId === ctx.agentId && !preservesCrashedOwner) {
+    return toolErr("Cannot send a task to yourself, are you drunk?", {
+      data: { yourAgentId: ctx.agentId },
+    });
+  }
 
   // Slack-routing coherence guard: reject a hand-typed slackChannelId/slackThreadTs
   // that disagrees with the parent task or the contextKey this child will inherit.

--- a/src/tools/store-progress.ts
+++ b/src/tools/store-progress.ts
@@ -348,6 +348,7 @@ export const registerStoreProgressTool = (server: McpServer) => {
                 // biome-ignore lint/correctness/noEmptyPattern: data unused, ctx needed
                 filter: ({}, ctx) => ctx.deps.length > 0,
                 conditions: [{ timeout_ms: 3_600_000 }], // 1 hour
+              });
             });
 
             if (existingTask.agentId) {

--- a/src/tools/store-progress.ts
+++ b/src/tools/store-progress.ts
@@ -302,11 +302,21 @@ export const registerStoreProgressTool = (server: McpServer) => {
           }
         }
 
+        // A common harness failure mode is completing with the final answer in
+        // `progress` while omitting `output`. Preserve the explicit output when
+        // supplied; otherwise promote the latest useful progress for ordinary
+        // (non-structured) tasks so the UI never renders a blank completion.
+        const completionOutput = output ?? (
+          status === "completed" && !existingTask.outputSchema
+            ? progress ?? updatedTask.progress ?? existingTask.progress ?? undefined
+            : undefined
+        );
+
         // Validate structured output against outputSchema if present
         if (status === "completed") {
           const outputValidationError = getTaskOutputValidationError(
             existingTask.outputSchema,
-            output,
+            completionOutput,
           );
           if (outputValidationError) {
             return { success: false, message: outputValidationError };
@@ -315,7 +325,7 @@ export const registerStoreProgressTool = (server: McpServer) => {
 
         // Handle status change
         if (status === "completed") {
-          const result = await completeTask(taskId, output);
+          const result = await completeTask(taskId, completionOutput);
           if (result) {
             updatedTask = result;
 
@@ -332,13 +342,12 @@ export const registerStoreProgressTool = (server: McpServer) => {
                   taskId,
                   agentId: existingTask.agentId,
                   previousStatus: existingTask.status,
-                  hasOutput: !!output,
+                  hasOutput: !!completionOutput,
                 },
                 validator: (data) => data.previousStatus === "in_progress",
                 // biome-ignore lint/correctness/noEmptyPattern: data unused, ctx needed
                 filter: ({}, ctx) => ctx.deps.length > 0,
                 conditions: [{ timeout_ms: 3_600_000 }], // 1 hour
-              });
             });
 
             if (existingTask.agentId) {

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -191,20 +191,21 @@ Resume generation: {{generation_next}} of {{max_generations}} (max).{{artifacts_
 
 ## Your job
 
-The worker that was handling this task crashed and did not come back within the grace window, so its pinned resume was never reclaimed. Pick an agent to take this work over and RE-DELEGATE it — do NOT execute it yourself, and do NOT leave routing to the default.
+The worker session handling this task crashed and did not come back within the grace window, so its pinned resume was never reclaimed. Preserve the original task owner: dispatch a fresh resume to the exact original agent ID. A worker-session crash does not transfer professional ownership or authorize a peer role.
 
-Use the crashed agent's identity above as context for who was on it and what kind of work it is. You may re-delegate to the same kind of agent, a peer, or whoever you judge appropriate — the choice is yours, but you MUST choose explicitly.
+Do not send the work to another agent, even if that agent appears idle or has adjacent skills. If the original agent cannot accept a fresh resume, report BLOCKED for Human intervention instead of changing owner.
 
 Dispatch via \`send-task\` with ALL of:
-- an explicit \`agentId\` (the chosen worker) — REQUIRED. If you omit it, \`send-task\` auto-routes to the original task's agent, which is the dead worker, and the work re-strands.
+- explicit \`agentId: {{original_agent_id}}\` — REQUIRED.
 - \`taskType: "resume"\`
 - the tag \`resume-generation:{{generation_next}}\`
 - \`parentTaskId: {{original_task_id}}\`
 - do NOT inherit the original task's \`model\` (the new worker runs on its own).
 
-This work will NOT fall back to the unassigned pool — you are the only re-delegation path.`,
+This work will NOT fall back to the unassigned pool and must not cross role ownership.`,
   variables: [
     { name: "original_agent_name", description: "Name or ID prefix of the crashed agent" },
+    { name: "original_agent_id", description: "Stable ID of the original task owner" },
     {
       name: "original_agent_identity",
       description:

--- a/src/workflows/executors/agent-task.ts
+++ b/src/workflows/executors/agent-task.ts
@@ -29,6 +29,7 @@ const AgentTaskConfigSchema = z.object({
   parentTaskId: z.string().uuid().optional(),
   requestedByUserId: z.string().optional(),
   outputSchema: z.record(z.string(), z.unknown()).optional(),
+  inheritParentOutputSchema: z.boolean().optional(),
   followUpConfig: FollowUpConfigSchema.optional(),
 });
 
@@ -111,6 +112,7 @@ export class AgentTaskExecutor extends BaseExecutor<
         parentTaskId: config.parentTaskId,
         requestedByUserId: config.requestedByUserId ?? meta.requestedByUserId,
         outputSchema: config.outputSchema,
+        inheritParentOutputSchema: config.inheritParentOutputSchema,
         followUpConfig: config.followUpConfig,
         contextKey: workflowContextKey({ workflowRunId: meta.runId }),
       },

--- a/templates/skills/brand-identity/config.json
+++ b/templates/skills/brand-identity/config.json
@@ -1,0 +1,15 @@
+{
+  "category": "skills",
+  "description": "Create, review, and evolve brand identity systems with explicit governance and Human approval of material identity decisions. Use for logos, brand systems, colour, typography, visual language, imagery, iconography, motion, guidelines, and brand applications; do not use for ordinary product UI design or executable UI prototypes.",
+  "displayName": "Brand Identity",
+  "kind": "skill",
+  "name": "brand-identity",
+  "placeholders": [],
+  "runAllSeedersCandidate": true,
+  "slug": "brand-identity",
+  "systemDefault": false,
+  "tags": ["brand", "identity", "design"],
+  "title": "Brand Identity",
+  "userInvocable": true,
+  "version": "1.0.0"
+}

--- a/templates/skills/brand-identity/config.json
+++ b/templates/skills/brand-identity/config.json
@@ -6,6 +6,7 @@
   "name": "brand-identity",
   "placeholders": [],
   "runAllSeedersCandidate": true,
+  "scope": "agent",
   "slug": "brand-identity",
   "systemDefault": false,
   "tags": ["brand", "identity", "design"],

--- a/templates/skills/brand-identity/content.md
+++ b/templates/skills/brand-identity/content.md
@@ -1,0 +1,60 @@
+# Brand Identity
+
+Own the integrity and coherent evolution of a brand identity. Produce a clear recommendation with rationale, not an unranked collection of options. Use professional craft judgment for routine decisions; require Human approval before any material identity decision becomes accepted.
+
+## Authoring and authority
+
+All `brand-identity` visual authoring MUST use the managed OpenPencil workspace. The assignment of this skill authorizes and requires OpenPencil for its visual work; do not ask the Human to repeat that tool choice. Create logo work, creative territories, colour and typography explorations, visual-language and imagery direction, brand applications, and visual guideline compositions there.
+
+Confluence and other durable brand records hold accepted decisions, rationale, state, and governance. OpenPencil is the editable visual working surface, not the sole authority. Storybook is not a brand-authoring environment. Do not create or modify production UI components to demonstrate a brand. Brand-to-product propagation requires a separate, explicit, approved mapping into ICE Design System primitives or components; only that downstream task uses Storybook.
+
+The request-only OpenPencil rule for `product-design` and `ux-analysis` remains unchanged. This exception applies only while `brand-identity` is the active capability.
+
+Follow the managed OpenPencil lifecycle: use one stable document ID and managed `.fig` path, save successfully, list and reopen that exact document, verify its identity, and return the stable managed Human URL. Fail closed if durable save, reopen, or review access cannot be established. Do not run ICE binding/finalization unless a separately approved Brand → ICE task explicitly requires it.
+
+## Select the minimum sufficient mode
+
+- `BRAND_REVIEW`: assess existing identity and readiness without redesigning it.
+- `BRAND_ELEMENT`: create or evolve one bounded element, such as a logo system or colour system.
+- `BRAND_EVOLUTION`: evolve multiple connected elements while preserving accepted equity.
+- `FULL_BRAND_IDENTITY`: establish an end-to-end identity and guideline system.
+
+Do not expand to a broader mode merely because additional improvement is possible.
+
+## Establish state before making
+
+Record the current brand state and distinguish:
+
+- `FIXED`: accepted and not open to change in this task;
+- `ADJUSTABLE`: may evolve inside stated constraints;
+- `FLEXIBLE`: open for exploration.
+
+Keep artifacts separated as `WORKING`, `ACCEPTED`, or `ARCHIVE`. Never overwrite or silently mutate accepted identity. Preserve prior accepted material and create attributable working revisions.
+
+## Working method
+
+1. Read the accepted foundations, decisions, constraints, existing assets, and latest state. Separate evidence from assumptions and unresolved choices.
+2. Choose the minimum mode and name the material Human decisions that may arise.
+3. Audit the existing identity and its real use contexts before proposing change.
+4. Form a strategic design premise and a generative idea. Explore meaningfully distinct territories only when the mode needs them.
+5. Develop the required system with appropriate optical, typographic, colour, production, accessibility, and scalability discipline.
+6. Test representative real applications, including small size, light/dark, monochrome, dense/quiet contexts, and relevant channels. A presentation board alone is not proof of a usable system.
+7. Recommend one direction with rationale, risks, and consequences. Ask for a Human decision only where material identity, scope, or an irreversible trade-off requires it.
+8. After approval, update durable state and manifests. Keep rejected or superseded work in `ARCHIVE`, never mixed with accepted assets.
+
+## Progressive references
+
+Read only what the selected mode and artifact require:
+
+- For discovery, audit, strategy, and territories: `references/research-strategy-and-visual-audit.md` and `references/generative-idea-and-creative-territories.md`.
+- For logos and scalable identity structure: `references/logo-craft-and-brand-architecture.md`.
+- For type or colour: `references/typography-craft.md` and `references/colour-craft.md`.
+- For composition, imagery, icons, or motion: the corresponding visual-language, imagery, iconography, or motion reference.
+- Before acceptance: `references/accessibility-internationalisation-and-production.md` and `references/application-and-stress-testing.md`.
+- Only for an approved downstream mapping: `references/brand-to-ice-handoff.md`.
+
+Use the templates under `assets/` for durable output when applicable; do not treat templates as accepted content.
+
+## Completion contract
+
+Return the selected mode; sources and constraints used; state of affected elements; recommendation and rationale; OpenPencil document ID/path/managed URL; tests performed and observed failures; material decisions awaiting Human approval; and proposed durable status. Never label work `ACCEPTED` without the required Human decision.

--- a/templates/skills/brand-identity/files/assets/brand-asset-manifest-schema.yml
+++ b/templates/skills/brand-identity/files/assets/brand-asset-manifest-schema.yml
@@ -1,0 +1,13 @@
+brand: ""
+revision: ""
+status: WORKING
+assets:
+  - id: ""
+    role: ""
+    variant: ""
+    format: ""
+    source_artifact: ""
+    source_revision: ""
+    usage: ""
+    restrictions: []
+    checksum: ""

--- a/templates/skills/brand-identity/files/assets/brand-decision-record-template.md
+++ b/templates/skills/brand-identity/files/assets/brand-decision-record-template.md
@@ -1,0 +1,13 @@
+# Brand decision record
+
+- Decision:
+- Status: PROPOSED
+- Date:
+- Decision owner: Human
+- Evidence considered:
+- Recommendation:
+- Rationale:
+- Alternatives and consequences:
+- Affected elements:
+- Accepted artifact revision:
+- Follow-up mappings:

--- a/templates/skills/brand-identity/files/assets/brand-discovery-template.md
+++ b/templates/skills/brand-identity/files/assets/brand-discovery-template.md
@@ -1,0 +1,10 @@
+# Brand discovery
+
+## Evidence and sources
+## Audience and context
+## Positioning and intended meaning
+## Existing equity
+## Constraints
+## Current state
+## Open decisions
+## Recommended mode and next step

--- a/templates/skills/brand-identity/files/assets/brand-guideline-blueprint.md
+++ b/templates/skills/brand-identity/files/assets/brand-guideline-blueprint.md
@@ -1,0 +1,15 @@
+# Brand guideline blueprint
+
+## Status and scope
+## Foundations
+## Generative idea
+## Logo system
+## Colour system
+## Typography
+## Visual language
+## Imagery and art direction
+## Iconography and illustration
+## Motion
+## Applications and stress tests
+## Accessibility and production
+## Governance and asset register

--- a/templates/skills/brand-identity/files/assets/brand-status-schema.yml
+++ b/templates/skills/brand-identity/files/assets/brand-status-schema.yml
@@ -1,0 +1,11 @@
+brand: ""
+revision: ""
+status: WORKING # WORKING | ACCEPTED | ARCHIVE
+mode: BRAND_REVIEW # BRAND_REVIEW | BRAND_ELEMENT | BRAND_EVOLUTION | FULL_BRAND_IDENTITY
+elements:
+  - name: ""
+    control: FLEXIBLE # FIXED | ADJUSTABLE | FLEXIBLE
+    status: WORKING
+    artifact_ref: ""
+    accepted_decision_ref: null
+open_decisions: []

--- a/templates/skills/brand-identity/files/references/accessibility-internationalisation-and-production.md
+++ b/templates/skills/brand-identity/files/references/accessibility-internationalisation-and-production.md
@@ -1,0 +1,3 @@
+# Accessibility, internationalisation, and production
+
+Verify contrast and non-colour cues, readable scale, motion alternatives, language and script coverage, bidirectional implications where relevant, and culturally sensitive meanings. Verify deliverable formats, colour profiles, font licenses, vector integrity, export naming, safe areas, and reproduction constraints. Record known limitations rather than hiding them in presentation mocks.

--- a/templates/skills/brand-identity/files/references/application-and-stress-testing.md
+++ b/templates/skills/brand-identity/files/references/application-and-stress-testing.md
@@ -1,0 +1,3 @@
+# Application and stress testing
+
+Before proposing a baseline, test the system in representative situations: smallest and largest logo use, monochrome, light/dark, low contrast, dense information, quiet editorial space, social/avatar crop, document, presentation, marketing surface, and relevant product context. Compose these examples in OpenPencil. Test failure boundaries, not just ideal usage. List observed failures and required corrections.

--- a/templates/skills/brand-identity/files/references/brand-to-ice-handoff.md
+++ b/templates/skills/brand-identity/files/references/brand-to-ice-handoff.md
@@ -1,0 +1,3 @@
+# Brand to ICE handoff
+
+Read only after a Human has accepted a brand decision and explicitly authorized product propagation. Map accepted brand semantics to proposed ICE tokens, primitives, assets, or components without changing the brand source. Identify affected product surfaces, accessibility impacts, compatibility, rollout, and rollback. ICE and Storybook become the implementation and review surface for this separate mapping task; OpenPencil remains the brand source artifact.

--- a/templates/skills/brand-identity/files/references/colour-craft.md
+++ b/templates/skills/brand-identity/files/references/colour-craft.md
@@ -1,0 +1,3 @@
+# Colour craft
+
+Define colour by semantic role and usage relationship, not swatch names alone. Include primary, supporting, neutral, surface, text, and status relationships only when relevant. Record source values and conversion assumptions for RGB/HEX and print systems. Test contrast, light/dark contexts, colour-blind distinguishability, low-quality displays, and monochrome fallback. Brand acceptance does not waive product accessibility requirements.

--- a/templates/skills/brand-identity/files/references/generative-idea-and-creative-territories.md
+++ b/templates/skills/brand-identity/files/references/generative-idea-and-creative-territories.md
@@ -1,0 +1,3 @@
+# Generative idea and creative territories
+
+Translate strategy into a concise idea capable of generating a system, not a slogan pasted onto visuals. When alternatives are needed, build a small set of genuinely distinct territories with a premise, visual mechanism, strengths, risks, and rejection criteria. Avoid cosmetic variants of one idea. Recommend the strongest territory and state what Human approval would authorize.

--- a/templates/skills/brand-identity/files/references/iconography-and-illustration.md
+++ b/templates/skills/brand-identity/files/references/iconography-and-illustration.md
@@ -1,0 +1,3 @@
+# Iconography and illustration
+
+Define grid, stroke/shape logic, corner treatment, perspective, detail level, optical correction, colour behavior, and small-size limits. Distinguish functional product icons from expressive brand illustration. Product icon implementation belongs downstream; brand work defines the accepted visual rule and representative examples.

--- a/templates/skills/brand-identity/files/references/imagery-and-art-direction.md
+++ b/templates/skills/brand-identity/files/references/imagery-and-art-direction.md
@@ -1,0 +1,3 @@
+# Imagery and art direction
+
+Specify subject, perspective, light, colour treatment, cropping, realism, diversity, sourcing, and prohibited patterns. Use references to explain principles, not as unlicensed deliverables. Identify whether photography, generated imagery, illustration, or mixed media is appropriate and record provenance and usage constraints for final assets.

--- a/templates/skills/brand-identity/files/references/logo-craft-and-brand-architecture.md
+++ b/templates/skills/brand-identity/files/references/logo-craft-and-brand-architecture.md
@@ -1,0 +1,3 @@
+# Logo craft and brand architecture
+
+Treat a logo as a coordinated system: primary, compact, icon, monochrome, reversed/light-dark, and required lockups. Check silhouette, optical balance, counterforms, spacing, minimum size, pixel behavior, one-colour reproduction, background control, and misuse resistance. Define relationships among master brand, products, sub-brands, descriptors, and endorsed marks only when scope requires them. Do not add architecture to solve a naming problem without Human authority.

--- a/templates/skills/brand-identity/files/references/motion-craft.md
+++ b/templates/skills/brand-identity/files/references/motion-craft.md
@@ -1,0 +1,3 @@
+# Motion craft
+
+Define motion purpose, tempo, easing character, sequencing, transformation logic, and reduced-motion behavior. Use motion to reinforce identity or comprehension, not decoration. Document representative transitions and constraints; production animation or UI component work requires a separate downstream task.

--- a/templates/skills/brand-identity/files/references/research-strategy-and-visual-audit.md
+++ b/templates/skills/brand-identity/files/references/research-strategy-and-visual-audit.md
@@ -1,0 +1,3 @@
+# Research, strategy, and visual audit
+
+Use for every BRAND_REVIEW and before broader creation. Inspect accepted foundations, audiences, positioning, existing assets, touchpoints, competitors, cultural context, and production constraints. Mark each conclusion as evidence, inference, or open decision. Audit recognition, distinctiveness, coherence, accessibility, reproduction, scalability, and fit to intended meaning. End with the design problem, equity to preserve, liabilities to resolve, and a recommended next scope.

--- a/templates/skills/brand-identity/files/references/typography-craft.md
+++ b/templates/skills/brand-identity/files/references/typography-craft.md
@@ -1,0 +1,3 @@
+# Typography craft
+
+Select type for voice, legibility, language coverage, licensing, availability, and production reality. Define roles and hierarchy before enumerating sizes. Test headlines, long reading, data, UI-like labels where relevant, numerals, punctuation, diacritics, and fallback behavior. Record licensed sources and permitted distribution; never package an unlicensed font.

--- a/templates/skills/brand-identity/files/references/visual-language-and-composition.md
+++ b/templates/skills/brand-identity/files/references/visual-language-and-composition.md
@@ -1,0 +1,3 @@
+# Visual language and composition
+
+Define repeatable principles for geometry, spacing, framing, rhythm, density, contrast, layout, and recognizable brand gestures. Show rules across varied formats rather than one polished hero. Separate invariant identity signals from flexible campaign expression. Avoid rules that depend on one application size or a single background.


### PR DESCRIPTION
## Summary
- preserve task ownership and final progress during crash/recovery paths
- resume explicit Agent Chat Codex turns and filter automatic sessions from human chat lists
- leave Product Delivery stage recovery to its state engine
- add the assignment-scoped `brand-identity` Designer skill with OpenPencil authoring rules and bundled references/templates

## Validation
- 304 Agent Chat/session/recovery tests passed
- 12 bundled-skill seeding tests passed
- TypeScript check passed
- live deployment verified `brand-identity` only on UI/UX Product Designer with 17 bundled files