### PR TITLE
feat(ui): forward query params from /pages/:id to the page body

### DIFF
--- a/apps/ui/src/pages/pages/[id]/page.tsx
+++ b/apps/ui/src/pages/pages/[id]/page.tsx
@@ -74,6 +74,37 @@ function getPageHtmlUrl(id: string): string {
 }
 
 /**
+ * Query params the SPA owns on `/pages/:id` and must never forward to the
+ * page body: `mode` (full-screen toggle), `key` (password unlock is handled
+ * by the password frame itself) and the connection overrides, which would
+ * otherwise hand the API key to agent-authored HTML.
+ */
+const SPA_RESERVED_PAGE_PARAMS = new Set(["mode", "key", "apiUrl", "apiKey"]);
+
+/**
+ * Query string forwarded from the SPA route to the page body, so a link like
+ * `/pages/<id>?target=pr-1373` reaches the iframe as `/p/<id>?target=pr-1373`
+ * and the page can filter or deep-link on its own params. Empty when there is
+ * nothing to forward.
+ */
+function pageFrameQuery(searchParams: URLSearchParams): string {
+  const forwarded = new URLSearchParams();
+  for (const [name, value] of searchParams) {
+    if (!SPA_RESERVED_PAGE_PARAMS.has(name)) forwarded.append(name, value);
+  }
+  const query = forwarded.toString();
+  return query ? `?${query}` : "";
+}
+
+/** SPA route for the page, keeping the forwarded params and toggling `mode=full`. */
+function pageRoute(id: string, frameQuery: string, full: boolean): string {
+  const params = new URLSearchParams(frameQuery);
+  if (full) params.set("mode", "full");
+  const query = params.toString();
+  return `/pages/${id}${query ? `?${query}` : ""}`;
+}
+
+/**
  * Fetch the page metadata. For authed pages, the first call typically 401s —
  * we then attempt `launchPage` (which uses the bearer to mint a cookie) and
  * retry. Password pages can't be launched via the bearer endpoint, so we
@@ -127,6 +158,8 @@ async function fetchPageMetadataWithLaunchRetry(id: string): Promise<PageMetadat
 interface FrameProps {
   id: string;
   title: string;
+  /** `?a=b` string forwarded to the page body (see `pageFrameQuery`), or "". */
+  frameQuery: string;
   iframeRef?: React.RefObject<HTMLIFrameElement | null>;
 }
 
@@ -155,8 +188,8 @@ function PageIframe({
   );
 }
 
