### PR TITLE
test(providers): poll for the killed grandchild in provider-process-group test

### DIFF
--- a/src/tests/provider-process-group.test.ts
+++ b/src/tests/provider-process-group.test.ts
@@ -15,6 +15,24 @@ function processExists(pid: number): boolean {
   }
 }
 
+/**
+ * `terminateProcessGroup` returns as soon as SIGKILL is *sent*. The kernel then
+ * tears the grandchild down asynchronously, and `kill(pid, 0)` keeps succeeding
+ * while it is a zombie waiting for init to reap it. Under CI load that window
+ * spans the immediate assertion (merge-gate flaked 3 of 6 runs), so poll with a
+ * bounded deadline instead of asserting once.
+ */
+async function waitForProcessGone(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (processExists(pid)) {
+    if (Date.now() >= deadline) return false;
+    await Bun.sleep(20);
+  }
+  return true;
+}
+
+const PROCESS_GONE_TIMEOUT_MS = 5_000;
+
 describe("provider process groups", () => {
   const posixTest = process.platform === "win32" ? test.skip : test;
 
@@ -70,7 +88,7 @@ describe("provider process groups", () => {
 
         expect(result.exitCode).toBe(0);
         expect(Number.isInteger(grandchildPid)).toBe(true);
-        expect(processExists(grandchildPid)).toBe(false);
+        expect(await waitForProcessGone(grandchildPid, PROCESS_GONE_TIMEOUT_MS)).toBe(true);
       } finally {
         if (grandchildPid && processExists(grandchildPid)) {
           try {


### PR DESCRIPTION
## Why

`src/tests/provider-process-group.test.ts` (added in #1371) flaked 3 of 6 merge-gate runs on #1373 with:

```
expect(processExists(grandchildPid)).toBe(false)   // received: true
```

`terminateProcessGroup` returns right after it *sends* SIGKILL. The kernel then tears the SIGTERM-resistant grandchild down asynchronously, and `kill(pid, 0)` keeps succeeding while the process is a zombie waiting for init to reap it. On a loaded 4-core runner with `--parallel=4` that window is wide enough to hit the immediate assertion. On a 10-core Mac it never reproduced (0 of 40 runs, 8 in parallel).

## What

Test-only change. Replace the one-shot assertion with `waitForProcessGone(pid, 5_000)`: a 20 ms poll with a bounded deadline. The test budget is 35 s, so a group that really survives still fails the test at the deadline.

No runtime code changes. `terminateProcessGroup` still returns after sending SIGKILL; making it wait for the tree to vanish would be a behaviour change for every adapter and is not needed for correctness.

## Verification

```
/tmp/ppg-flake/stress.sh <worktree> 40 8   # 40 runs of the file, 8 in parallel
iterations=40 parallel=8 failures=0        # before AND after (macOS does not reproduce the race)
bunx biome check src/tests/provider-process-group.test.ts   # clean
bun run tsc:check                                           # clean
```

The real check is merge-gate on this PR, which runs the file under the same load that flaked before.

https://claude.ai/code/session_016fip841Np3TyYxh3sCsSwJ
