### PR TITLE
docs(db-seam): justify allowlist entries in-script and enforce shrink strategy

### DIFF
--- a/scripts/check-async-db-seam.sh
+++ b/scripts/check-async-db-seam.sh
@@ -7,8 +7,22 @@
 # that runs once during startup (migrations, backfills, seeders), where the
 # async seam buys nothing and sync is the safer shape.
 #
-# Allowlist source of truth: the stay-sync-boot classification from the async
-# refactor (see PR for .asyncdb/txn-analysis.json). Finalize after Step 3.
+# Allowlist source of truth: per-file justifications live HERE, next to the
+# entries CI reviews — not in scratch files (see #1227). Every entry carries
+# an inline justification comment with a classification tag (enforced below).
+#
+# Legend:
+#   [boot-permanent]  — runs once during startup before any traffic
+#   (migrations, backfills, seeders, seam internals); raw sync is the
+#   intended shape forever.
+#   [needs-redesign]  — runtime (or boot-called but Postgres-blocking) surface
+#   that must leave the list; each entry names its redesign sketch. Tracked
+#   under #1227; exit criterion is boot-permanent entries only — the
+#   precondition for a worker-thread driver or a Postgres client behind
+#   the seam.
+#
+# Review rule: a new allowlist entry requires an inline justification comment
+# with a classification tag. The UNJUSTIFIED check below fails CI otherwise.
 #
 # Note: `.prepare(` currently only ever appears on bun:sqlite handles in this
 # repo; if a non-DB prepare() API ever appears, tighten the pattern instead of
@@ -17,21 +31,65 @@
 set -euo pipefail
 
 ALLOWLIST=(
-  src/be/db.ts                                  # seam owner + initDb boot path
-  src/be/db-client.ts                           # the seam implementation
-  src/be/migrations/runner.ts                   # boot: SQL migrations
-  src/be/oauth-encryption-backfill.ts           # boot: one-time backfill
-  src/be/connection-bindings-blob-migration.ts  # boot: one-time migration
-  src/be/seed-pricing.ts                        # boot: seeder
-  src/be/rbac-roles.ts                          # boot: ensureRbacSeedsSynced
-  src/be/asset-key-audit.ts                     # boot: startup audit (raw handle param)
-  src/be/memory/providers/sqlite-store.ts       # constructor vec/FTS bootstrap; instance is boot-warmed by startMemoryGc()'s initial tick (async init = future decision)
-  src/be/script-connections.ts                  # listScriptConnections feeds default parameter expressions (must stay sync)
-  src/http/db-query.ts                          # read-only admin guard needs Statement.columnNames introspection
-  src/http/db-query-shared.ts                   # same columnNames guard (in-process fallback path)
-  src/http/db-query-bounded.ts                  # child process opens its own connection outside the seam; parent only reads getDb().filename
-  src/http/assets.ts                            # passes the raw handle into the shared sync auditAssetKeys (wrapped in a client transaction at the call site)
+  # NOTE (src/be/db.ts): seam owner + initDb boot path (CHECK-constraint rebuild,
+  # ensureAgentProfileColumns, seedContextVersions, autoEncryptLegacyPlaintextSecrets)
+  # plus getDb/getDbClient/closeDb themselves. The prompt-template chain in this
+  # file (getPromptTemplates/upsertPromptTemplate/resetPromptTemplateToDefault/
+  # resolvePromptTemplate, DI-injected into sync resolveTemplate() with ~19 sync
+  # callers) still needs an async resolver seam — tracked under #1227.
+  src/be/db.ts                                  # [boot-permanent] seam owner + initDb boot path
+  src/be/db-client.ts                           # [boot-permanent] the seam implementation itself
+  src/be/migrations/runner.ts                   # [boot-permanent] migration runner, runs before any traffic
+  src/be/oauth-encryption-backfill.ts           # [boot-permanent] one-time boot backfill
+  src/be/connection-bindings-blob-migration.ts  # [boot-permanent] one-time boot migration
+  src/be/seed-pricing.ts                        # [boot-permanent] boot seeder (prepared insert + raw transaction)
+  # ensureRbacSeedsSynced holds eight prepared-statement objects that cannot cross
+  # the seam, and CREATE_USER_DEFAULT_ROLE_TRIGGER_SQL is a multi-statement body the
+  # client's single-statement run() cannot execute. Options: multi-statement exec on
+  # the seam (boot-gated), or split the trigger SQL.
+  src/be/rbac-roles.ts                          # [needs-redesign] boot-called seed sync; prepared statements + multi-statement trigger
+  # Shared sync auditAssetKeys(database) helper, called from initDb AND two runtime
+  # paths (db.ts prompt-template transaction, http/assets.ts:252). Split boot vs
+  # runtime entry points.
+  src/be/asset-key-audit.ts                     # [needs-redesign] shared sync audit helper (boot + runtime callers)
+  # vec/FTS bootstrap runs in the constructor (cannot await); helpers shared with
+  # async read paths. Instance is boot-warmed by startMemoryGc()'s initial tick.
+  # Needs a lazy async-init redesign of the store.
+  src/be/memory/providers/sqlite-store.ts       # [needs-redesign] constructor vec/FTS bootstrap; needs lazy async init
+  # listScriptConnections feeds default parameter expressions in typecheck.ts (a
+  # default-parameter expression cannot await). Hoist the defaults into the call
+  # sites; async twin listScriptConnectionsAsync already exists for migrated callers.
+  src/be/script-connections.ts                  # [needs-redesign] sync list for typecheck defaults; hoist defaults to call sites
+  # In-process fallback path: read-only guard needs Statement.columnNames
+  # introspection, which the seam deliberately does not expose. Options: narrow
+  # read-only introspection on the client, or route through the bounded child.
+  src/http/db-query-shared.ts                   # [needs-redesign] columnNames guard (in-process fallback path)
+  # Bounded child-process query path owns its own connection outside the seam;
+  # parent only reads getDb().filename. Decide: stays exempt by design or routes
+  # the filename through the seam.
+  src/http/db-query-bounded.ts                  # [needs-redesign] child owns its connection; exempt-by-design decision pending
+  # Passes the raw handle into the shared sync auditAssetKeys (wrapped in a client
+  # transaction at the call site). Resolves when auditAssetKeys splits boot vs runtime.
+  src/http/assets.ts                            # [needs-redesign] raw handle into shared sync audit helper
 )
