### PR TITLE
fix: stabilize script pause, query saturation, and migration queue checks

### DIFF
--- a/src/script-workflows/executor.ts
+++ b/src/script-workflows/executor.ts
@@ -197,6 +197,19 @@ export class LocalProcessScriptExecutor implements ScriptExecutor {
     const server = createServer((socket) => {
       sockets.add(socket);
       socket.once("close", () => sockets.delete(socket));
+      const failProtocol = (error: unknown) => {
+        protocolFailure ??=
+          error instanceof Error ? error : new Error(`Capability protocol failed: ${error}`);
+        built.abortInFlightSteps(protocolFailure);
+        socket.destroy();
+        proc?.kill();
+      };
+      // Failed writes also emit an error event, even with a write callback.
+      // Unauthenticated connections must not terminate the active workflow.
+      socket.on("error", (error) => {
+        if (socket === capabilitySocket) failProtocol(error);
+        else socket.destroy();
+      });
       // The harness authenticates before it imports user code. Reject later
       // connections once that handshake has claimed the bridge.
       if (capabilitySocket) {
@@ -216,14 +229,6 @@ export class LocalProcessScriptExecutor implements ScriptExecutor {
       }, 2_000);
       handshakeTimeout.unref?.();
       socket.once("close", () => clearTimeout(handshakeTimeout));
-
-      const failProtocol = (error: unknown) => {
-        protocolFailure =
-          error instanceof Error ? error : new Error(`Capability protocol failed: ${error}`);
-        built.abortInFlightSteps(protocolFailure);
-        socket.destroy();
-        proc?.kill();
-      };
 
       const writeResponse = (response: string): Promise<void> => {
         const framed = `${response}\n`;

--- a/src/tests/db-query.test.ts
+++ b/src/tests/db-query.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, spyOn, test } from "bun:test";
 import { createServer as createHttpServer, type Server } from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
@@ -611,35 +611,51 @@ describe("db-query bounded execution (Fix 1)", () => {
     expect(body.message).toMatch(/150ms budget/);
   });
 
-  // Review round 4 (desplega-bot, pullrequestreview-4975616777): the
-  // concurrency cap was also collapsed into the generic 400. Saturate the
-  // cap with slots that never release (SELECT 1 calls made without an
-  // `await` between them so the acquire checks all run in the same tick —
-  // same technique as test O), then confirm the one HTTP call that lands on
-  // top gets 429 with a stable code and a Retry-After header instead of 400.
+  // Hold completion of real query children until the HTTP assertion finishes.
+  // SELECT 1 can finish before the HTTP request arrives and release the slots.
   test("caps saturation via the HTTP route returns 429 with a stable code and Retry-After", async () => {
+    const release = Promise.withResolvers<void>();
+    const childExits: Promise<number>[] = [];
+    const originalSpawn = Bun.spawn;
+    const spawnSpy = spyOn(Bun, "spawn").mockImplementation(((
+      ...args: Parameters<typeof Bun.spawn>
+    ) => {
+      const child = originalSpawn(...args);
+      const exited = child.exited;
+      childExits.push(exited);
+      Object.defineProperty(child, "exited", {
+        value: release.promise.then(() => exited),
+      });
+      return child;
+    }) as typeof Bun.spawn);
     const fillers = Array.from({ length: getDbQueryConcurrencyCap() }, () =>
       executeReadOnlyQueryBounded("SELECT 1", [], 10_000),
     );
+    spawnSpy.mockRestore();
 
-    const { status, headers, body } = await withDbQueryHttpServer(async (_post) => {
-      const res = await fetch(`http://localhost:${HTTP_TEST_PORT}/api/db-query`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sql: "SELECT 1", params: [] }),
+    try {
+      await Promise.all(childExits);
+      const { status, headers, body } = await withDbQueryHttpServer(async (_post) => {
+        const res = await fetch(`http://localhost:${HTTP_TEST_PORT}/api/db-query`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sql: "SELECT 1", params: [] }),
+        });
+        return {
+          status: res.status,
+          headers: res.headers,
+          body: (await res.json()) as DbQueryHttpBody,
+        };
       });
-      return {
-        status: res.status,
-        headers: res.headers,
-        body: (await res.json()) as DbQueryHttpBody,
-      };
-    });
 
-    expect(status).toBe(429);
-    expect(body.error).toBe("db_query_concurrency_cap");
-    expect(headers.get("retry-after")).not.toBeNull();
-
-    await Promise.allSettled(fillers);
+      expect(status).toBe(429);
+      expect(body.error).toBe("db_query_concurrency_cap");
+      expect(headers.get("retry-after")).not.toBeNull();
+    } finally {
+      spawnSpy.mockRestore();
+      release.resolve();
+      await Promise.allSettled(fillers);
+    }
   });
 
   // L: DB_QUERY_HTTP_MAX_ROWS actually reaches the HTTP route's row cap.

