### PR TITLE
fix(ui): tolerate /status responses without automations (pre-v1.142.0 APIs)

### DIFF
--- a/apps/ui/src/api/types.ts
+++ b/apps/ui/src/api/types.ts
@@ -2450,7 +2450,11 @@ export interface StatusResponse {
   setup: SetupMilestone[];
   activity: StatusActivity;
   agent_fs: StatusAgentFs;
-  automations: StatusAutomation[];
+  /**
+   * Added in v1.142.0 (#1330). Absent when the dashboard talks to an older API,
+   * so every consumer must treat it as optional.
+   */
+  automations?: StatusAutomation[];
   /** Phase 2: rolled-up health for the always-on header badge. */
   health: StatusHealth;
 }

--- a/apps/ui/src/components/dashboard/dashboard-nudges.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-nudges.tsx
@@ -29,7 +29,7 @@ export function DashboardNudges() {
   const showUpgrade =
     upgradeGate.currentVersion !== null && !upgradeGate.supported && !upgradeCard.dismissed;
   const showOrgName = configs !== undefined && !orgName && !orgNameCard.dismissed;
-  const waitingAutomations = status?.automations.filter(
+  const waitingAutomations = status?.automations?.filter(
     (automation) => automation.state === "needs_setup",
   );
   const showAutomations = (waitingAutomations?.length ?? 0) > 0;


### PR DESCRIPTION
## Summary

The hosted dashboard (v1.142.0 build) crashes on the home page when it talks to any API older than v1.142.0:

```
TypeError: Cannot read properties of undefined (reading 'filter')
  in <DashboardNudges>
```

PR #1330 added the `automations` array to `GET /status` in v1.142.0. The UI typed it as required and called `status?.automations.filter(...)` in the home page nudges. On older APIs the key is absent, so the component throws inside the error boundary and the whole home page shows "Something went wrong".

## Changes

- `apps/ui/src/components/dashboard/dashboard-nudges.tsx`: optional-chain the `automations` filter. With no automations the nudge simply does not render.
- `apps/ui/src/api/types.ts`: mark `automations` optional on `StatusResponse`, with a comment noting it was added in v1.142.0. The compiler now rejects any future non-null-safe consumer.

Every other reader of the field (schedules and workflows list pages via `findAutomation`) already accepted `undefined`, so no other change was needed. No other `/status` field changed between v1.141.0 and main.

## Verification

- `cd apps/ui && bun run lint` clean, `bunx tsc -b` clean, automations-related `bun test` files pass (5/5).
- Real repro: booted a v1.141.0 API from a detached worktree on a fresh SQLite DB and pointed the dev UI from this branch at it. With the fix stashed the home page crashed with the exact error above. With the fix in place Home, Schedules, and Workflows render cleanly with an empty browser console.

### Before (v1.141.0 API, main)

![Home page crash against a v1.141.0 API](https://fly.storage.tigris.dev/agent-fs-taras-storage/648a5f3c-35c8-4f11-8673-b89de52cd6bd/drives/2faf73ba-4eee-4472-8b3b-359c4ed6bfbb/qa/agent-swarm/2026-09-08-ui-automations-backcompat/before-v1.141.0-crash.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=tid_HmeSWgYTsPMlIrxsHowzHXHDjaeoDuEISZtTlyZVAXApPgFSNu%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260908T093350Z&X-Amz-Expires=604800&X-Amz-Signature=074074efe538fc03d49de7c0e337f4ce537c3193b3e58b591da9549c21702f7d&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27before-v1.141.0-crash.png&response-content-type=image%2Fpng&x-amz-checksum-mode=ENABLED&x-id=GetObject)

### After (v1.141.0 API, this branch)

![Home page rendering against a v1.141.0 API after the fix](https://fly.storage.tigris.dev/agent-fs-taras-storage/648a5f3c-35c8-4f11-8673-b89de52cd6bd/drives/2faf73ba-4eee-4472-8b3b-359c4ed6bfbb/qa/agent-swarm/2026-09-08-ui-automations-backcompat/after-v1.141.0-fixed.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=tid_HmeSWgYTsPMlIrxsHowzHXHDjaeoDuEISZtTlyZVAXApPgFSNu%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260908T093350Z&X-Amz-Expires=604800&X-Amz-Signature=47ce411ca33eaad2651452ce9782ce9417f6361920544f992f1c0c51eb372b54&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27after-v1.141.0-fixed.png&response-content-type=image%2Fpng&x-amz-checksum-mode=ENABLED&x-id=GetObject)

Signed URLs expire 2026-09-15.