+
+# Review-rule enforcement (#1227): every ALLOWLIST entry line in THIS file must
+# carry an inline justification comment with a classification tag. CI invokes
+# this script as `bash scripts/check-async-db-seam.sh` from the repo root, so
+# $0 resolves to this file.
+ALLOWLIST_UNJUSTIFIED=$(grep -E '^[[:space:]]*src/' "$0" | grep -vE '#.*\[(boot-permanent|needs-redesign)\]' || true)
+if [ -n "$ALLOWLIST_UNJUSTIFIED" ]; then
+  echo "ERROR: allowlist entries without a justification comment!"
+  echo ""
+  echo "Every ALLOWLIST entry in scripts/check-async-db-seam.sh must carry an"
+  echo "inline justification comment with a classification tag (see the legend"
+  echo "at the top of this file):"
+  echo "  src/path/to/file.ts  # [boot-permanent|needs-redesign] reason..."
+  echo ""
+  echo "Unjustified entries:"
+  echo "$ALLOWLIST_UNJUSTIFIED"
+  exit 1
+fi
 
 PATTERN='(\bgetDb\s*\(|\.prepare\s*\(|from\s+["'\'']bun:sqlite)'
 
@@ -60,6 +118,8 @@ if [ -n "$MATCHES" ]; then
   echo ""
   echo "If this is genuinely boot-path (runs once during startup before any"
   echo "concurrency), add the file to ALLOWLIST in this script with a comment."
+  echo "The comment must include a classification tag: # [boot-permanent] or"
+  echo "# [needs-redesign] plus the reason (see the legend above; #1227)."
   exit 1
 fi
 


### PR DESCRIPTION
Relates to #1227 (partial: work items 1-2; items 3-4 remain tracking work).

## Summary

Moves the per-file async-DB-seam allowlist justifications out of scratch and into `scripts/check-async-db-seam.sh` as comments next to each entry, classifies every entry as `boot-permanent` vs `needs-redesign`, adds CI enforcement that new entries carry a justification, and shrinks the list by one proven-stale entry.

## Root cause / why

PR #1204 converted the API's DB layer to the async `DbClient` seam with a 14-file allowlist, but the *reasons* lived only in an untracked scratch file (`.asyncdb/residual-sync-allowlist.json`) and there was no agreed strategy for shrinking the list or gating new entries. Before any Postgres (or worker-thread driver) work, every non-boot entry is a blocker — but nothing in the repo said which entries those were.

## What changed (`scripts/check-async-db-seam.sh` only, +76/-16)

- Lines 10-25: header now documents the classification legend (`[boot-permanent]` vs `[needs-redesign]`), the shrink strategy, the review rule, and the exit criterion (boot-path files only), referencing #1227.
- Lines 33-74: every allowlist entry annotated with its tag plus the reason from #1227 (verified against the code — e.g. `rbac-roles.ts` prepared statements, `script-connections.ts` default-parameter constraint, `db-query-shared.ts`/`db-query-bounded.ts` `columnNames` introspection). The `src/be/db.ts` entry notes the prompt-template chain inside it still needs an async resolver seam.
- Removed the stale `src/http/db-query.ts` entry: the file has zero `getDb(`/`.prepare(`/`bun:sqlite` matches (it delegates to `db-query-shared`/`db-query-bounded`), so the exclusion was dead weight. 14 entries -> 13.
- Lines 76-92: new `ALLOWLIST_UNJUSTIFIED` self-check — CI fails any allowlist line lacking `# ... [boot-permanent|needs-redesign] ...`.
- Lines 119-122: the violation guidance now tells contributors the comment must include a classification tag.

## Test evidence

- `bash scripts/check-async-db-seam.sh` (Git Bash, Windows): `Async DB seam check passed.` — proves the `db-query.ts` removal is safe and all entries satisfy the new rule.
- `bash -n scripts/check-async-db-seam.sh`: syntax OK.
- Negative test (throwaway copy with one tag stripped): fails with `ERROR: allowlist entries without a justification comment!` and names the offending line; restored file passes. Proves the enforcement bites.
- `bun run lint` / `tsc:check` / `test:root` not run: the diff touches only a CI shell script (no TS), and its covering check is the script itself, run above.

## Checklist

- [x] Follows CONTRIBUTING.md (docs-only change to a CI script; no new deps, no migrations)
- [x] Minimal focused diff; no runtime behavior change
- [x] Covering check run locally (see Test evidence)
- [x] No new allowlist entries; one removed with proof