--- a/src/tests/script-workflows-runtime-e2e.test.ts
+++ b/src/tests/script-workflows-runtime-e2e.test.ts
@@ -1,6 +1,16 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
 import { rm, unlink } from "node:fs/promises";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { Server as NetServer, type Socket } from "node:net";
 import {
   closeDb,
   createAgent,
@@ -18,6 +28,7 @@ import { pauseScriptRunProcess } from "../script-workflows/supervisor";
 import { refreshSecretScrubberCache } from "../utils/secret-scrubber";
 import { SKIP_SANDBOX_SPAWN_TESTS } from "./sandbox-spawn-test-helpers";
 import { listenOnFreePort } from "./test-net";
+import { CHILD_PROCESS_TEST_BUDGET_MS } from "./test-proc";
 
 const TEST_DB_PATH = "./test-script-workflows-runtime-e2e.sqlite";
 const WORKFLOW_RUNTIME_DIR = "./test-script-workflows-runtime";
@@ -481,6 +492,65 @@ describe("script workflow runtime", () => {
       expect((await getScriptRun(id))?.status).toBe("paused");
       expect(await listScriptRunJournalSteps(id)).toHaveLength(0);
     },
+  );
+
+  spawnTest(
+    "handles a capability socket error while host polling is active",
+    async () => {
+      holdAgentTaskResponses = true;
+      let capabilitySocket: Socket | undefined;
+      const originalEmit = NetServer.prototype.emit;
+      const emitSpy = spyOn(NetServer.prototype, "emit").mockImplementation(function (
+        this: NetServer,
+        event,
+        ...args
+      ) {
+        const address = this.address();
+        if (
+          event === "connection" &&
+          typeof address === "string" &&
+          address.endsWith("/capability.sock")
+        ) {
+          capabilitySocket = args[0] as Socket;
+        }
+        return originalEmit.call(this, event, ...args);
+      });
+      let runId: string | undefined;
+      try {
+        const created = await api("/api/script-runs", {
+          method: "POST",
+          body: JSON.stringify({
+            source: `export default async function main(_args, ctx) {
+              return await ctx.step.agentTask("broken-pipe", { task: "stay pending" });
+            }`,
+            background: true,
+          }),
+        });
+        expect(created.status).toBe(201);
+        const { id } = (await created.json()) as { id: string };
+        runId = id;
+        await waitUntil(() => agentTaskRequestCount === 1, "Agent task poll did not start");
+        expect(capabilitySocket).toBeDefined();
+
+        // A failed socket write also emits an error event after its callback.
+        // Inject that event deterministically instead of racing the guest exit.
+        const error = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+        expect(() => capabilitySocket!.emit("error", error)).not.toThrow();
+
+        const run = await waitForRun(id);
+        expect(run.status).toBe("failed");
+        expect(run.error).toBe("write EPIPE");
+        await waitUntil(
+          () => agentTaskClosedCount === 1,
+          "Host-side agent task poll was not aborted",
+        );
+        expect(await listScriptRunJournalSteps(id)).toHaveLength(0);
+      } finally {
+        emitSpy.mockRestore();
+        if (runId) await pauseScriptRunProcess(runId);
+      }
+    },
+    CHILD_PROCESS_TEST_BUDGET_MS,
   );
 
   // macOS cannot enforce the runtime's ulimit preamble (no usable RLIMIT_AS);

--- a/src/tests/vendored-openapi.test.ts
+++ b/src/tests/vendored-openapi.test.ts
@@ -26,7 +26,6 @@ import {
 import { getPathSegments, parseQueryParams } from "../http/utils";
 
 const TEST_DB_PATH = "./test-vendored-openapi.sqlite";
-const MIGRATION_DB_PATH = "./test-vendored-openapi-migration.sqlite";
 const originalFetch = globalThis.fetch;
 let leadAgentId: string;
 
@@ -95,7 +94,6 @@ afterEach(async () => {
 afterAll(() => {
   closeDb();
   removeDbFiles(TEST_DB_PATH);
-  removeDbFiles(MIGRATION_DB_PATH);
 });
 
 describe("vendored OpenAPI", () => {
@@ -234,8 +232,9 @@ describe("vendored OpenAPI", () => {
   });
 
   test("migration 117 preserves rows while widening the source-kind check", () => {
-    removeDbFiles(MIGRATION_DB_PATH);
-    const database = new Database(MIGRATION_DB_PATH);
+    // This checks schema and row preservation within one connection.
+    // Avoid disk synchronization for every migration in this isolated fixture.
+    const database = new Database(":memory:");
     try {
       database.run(`
         CREATE TABLE _migrations (


### PR DESCRIPTION
Fix three failures that block the merge queue on main:

- **Script pause:** a failed socket write invokes its callback and emits an `error` event. The executor only caught the callback error. Handle socket errors through the existing protocol failure path and preserve the first error. Errors from unauthenticated connections only destroy their own socket.
- **Database saturation:** filler queries can finish before the HTTP request arrives, producing 200 instead of 429. Hold observation of each real child's exit until the HTTP assertion completes. Restore the spawn spy before the HTTP request. Always release and await the fillers in `finally`.
- **Migration fixture:** the test runs every migration against disk without needing persistence or another connection. CI spent over a second on several migrations and exceeded the timeout. Use an in-memory database with the same schema and row-preservation assertions.

The socket regression emits `EPIPE` on the real authenticated socket during host polling. It fails before the fix and passes afterward. It checks the failed status, aborted polling, and empty journal.

No tests are disabled, and no timeouts are increased.

Failure evidence: [script pause](https://github.com/desplega-ai/agent-swarm/actions/runs/34268979939/job/102205549137), [database saturation](https://github.com/desplega-ai/agent-swarm/actions/runs/34274196340/job/102223138515), [migration fixture](https://github.com/desplega-ai/agent-swarm/actions/runs/34274907498/job/102225518286).

Validation:

- [Linux CI](https://github.com/desplega-ai/agent-swarm/actions/runs/34275383563): both shards passed, totaling 8,397 passes, 7 skips, and 0 failures.
- Affected files passed locally. Database saturation and migration tests each passed 30 consecutive runs.
- Lint, TypeScript, and all applicable pre-push checks passed.
- Local API E2E: 10 passed. Local UI E2E: 40 passed, 17 skipped.
