### PR TITLE
fix(entrypoint): keep /workspace/start-up.sh readable across container restarts

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -745,7 +745,10 @@ if [ -n "$AGENT_ID" ]; then
                     | sed '/^# === Agent-managed setup (from DB) ===$/,/^# === End agent-managed setup ===$/d' \
                     >> "$TEMP_FILE"
                 mv "$TEMP_FILE" "$EXISTING_STARTUP"
-                chmod +x "$EXISTING_STARTUP"
+                # mktemp creates the temp file 0600; mv keeps that mode, and `chmod +x`
+                # would leave it 0711 (root-owned, unreadable by the worker uid that
+                # has to `head` and run it). Set the full mode explicitly.
+                chmod 755 "$EXISTING_STARTUP"
             elif [ -n "$AGENT_SCRIPT" ]; then
                 # Create new start-up.sh
                 echo "Creating /workspace/start-up.sh from agent setup script..."
@@ -753,7 +756,7 @@ if [ -n "$AGENT_ID" ]; then
                 echo "# === Agent-managed setup (from DB) ===" >> /workspace/start-up.sh
                 echo "$AGENT_SCRIPT" >> /workspace/start-up.sh
                 echo "# === End agent-managed setup ===" >> /workspace/start-up.sh
-                chmod +x /workspace/start-up.sh
+                chmod 755 /workspace/start-up.sh
             fi
             echo "Setup scripts prepared (global root hook: $([ -n "$GLOBAL_SCRIPT" ] && echo "yes" || echo "no"), agent worker hook: $([ -n "$AGENT_SCRIPT" ] && echo "yes" || echo "no"))"
         else


### PR DESCRIPTION
## Summary

Second restart crash-loop in the worker entrypoint, found while verifying #1350 on v1.139.0. A worker whose agent has a setup script (any template with `start-up.sh`, e.g. content-reviewer, discoverability-optimizer, content-writer) loops forever after a plain container restart:

```
=== Startup Script Detection (worker) ===
Found startup script: /workspace/start-up.sh
Executing startup script as user: worker (uid 1001)
head: cannot open '/workspace/start-up.sh' for reading: Permission denied
```

Only a recreate (`docker compose up -d --force-recreate`) recovers it.

## Root cause

On first boot `/workspace/start-up.sh` does not exist, so the "create" branch writes it with `echo >` under umask 022: mode 755, readable by `worker`.

On a restart the file exists, so the "prepend" branch builds the new content in `$(mktemp)`, which creates the temp file with mode **0600**, then `mv`s it over `/workspace/start-up.sh` (mode travels with the inode) and runs `chmod +x`. Result: `-rwx--x--x root:root`. The worker bootstrap then runs `head -n 1` on it as uid 1001 to detect the interpreter, gets `EACCES`, and `set -e` exits.

Reproduced on the demo swarm (worker `Auditor`, discoverability-optimizer template) right after the #1350 fix landed there: `docker compose restart worker-worker-5` looped with exactly that mode on the file.

## Fix

Set an explicit `755` after the `mv` (and in the create branch, so both paths agree regardless of umask). The worker only needs read + execute; ownership is unchanged.

## Verification

- `f=$(mktemp); mv "$f" x; chmod +x x; stat -c %A x` prints `-rwx--x--x` (the bug); with `chmod 755` it prints `-rwxr-xr-x`.
- Entrypoint test files pass.
- After a release with this change: `docker compose restart <worker with start-up.sh>` comes back `Up` instead of `Restarting`.
