### PR TITLE
ci(slack-visuals): run the E2E and upload the artifact on fork PRs

### DIFF
--- a/.github/workflows/slack-visuals.yml
+++ b/.github/workflows/slack-visuals.yml
@@ -2,7 +2,8 @@
 # (legacy renderer, then SLACK_RENDER_V2=true), renders one PNG per Slack event from the
 # slack-mock journal, and upserts one sticky PR comment with both columns side by side.
 # Images live on the single-commit `ci-visuals` branch (rebuilt on every run, so history never
-# grows). Fork PRs have a read-only token and only get the artifact.
+# grows). Fork PRs run with a read-only token: they still run the E2E and upload the artifact,
+# but the two write steps (publish to `ci-visuals`, post the PR comment) are skipped.
 name: Slack Visuals
 
 on:
@@ -22,7 +23,7 @@ concurrency:
 
 jobs:
   visuals:
-    if: github.repository == 'desplega-ai/agent-swarm' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.repository == 'desplega-ai/agent-swarm'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -75,8 +76,10 @@ jobs:
           path: visuals/
           if-no-files-found: warn
 
+      # Both write steps need a token with `contents: write` + `pull-requests: write`. GitHub
+      # downgrades the token to read-only on fork PRs, so gate them on a same-repo head.
       - name: Publish Slack visuals
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         id: publish
         env:
           PR: ${{ github.event.pull_request.number }}
@@ -89,7 +92,7 @@ jobs:
           echo "base_url=${base_url#base_url=}" >> "$GITHUB_OUTPUT"
 
       - name: Post Slack visual preview
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Why

The Slack Visuals workflow skipped its only job on #1384 because the PR head lives in a fork (`Capchase/agent-swarm`). The job-level guard required `head.repo.full_name == github.repository`, so fork PRs got nothing, not even the artifact. The header comment claimed fork PRs "only get the artifact", which was not true.

## What

- Drop the fork clause from the job-level `if`. The job now runs for every `pull_request` and `workflow_dispatch` on `desplega-ai/agent-swarm`.
- Gate only the two write steps (Publish to `ci-visuals`, Post the sticky comment) on a same-repo head. GitHub downgrades the token to read-only on fork PRs, so those steps cannot succeed there.
- Fix the header comment to describe the actual behavior.

Fork PRs now run both Slack E2E passes, render the PNGs and GIFs, and upload the `slack-visuals` artifact. Same-repo PRs keep the sticky comment.

No `pull_request_target`. Fork code still runs with a read-only token.

## Verification

- `actionlint .github/workflows/slack-visuals.yml` passes.
- This PR touches `.github/workflows/slack-visuals.yml`, which is in the path filter, so the workflow runs here as a same-repo check.