-function PublicHtmlFrame({ id, title, iframeRef }: FrameProps) {
-  const src = getPageHtmlUrl(id);
+function PublicHtmlFrame({ id, title, frameQuery, iframeRef }: FrameProps) {
+  const src = getPageHtmlUrl(id) + frameQuery;
   return <PageIframe src={src} title={title} iframeRef={iframeRef} />;
 }
 
@@ -185,7 +218,7 @@ async function assertAuthedPageBodyReady(
   throw new Error(`page body ${id}: ${res.status}`);
 }
 
-function AuthedHtmlFrame({ id, title, iframeRef }: FrameProps) {
+function AuthedHtmlFrame({ id, title, frameQuery, iframeRef }: FrameProps) {
   const [frameState, setFrameState] = useState<
     { status: "loading" } | { status: "ready"; src: string } | { status: "error"; message: string }
   >({ status: "loading" });
@@ -209,7 +242,7 @@ function AuthedHtmlFrame({ id, title, iframeRef }: FrameProps) {
         if (!active) return;
 
         if (bodyStatus === "ready") {
-          setFrameState({ status: "ready", src: getPageHtmlUrl(id) });
+          setFrameState({ status: "ready", src: getPageHtmlUrl(id) + frameQuery });
           return;
         }
 
@@ -233,7 +266,7 @@ function AuthedHtmlFrame({ id, title, iframeRef }: FrameProps) {
       active = false;
       controller.abort();
     };
-  }, [id]);
+  }, [id, frameQuery]);
 
   if (frameState.status === "loading") {
     return <Skeleton className="h-[calc(100vh-6rem)] w-full rounded-md" />;
@@ -246,7 +279,7 @@ function AuthedHtmlFrame({ id, title, iframeRef }: FrameProps) {
   return <PageIframe src={frameState.src} title={title} iframeRef={iframeRef} />;
 }
 
-function PasswordHtmlFrame({ id, title, iframeRef }: FrameProps) {
+function PasswordHtmlFrame({ id, title, frameQuery, iframeRef }: FrameProps) {
   const [password, setPassword] = useState("");
   const [iframeSrc, setIframeSrc] = useState<string | null>(null);
 
@@ -256,8 +289,9 @@ function PasswordHtmlFrame({ id, title, iframeRef }: FrameProps) {
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const url = `${getPageHtmlUrl(id)}?key=${encodeURIComponent(password)}`;
-    setIframeSrc(url);
+    const params = new URLSearchParams(frameQuery);
+    params.set("key", password);
+    setIframeSrc(`${getPageHtmlUrl(id)}?${params.toString()}`);
   }
 
   return (
@@ -320,6 +354,7 @@ export default function ArtifactPage() {
   const { id } = useParams<{ id: string }>();
   const [searchParams] = useSearchParams();
   const fullMode = searchParams.get("mode") === "full";
+  const frameQuery = pageFrameQuery(searchParams);
   const gate = useFeatureGate("1.79.0");
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const needsSlugResolve = !!id && !PAGE_ID_RE.test(id);
@@ -400,13 +435,34 @@ export default function ArtifactPage() {
   } else {
     switch (data.authMode) {
       case "public":
-        body = <PublicHtmlFrame id={pageId!} title={data.title} iframeRef={iframeRef} />;
+        body = (
+          <PublicHtmlFrame
+            id={pageId!}
+            title={data.title}
+            frameQuery={frameQuery}
+            iframeRef={iframeRef}
+          />
+        );
         break;
       case "authed":
-        body = <AuthedHtmlFrame id={pageId!} title={data.title} iframeRef={iframeRef} />;
+        body = (
+          <AuthedHtmlFrame
+            id={pageId!}
+            title={data.title}
+            frameQuery={frameQuery}
+            iframeRef={iframeRef}
+          />
+        );
         break;
       case "password":
-        body = <PasswordHtmlFrame id={pageId!} title={data.title} iframeRef={iframeRef} />;
+        body = (
+          <PasswordHtmlFrame
+            id={pageId!}
+            title={data.title}
+            frameQuery={frameQuery}
+            iframeRef={iframeRef}
+          />
+        );
         break;
     }
   }
@@ -424,7 +480,7 @@ export default function ArtifactPage() {
             <span className="font-mono text-[10px] text-muted-foreground">{data.authMode}</span>
           </div>
           <Button asChild variant="outline" size="sm">
-            <Link to={`/pages/${pageId}`}>
+            <Link to={pageRoute(pageId!, frameQuery, false)}>
               <Minimize2 className="size-3.5" />
               Exit full
             </Link>
@@ -443,6 +499,7 @@ export default function ArtifactPage() {
         action={
           <PageHeaderActions
             id={pageId!}
+            frameQuery={frameQuery}
             authMode={data.authMode}
             favorite={pageRow?.favorite}
             favoriteDisabled={favoriteToggle.isPending}
@@ -486,6 +543,7 @@ function PageSlugLine({ id }: { id: string }) {
  */
 function PageHeaderActions({
   id,
+  frameQuery,
   authMode,
   favorite,
   favoriteDisabled,
@@ -493,15 +551,16 @@ function PageHeaderActions({
   onExportPdf,
 }: {
   id: string;
+  frameQuery: string;
   authMode: PageMetadata["authMode"];
   favorite?: boolean;
   favoriteDisabled?: boolean;
   onToggleFavorite: () => void;
   onExportPdf: () => void;
 }) {
-  const config = getConfig();
-  const apiUrl = (config.apiUrl || "http://localhost:3013").replace(/\/+$/, "");
-  const href = `${apiUrl}/p/${encodeURIComponent(id)}`;
+  // The share link carries the same forwarded params as the iframe, so
+  // "Open" keeps whatever filter the page is showing.
+  const href = getPageHtmlUrl(id) + frameQuery;
   return (
     <div className="flex items-center gap-2">
       <FavoriteButton favorite={favorite} disabled={favoriteDisabled} onToggle={onToggleFavorite} />
@@ -524,7 +583,7 @@ function PageHeaderActions({
         Export PDF
       </Button>
       <Button asChild variant="outline" size="sm" title="Maximize within the SPA">
-        <Link to={`/pages/${id}?mode=full`}>
+        <Link to={pageRoute(id, frameQuery, true)}>
           <Maximize2 className="size-3.5" />
           Full
         </Link>

--- a/packages/ui-e2e/specs/pages.spec.ts
+++ b/packages/ui-e2e/specs/pages.spec.ts
@@ -40,3 +40,37 @@ test("pages list opens the public page and its share URL", async ({
 
   await clean.assertClean();
 });
+
+test("page viewer forwards its query params to the page body", async ({
+  page,
+  seed,
+  clean,
+}, testInfo) => {
+  test.skip(!seed, "remote run without seed");
+  const id = seed!.pages.public.id;
+
+  // `key` is SPA-reserved (password unlock) and must not reach the body;
+  // everything else rides along so a page can deep-link on its own params.
+  await page.goto(`/pages/${id}?target=pr-1373&status=failed&key=secret`);
+  const frame = page.locator("iframe[title='e2e public page']");
+  const forwarded = new RegExp(`/p/${id}\\?target=pr-1373&status=failed$`);
+  await expect(frame).toHaveAttribute("src", forwarded);
+  await expect(page.getByRole("link", { name: "Open", exact: true })).toHaveAttribute(
+    "href",
+    forwarded,
+  );
+  const screenshot = testInfo.outputPath("page-query-passthrough.png");
+  await page.screenshot({ path: screenshot });
+  await testInfo.attach("page-query-passthrough", { path: screenshot, contentType: "image/png" });
+
+  // Toggling full mode keeps the forwarded params on both the route and the body.
+  await page.getByRole("link", { name: "Full" }).click();
+  await expect(page).toHaveURL(`/pages/${id}?target=pr-1373&status=failed&mode=full`);
+  await expect(page.locator("iframe[title='e2e public page']")).toHaveAttribute("src", forwarded);
+  await expect(page.getByRole("link", { name: "Exit full" })).toHaveAttribute(
+    "href",
+    `/pages/${id}?target=pr-1373&status=failed`,
+  );
+
+  await clean.assertClean();
+});


### PR DESCRIPTION
## Why

A DB-backed page has no way to receive a deep link today: `/pages/<id>?target=pr-1373` drops the query on the floor because the viewer builds the iframe `src` from the id alone. The redesigned UI E2E tracker page (agent-work, branch `feat/ui-e2e-tracker-page-v2`) filters its target cards by `?target=` / `?status=`, so the dashboard has to pass the query through.

## What

`apps/ui/src/pages/pages/[id]/page.tsx`

- `pageFrameQuery(searchParams)` forwards every param on the SPA route to the page body except the SPA-owned ones: `mode` (full-screen toggle), `key` (the password frame sets it itself), `apiUrl` and `apiKey` (a connection override in the URL must not reach agent-authored HTML).
- Public, authed and password frames all use it. The authed frame re-prepares when the query changes.
- The **Open** link carries the same query, and **Full** / **Exit full** keep it (`pageRoute` helper), so a filtered view survives the toggles.

`packages/ui-e2e/specs/pages.spec.ts`

- New spec: loads `/pages/<id>?target=pr-1373&status=failed&key=secret`, asserts the iframe `src` and the Open link end with `?target=pr-1373&status=failed` (no `key`), clicks Full, asserts the route gained `mode=full`, the iframe kept the query, and Exit full points back without `mode`.

## Verification

```
bun run --cwd apps/ui lint        # Checked 403 files. No fixes applied.
cd apps/ui && bunx tsc -b         # clean
bun run e2e:ui -- --grep "page viewer forwards|pages list opens"
  ✓ pages list opens the public page and its share URL (1.8s)
  ✓ page viewer forwards its query params to the page body (748ms)
  2 passed
```

Screenshot from the spec (the viewer at the deep-linked URL; the proof is the asserted iframe `src`, which a screenshot cannot show):

![page viewer with forwarded query](https://fly.storage.tigris.dev/agent-fs-taras-storage/648a5f3c-35c8-4f11-8673-b89de52cd6bd/drives/2faf73ba-4eee-4472-8b3b-359c4ed6bfbb/qa/agent-swarm/2026-09-08-page-query-passthrough/page-query-passthrough.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=tid_HmeSWgYTsPMlIrxsHowzHXHDjaeoDuEISZtTlyZVAXApPgFSNu%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260908T005644Z&X-Amz-Expires=604800&X-Amz-Signature=810dfd3502e7b9746bc513cf96770c805d914a93af5bac332b55be08a822a2bd&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27page-query-passthrough.png&response-content-type=image%2Fpng&x-amz-checksum-mode=ENABLED&x-id=GetObject)

https://claude.ai/code/session_016fip841Np3TyYxh3sCsSwJ
