### PR TITLE
fix(ui): render Codex app-server logs and consistent context usage

### DIFF
--- a/apps/ui/src/lib/context-display.test.tsx
+++ b/apps/ui/src/lib/context-display.test.tsx
@@ -32,4 +32,12 @@ describe("findLatestUsableContextSnapshot", () => {
 
     expect(findLatestUsableContextSnapshot([usage, terminal])).toBe(usage);
   });
+
+  test("returns no usage snapshot when each value comes from a different row", () => {
+    const usedOnly = snapshot({ contextUsedTokens: 191_533 });
+    const totalOnly = snapshot({ id: "snapshot-2", contextTotalTokens: 200_000 });
+    const percentOnly = snapshot({ id: "snapshot-3", contextPercent: 18.241238095238096 });
+
+    expect(findLatestUsableContextSnapshot([usedOnly, totalOnly, percentOnly])).toBeUndefined();
+  });
 });

--- a/apps/ui/src/lib/context-display.test.tsx
+++ b/apps/ui/src/lib/context-display.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import type { ContextSnapshot } from "@/api/types";
+import { findLatestUsableContextSnapshot } from "./context-display";
+
+function snapshot(overrides: Partial<ContextSnapshot> = {}): ContextSnapshot {
+  return {
+    id: "snapshot-1",
+    taskId: "task-1",
+    agentId: "agent-1",
+    sessionId: "session-1",
+    eventType: "progress",
+    cumulativeInputTokens: 0,
+    cumulativeOutputTokens: 0,
+    createdAt: "2026-09-09T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("findLatestUsableContextSnapshot", () => {
+  test("skips a terminal snapshot that lacks a coherent usage set", () => {
+    const usage = snapshot({
+      contextUsedTokens: 191_533,
+      contextTotalTokens: 1_050_000,
+      contextPercent: 18.241238095238096,
+      contextFormula: "input-cache-output",
+    });
+    const terminal = snapshot({
+      id: "snapshot-2",
+      eventType: "completion",
+      contextTotalTokens: 200_000,
+    });
+
+    expect(findLatestUsableContextSnapshot([usage, terminal])).toBe(usage);
+  });
+});

--- a/apps/ui/src/lib/context-display.ts
+++ b/apps/ui/src/lib/context-display.ts
@@ -1,0 +1,21 @@
+import type { ContextSnapshot } from "@/api/types";
+
+/**
+ * Terminal and compaction snapshots can omit usage values. A display must use
+ * one usage snapshot so its percentage, used tokens, and window agree.
+ */
+export function findLatestUsableContextSnapshot(
+  snapshots: ContextSnapshot[],
+): ContextSnapshot | undefined {
+  for (let index = snapshots.length - 1; index >= 0; index--) {
+    const snapshot = snapshots[index];
+    if (
+      snapshot.contextUsedTokens !== undefined &&
+      snapshot.contextTotalTokens !== undefined &&
+      snapshot.contextPercent !== undefined
+    ) {
+      return snapshot;
+    }
+  }
+  return undefined;
+}

--- a/apps/ui/src/lib/context-display.ts
+++ b/apps/ui/src/lib/context-display.ts
@@ -1,19 +1,29 @@
 import type { ContextSnapshot } from "@/api/types";
 
+type UsableContextSnapshot = ContextSnapshot & {
+  contextUsedTokens: number;
+  contextTotalTokens: number;
+  contextPercent: number;
+};
+
+function hasCompleteUsage(snapshot: ContextSnapshot): snapshot is UsableContextSnapshot {
+  return (
+    snapshot.contextUsedTokens !== undefined &&
+    snapshot.contextTotalTokens !== undefined &&
+    snapshot.contextPercent !== undefined
+  );
+}
+
 /**
  * Terminal and compaction snapshots can omit usage values. A display must use
  * one usage snapshot so its percentage, used tokens, and window agree.
  */
 export function findLatestUsableContextSnapshot(
   snapshots: ContextSnapshot[],
-): ContextSnapshot | undefined {
+): UsableContextSnapshot | undefined {
   for (let index = snapshots.length - 1; index >= 0; index--) {
     const snapshot = snapshots[index];
-    if (
-      snapshot.contextUsedTokens !== undefined &&
-      snapshot.contextTotalTokens !== undefined &&
-      snapshot.contextPercent !== undefined
-    ) {
+    if (hasCompleteUsage(snapshot)) {
       return snapshot;
     }
   }

--- a/apps/ui/src/logs-parser/adapters.ts
+++ b/apps/ui/src/logs-parser/adapters.ts
@@ -249,6 +249,7 @@ function appendAcpChunk(
 export function normalizeCodex(ordered: DecodedRecord[]): NormalizedItem[] {
   const items: NormalizedItem[] = [];
   const toolCallById = new Map<string, NormalizedItem>();
+  const textByItemId = new Map<string, NormalizedItem>();
 
   for (const d of ordered) {
     const ev = d.event;
@@ -288,8 +289,14 @@ export function normalizeCodex(ordered: DecodedRecord[]): NormalizedItem[] {
             // These starts contain no text. Their completed event is the single
             // readable transcript row, so intentionally omit the empty marker.
             break;
-          default:
-            items.push(makeItem(d, "unknown", { role: "system", raw: ev }));
+          default: {
+            const userMessage = codexUserMessage(item);
+            if (userMessage) {
+              upsertCodexText(items, textByItemId, d, item, "user", userMessage, "replace");
+            } else {
+              items.push(makeItem(d, "unknown", { role: "system", raw: ev }));
+            }
+          }
         }
         break;
       }
@@ -317,7 +324,10 @@ export function normalizeCodex(ordered: DecodedRecord[]): NormalizedItem[] {
                 result: {
                   id: String(item.id ?? ""),
                   payload: item.result ?? item.aggregated_output ?? "",
-                  isError: typeof item.exit_code === "number" && item.exit_code !== 0,
+                  isError:
+                    (typeof item.exit_code === "number" && item.exit_code !== 0) ||
+                    item.status === "failed" ||
+                    item.error != null,
                 },
               }),
             );
@@ -354,7 +364,7 @@ export function normalizeCodex(ordered: DecodedRecord[]): NormalizedItem[] {
           }
           case "agent_message": {
             if (typeof item.text === "string") {
-              items.push(makeItem(d, "text", { role: "assistant", text: item.text }));
+              upsertCodexText(items, textByItemId, d, item, "assistant", item.text, "replace");
             }
             break;
           }
@@ -387,10 +397,25 @@ export function normalizeCodex(ordered: DecodedRecord[]): NormalizedItem[] {
             break;
           }
           default: {
-            items.push(makeItem(d, "unknown", { role: "system", raw: ev }));
+            const userMessage = codexUserMessage(item);
+            if (userMessage) {
+              upsertCodexText(items, textByItemId, d, item, "user", userMessage, "replace");
+            } else {
+              items.push(makeItem(d, "unknown", { role: "system", raw: ev }));
+            }
             break;
           }
         }
+        break;
+      }
+      case "message.delta": {
+        const itemId = asString(ev.item_id);
+        const delta = asString(ev.delta);
+        if (!itemId || delta === undefined) {
+          items.push(makeItem(d, "unknown", { role: "system", raw: ev }));
+          break;
+        }
+        upsertCodexText(items, textByItemId, d, { id: itemId }, "assistant", delta, "append");
         break;
       }
       case "turn.completed": {
@@ -752,6 +777,42 @@ function codexToolName(item: Record<string, unknown>): string {
   if (item.type === "mcp_tool_call") return `${item.server ?? "mcp"}.${item.tool ?? "unknown"}`;
   if (item.type === "collab_tool_call") return String(item.tool ?? "collaboration");
   return String(item.type ?? "tool");
+}
+
+function codexUserMessage(item: Record<string, unknown>): string | undefined {
+  if (item.type !== "unknown" || item.originalType !== "userMessage" || !isRecord(item.value)) {
+    return undefined;
+  }
+  const text = resultBlockText(item.value.content);
+  return text || undefined;
+}
+
+function upsertCodexText(
+  items: NormalizedItem[],
+  textByItemId: Map<string, NormalizedItem>,
+  d: DecodedRecord,
+  item: Record<string, unknown>,
+  role: LogRole,
+  text: string,
+  mode: "append" | "replace",
+): void {
+  const id = asString(item.id);
+  const key = id ? `${d.rec.sessionId}:${d.rec.iteration}:${id}` : undefined;
+  const existing = key ? textByItemId.get(key) : undefined;
+  if (existing && existing.role === role) {
+    if (text) existing.text = mode === "append" ? `${existing.text ?? ""}${text}` : text;
+    existing.coveredRecIds = [...new Set([...(existing.coveredRecIds ?? []), d.rec.id])];
+    return;
+  }
+  if (!text) return;
+
+  const normalized = makeItem(d, "text", {
+    role,
+    text,
+    meta: id ? { itemId: id } : undefined,
+  });
+  items.push(normalized);
+  if (key) textByItemId.set(key, normalized);
 }
 
 function codexCallInput(item: Record<string, unknown>): unknown {

--- a/apps/ui/src/logs-parser/adapters.ts
+++ b/apps/ui/src/logs-parser/adapters.ts
@@ -250,6 +250,7 @@ export function normalizeCodex(ordered: DecodedRecord[]): NormalizedItem[] {
   const items: NormalizedItem[] = [];
   const toolCallById = new Map<string, NormalizedItem>();
   const textByItemId = new Map<string, NormalizedItem>();
+  const completedTextKeys = new Set<string>();
 
   for (const d of ordered) {
     const ev = d.event;
@@ -365,11 +366,23 @@ export function normalizeCodex(ordered: DecodedRecord[]): NormalizedItem[] {
           case "agent_message": {
             if (typeof item.text === "string") {
               upsertCodexText(items, textByItemId, d, item, "assistant", item.text, "replace");
+              const id = asString(item.id);
+              if (id) completedTextKeys.add(codexTextKey(d, id));
             }
             break;
           }
           case "reasoning": {
-            const text = typeof item.text === "string" ? item.text : asString(item.summary);
+            const summary = Array.isArray(item.summary)
+              ? item.summary
+                  .filter((value): value is string => typeof value === "string")
+                  .join("\n")
+              : asString(item.summary);
+            const content = Array.isArray(item.content)
+              ? item.content
+                  .filter((value): value is string => typeof value === "string")
+                  .join("\n")
+              : undefined;
+            const text = asString(item.text) || summary || content;
             if (text) items.push(makeItem(d, "reasoning", { role: "assistant", text }));
             break;
           }
@@ -413,6 +426,14 @@ export function normalizeCodex(ordered: DecodedRecord[]): NormalizedItem[] {
         const delta = asString(ev.delta);
         if (!itemId || delta === undefined) {
           items.push(makeItem(d, "unknown", { role: "system", raw: ev }));
+          break;
+        }
+        const key = codexTextKey(d, itemId);
+        if (completedTextKeys.has(key)) {
+          const completed = textByItemId.get(key);
+          if (completed) {
+            completed.coveredRecIds = [...new Set([...(completed.coveredRecIds ?? []), d.rec.id])];
+          }
           break;
         }
         upsertCodexText(items, textByItemId, d, { id: itemId }, "assistant", delta, "append");
@@ -797,7 +818,7 @@ function upsertCodexText(
   mode: "append" | "replace",
 ): void {
   const id = asString(item.id);
-  const key = id ? `${d.rec.sessionId}:${d.rec.iteration}:${id}` : undefined;
+  const key = id ? codexTextKey(d, id) : undefined;
   const existing = key ? textByItemId.get(key) : undefined;
   if (existing && existing.role === role) {
     if (text) existing.text = mode === "append" ? `${existing.text ?? ""}${text}` : text;
@@ -813,6 +834,10 @@ function upsertCodexText(
   });
   items.push(normalized);
   if (key) textByItemId.set(key, normalized);
+}
+
+function codexTextKey(d: DecodedRecord, itemId: string): string {
+  return `${d.rec.sessionId}:${d.rec.iteration}:${itemId}`;
 }
 
 function codexCallInput(item: Record<string, unknown>): unknown {

--- a/apps/ui/src/pages/tasks/[id]/page.tsx
+++ b/apps/ui/src/pages/tasks/[id]/page.tsx
@@ -87,6 +87,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useLocalToggle } from "@/hooks/use-local-toggle";
 import { readStringParam, useUrlSearchState } from "@/hooks/use-url-search-state";
+import { findLatestUsableContextSnapshot } from "@/lib/context-display";
 import { formatCost } from "@/lib/cost-format";
 import { formatDurationMs } from "@/lib/format-duration-ms";
 import { formatTokens } from "@/lib/format-tokens";
@@ -465,10 +466,10 @@ function TaskContextSection({
   if (!context || context.summary.snapshotCount === 0) return null;
 
   const { summary } = context;
-  const latestSnapshot = context.snapshots[context.snapshots.length - 1];
-  const currentPercent = latestSnapshot?.contextPercent ?? summary.peakContextPercent ?? 0;
-  const usedTokens = latestSnapshot?.contextUsedTokens ?? summary.peakContextTokens ?? 0;
-  const totalTokens = latestSnapshot?.contextTotalTokens ?? summary.contextWindowSize ?? 0;
+  const latestUsageSnapshot = findLatestUsableContextSnapshot(context.snapshots);
+  const currentPercent = latestUsageSnapshot?.contextPercent ?? summary.peakContextPercent ?? 0;
+  const usedTokens = latestUsageSnapshot?.contextUsedTokens ?? summary.peakContextTokens ?? 0;
+  const totalTokens = latestUsageSnapshot?.contextTotalTokens ?? summary.contextWindowSize ?? 0;
 
   return (
     <>
@@ -491,16 +492,17 @@ function TaskContextSection({
             <span className="whitespace-nowrap">
               {formatTokens(usedTokens)} / {formatTokens(totalTokens)}
             </span>
-            {latestSnapshot?.contextFormula && latestSnapshot.contextFormula !== "unknown" && (
-              <Badge
-                variant="outline"
-                size="tag"
-                className="text-muted-foreground"
-                title={`Computed via formula: ${latestSnapshot.contextFormula}`}
-              >
-                {latestSnapshot.contextFormula}
-              </Badge>
-            )}
+            {latestUsageSnapshot?.contextFormula &&
+              latestUsageSnapshot.contextFormula !== "unknown" && (
+                <Badge
+                  variant="outline"
+                  size="tag"
+                  className="text-muted-foreground"
+                  title={`Computed via formula: ${latestUsageSnapshot.contextFormula}`}
+                >
+                  {latestUsageSnapshot.contextFormula}
+                </Badge>
+              )}
           </span>
         </MetaRow>
         {summary.peakContextPercent != null && (

--- a/apps/ui/src/pages/tasks/[id]/page.tsx
+++ b/apps/ui/src/pages/tasks/[id]/page.tsx
@@ -467,9 +467,6 @@ function TaskContextSection({
 
   const { summary } = context;
   const latestUsageSnapshot = findLatestUsableContextSnapshot(context.snapshots);
-  const currentPercent = latestUsageSnapshot?.contextPercent ?? summary.peakContextPercent ?? 0;
-  const usedTokens = latestUsageSnapshot?.contextUsedTokens ?? summary.peakContextTokens ?? 0;
-  const totalTokens = latestUsageSnapshot?.contextTotalTokens ?? summary.contextWindowSize ?? 0;
 
   return (
     <>
@@ -478,33 +475,42 @@ function TaskContextSection({
         <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
           Context Usage
         </span>
-        <div className="flex items-center gap-2 py-1">
-          <Progress
-            value={currentPercent}
-            className={cn("h-1.5 flex-1", progressBarTone(currentPercent))}
-          />
-          <span className="text-[10px] font-mono text-muted-foreground shrink-0">
-            {currentPercent.toFixed(0)}%
-          </span>
-        </div>
-        <MetaRow icon={Cpu} label="Used">
-          <span className="flex flex-col items-start gap-1 font-mono text-xs">
-            <span className="whitespace-nowrap">
-              {formatTokens(usedTokens)} / {formatTokens(totalTokens)}
-            </span>
-            {latestUsageSnapshot?.contextFormula &&
-              latestUsageSnapshot.contextFormula !== "unknown" && (
-                <Badge
-                  variant="outline"
-                  size="tag"
-                  className="text-muted-foreground"
-                  title={`Computed via formula: ${latestUsageSnapshot.contextFormula}`}
-                >
-                  {latestUsageSnapshot.contextFormula}
-                </Badge>
-              )}
-          </span>
-        </MetaRow>
+        {latestUsageSnapshot ? (
+          <>
+            <div className="flex items-center gap-2 py-1">
+              <Progress
+                value={latestUsageSnapshot.contextPercent}
+                className={cn("h-1.5 flex-1", progressBarTone(latestUsageSnapshot.contextPercent))}
+              />
+              <span className="text-[10px] font-mono text-muted-foreground shrink-0">
+                {latestUsageSnapshot.contextPercent.toFixed(0)}%
+              </span>
+            </div>
+            <MetaRow icon={Cpu} label="Used">
+              <span className="flex flex-col items-start gap-1 font-mono text-xs">
+                <span className="whitespace-nowrap">
+                  {formatTokens(latestUsageSnapshot.contextUsedTokens)} /{" "}
+                  {formatTokens(latestUsageSnapshot.contextTotalTokens)}
+                </span>
+                {latestUsageSnapshot.contextFormula &&
+                  latestUsageSnapshot.contextFormula !== "unknown" && (
+                    <Badge
+                      variant="outline"
+                      size="tag"
+                      className="text-muted-foreground"
+                      title={`Computed via formula: ${latestUsageSnapshot.contextFormula}`}
+                    >
+                      {latestUsageSnapshot.contextFormula}
+                    </Badge>
+                  )}
+              </span>
+            </MetaRow>
+          </>
+        ) : (
+          <MetaRow icon={Cpu} label="Current">
+            <span className="text-xs text-muted-foreground">Unavailable</span>
+          </MetaRow>
+        )}
         {summary.peakContextPercent != null && (
           <MetaRow icon={Activity} label="Peak">
             <span className="text-xs font-mono">{summary.peakContextPercent.toFixed(0)}%</span>

--- a/packages/ui-e2e/specs/codex-logs.spec.ts
+++ b/packages/ui-e2e/specs/codex-logs.spec.ts
@@ -1,0 +1,246 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures";
+
+type SessionLogsResponse = { success: true; count: number };
+
+interface CodexLogSeed {
+  firstMessage: string;
+  liveItemId: string;
+  liveMessage: string;
+  livePartial: string;
+  mcpResult: string;
+  secondMessage: string;
+  sessionId: string;
+  wrappedUserMessage: string;
+}
+
+function codexLogSeed(suffix: string): CodexLogSeed {
+  const prefix = `e2e Codex ${suffix}`;
+  return {
+    firstMessage: `${prefix} distinct response alpha`,
+    liveItemId: `e2e-codex-live-${suffix}`,
+    liveMessage: `${prefix} live response`,
+    livePartial: `${prefix} live`,
+    mcpResult: `${prefix} MCP result`,
+    secondMessage: `${prefix} distinct response beta`,
+    sessionId: `e2e-codex-logs-${suffix}`,
+    wrappedUserMessage: `${prefix} wrapped user message`,
+  };
+}
+
+async function seedCodexLogs(
+  api: { post<T>(path: string, body: unknown): Promise<T> },
+  taskId: string,
+  suffix: string,
+): Promise<CodexLogSeed> {
+  const seed = codexLogSeed(suffix);
+  const wrappedUserMessage = {
+    id: `e2e-codex-user-${suffix}`,
+    type: "unknown",
+    originalType: "userMessage",
+    value: {
+      type: "userMessage",
+      id: `e2e-codex-user-${suffix}`,
+      content: [{ type: "text", text: seed.wrappedUserMessage }],
+    },
+  };
+
+  await api.post<SessionLogsResponse>("/api/session-logs", {
+    sessionId: seed.sessionId,
+    iteration: 1,
+    taskId,
+    cli: "codex",
+    lines: [
+      JSON.stringify({ type: "item.started", item: wrappedUserMessage }),
+      JSON.stringify({ type: "item.completed", item: wrappedUserMessage }),
+      JSON.stringify({
+        type: "message.delta",
+        item_id: seed.liveItemId,
+        delta: `${prefix(seed)} `,
+      }),
+      JSON.stringify({ type: "message.delta", item_id: seed.liveItemId, delta: "live" }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: `e2e-codex-first-${suffix}`, type: "agent_message", text: seed.firstMessage },
+      }),
+      JSON.stringify({
+        type: "item.completed",
+        item: {
+          id: `e2e-codex-second-${suffix}`,
+          type: "agent_message",
+          text: seed.secondMessage,
+        },
+      }),
+      JSON.stringify({
+        type: "item.started",
+        item: {
+          id: `e2e-codex-mcp-${suffix}`,
+          type: "mcp_tool_call",
+          server: "e2e-mcp",
+          tool: "inspect",
+          arguments: { target: "logs" },
+        },
+      }),
+      JSON.stringify({
+        type: "item.completed",
+        item: {
+          id: `e2e-codex-mcp-${suffix}`,
+          type: "mcp_tool_call",
+          server: "e2e-mcp",
+          tool: "inspect",
+          arguments: { target: "logs" },
+          result: { content: [{ type: "text", text: seed.mcpResult }] },
+        },
+      }),
+    ],
+  });
+  return seed;
+}
+
+function prefix(seed: CodexLogSeed): string {
+  return seed.livePartial.slice(0, -" live".length);
+}
+
+async function completeLiveMessage(
+  api: { post<T>(path: string, body: unknown): Promise<T> },
+  taskId: string,
+  seed: CodexLogSeed,
+) {
+  await api.post<SessionLogsResponse>("/api/session-logs", {
+    sessionId: seed.sessionId,
+    iteration: 1,
+    taskId,
+    cli: "codex",
+    lines: [
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: seed.liveItemId, type: "agent_message", text: seed.liveMessage },
+      }),
+    ],
+  });
+}
+
+async function openSessionLogs(page: Page, taskId: string, mobile = false) {
+  await page.goto(`/tasks/${taskId}`);
+  if (mobile) await page.getByRole("tab", { name: "Session Logs" }).click();
+}
+
+async function seedContextSnapshots(
+  swarm: { apiKey: string; apiUrl: string },
+  taskId: string,
+  agentId: string,
+  suffix: string,
+) {
+  const postSnapshot = async (body: Record<string, unknown>) => {
+    const response = await fetch(`${swarm.apiUrl}/api/tasks/${taskId}/context`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${swarm.apiKey}`,
+        "Content-Type": "application/json",
+        "X-Agent-ID": agentId,
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) throw new Error(`Context snapshot failed: ${response.status}`);
+  };
+
+  await postSnapshot({
+    eventType: "progress",
+    sessionId: `e2e-codex-context-${suffix}`,
+    contextUsedTokens: 191_533,
+    contextTotalTokens: 1_050_000,
+    contextPercent: 18.241238095238096,
+  });
+  await postSnapshot({
+    eventType: "completion",
+    sessionId: `e2e-codex-context-${suffix}`,
+    contextTotalTokens: 200_000,
+  });
+}
+
+test("Codex app-server logs render messages, deltas, and MCP results", async ({
+  page,
+  api,
+  seed,
+  clean,
+}, testInfo) => {
+  test.skip(!seed, "remote run without seed");
+  const logs = await seedCodexLogs(api, seed!.tasks.inProgress, testInfo.testId);
+  await openSessionLogs(page, seed!.tasks.inProgress);
+
+  await expect(
+    page.getByText(logs.wrappedUserMessage, { exact: true }).filter({ visible: true }),
+  ).toHaveCount(1);
+  await expect(
+    page.getByText(logs.livePartial, { exact: true }).filter({ visible: true }),
+  ).toHaveCount(1);
+  await expect(
+    page.getByText(logs.firstMessage, { exact: true }).filter({ visible: true }),
+  ).toHaveCount(1);
+  await expect(
+    page.getByText(logs.secondMessage, { exact: true }).filter({ visible: true }),
+  ).toHaveCount(1);
+  await expect(page.getByText("Unknown · message.delta", { exact: true })).toHaveCount(0);
+
+  await page.getByRole("button", { name: /e2e-mcp\.inspect/ }).click();
+  await page
+    .getByRole("button", { name: /e2e-mcp\.inspect/ })
+    .last()
+    .click();
+  await expect(
+    page.getByText(logs.mcpResult, { exact: true }).filter({ visible: true }),
+  ).toBeVisible();
+
+  await completeLiveMessage(api, seed!.tasks.inProgress, logs);
+  await expect(
+    page.getByText(logs.liveMessage, { exact: true }).filter({ visible: true }),
+  ).toHaveCount(1, {
+    timeout: 15_000,
+  });
+
+  await clean.assertClean();
+});
+
+test("context usage keeps the latest complete measurement", async ({
+  page,
+  seed,
+  swarm,
+  clean,
+}, testInfo) => {
+  test.skip(!seed, "remote run without seed");
+  await seedContextSnapshots(swarm, seed!.tasks.inProgress, seed!.agents.workerA, testInfo.testId);
+  await page.goto(`/tasks/${seed!.tasks.inProgress}`);
+
+  await expect(
+    page.getByText("191.5K / 1.1M", { exact: true }).filter({ visible: true }),
+  ).toBeVisible();
+  await expect(page.getByText("18%", { exact: true }).filter({ visible: true })).toHaveCount(2);
+  await expect(page.getByText("200K", { exact: true })).toHaveCount(0);
+
+  await clean.assertClean();
+});
+
+test.describe("below the lg breakpoint", () => {
+  test.use({ viewport: { width: 900, height: 900 } });
+
+  test("Codex app-server messages render in the Session Logs tab", async ({
+    page,
+    api,
+    seed,
+    clean,
+  }, testInfo) => {
+    test.skip(!seed, "remote run without seed");
+    const logs = await seedCodexLogs(api, seed!.tasks.inProgress, testInfo.testId);
+    await openSessionLogs(page, seed!.tasks.inProgress, true);
+
+    await expect(
+      page.getByText(logs.wrappedUserMessage, { exact: true }).filter({ visible: true }),
+    ).toHaveCount(1);
+    await expect(
+      page.getByText(logs.livePartial, { exact: true }).filter({ visible: true }),
+    ).toHaveCount(1);
+    await expect(page.getByText("Unknown · message.delta", { exact: true })).toHaveCount(0);
+
+    await clean.assertClean();
+  });
+});

--- a/packages/ui-e2e/specs/codex-logs.spec.ts
+++ b/packages/ui-e2e/specs/codex-logs.spec.ts
@@ -130,6 +130,7 @@ async function seedContextSnapshots(
   taskId: string,
   agentId: string,
   suffix: string,
+  completeMeasurement = true,
 ) {
   const postSnapshot = async (body: Record<string, unknown>) => {
     const response = await fetch(`${swarm.apiUrl}/api/tasks/${taskId}/context`, {
@@ -148,7 +149,7 @@ async function seedContextSnapshots(
     eventType: "progress",
     sessionId: `e2e-codex-context-${suffix}`,
     contextUsedTokens: 191_533,
-    contextTotalTokens: 1_050_000,
+    contextTotalTokens: completeMeasurement ? 1_050_000 : undefined,
     contextPercent: 18.241238095238096,
   });
   await postSnapshot({
@@ -183,10 +184,6 @@ test("Codex app-server logs render messages, deltas, and MCP results", async ({
   await expect(page.getByText("Unknown · message.delta", { exact: true })).toHaveCount(0);
 
   await page.getByRole("button", { name: /e2e-mcp\.inspect/ }).click();
-  await page
-    .getByRole("button", { name: /e2e-mcp\.inspect/ })
-    .last()
-    .click();
   await expect(
     page.getByText(logs.mcpResult, { exact: true }).filter({ visible: true }),
   ).toBeVisible();
@@ -215,8 +212,32 @@ test("context usage keeps the latest complete measurement", async ({
     page.getByText("191.5K / 1.1M", { exact: true }).filter({ visible: true }),
   ).toBeVisible();
   await expect(page.getByText("18%", { exact: true }).filter({ visible: true })).toHaveCount(2);
-  await expect(page.getByText("200K", { exact: true })).toHaveCount(0);
+  await expect(page.getByText("191.5K / 200.0K", { exact: true })).toHaveCount(0);
 
+  await clean.assertClean();
+});
+
+test("context usage does not combine incomplete measurements", async ({
+  page,
+  seed,
+  swarm,
+  clean,
+}, testInfo) => {
+  test.skip(!seed, "remote run without seed");
+  await seedContextSnapshots(
+    swarm,
+    seed!.tasks.completed,
+    seed!.agents.workerA,
+    testInfo.testId,
+    false,
+  );
+  await page.goto(`/tasks/${seed!.tasks.completed}`);
+
+  await expect(
+    page.getByText("Unavailable", { exact: true }).filter({ visible: true }),
+  ).toBeVisible();
+  await expect(page.getByText("191.5K / 200.0K", { exact: true })).toHaveCount(0);
+  await expect(page.getByText("18%", { exact: true }).filter({ visible: true })).toHaveCount(1);
   await clean.assertClean();
 });
 

--- a/src/tests/ui-logs-parser.test.ts
+++ b/src/tests/ui-logs-parser.test.ts
@@ -280,6 +280,36 @@ describe("ui logs parser", () => {
     });
   });
 
+  test("ignores a stale codex delta persisted after its completed message", () => {
+    const result = normalizeSessionLogs([
+      log(
+        "done",
+        "codex",
+        0,
+        {
+          type: "item.completed",
+          item: { id: "msg-1", type: "agent_message", text: "Final response" },
+        },
+        "2026-09-09T00:00:20.000Z",
+      ),
+      log(
+        "late-delta",
+        "codex",
+        0,
+        { type: "message.delta", item_id: "msg-1", delta: " stale fragment" },
+        "2026-09-09T00:00:21.000Z",
+      ),
+    ]);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      kind: "text",
+      text: "Final response",
+      recId: "done",
+      coveredRecIds: ["late-delta"],
+    });
+  });
+
   test("keeps repeated codex item ids separate across sessions", () => {
     const first = log("first", "codex", 1, {
       type: "message.delta",
@@ -333,6 +363,38 @@ describe("ui logs parser", () => {
       recId: "user-start",
       coveredRecIds: ["user-done"],
     });
+  });
+
+  test("renders codex reasoning summary and content arrays", () => {
+    const result = normalizeSessionLogs([
+      log("summary", "codex", 1, {
+        type: "item.completed",
+        item: {
+          id: "reasoning-1",
+          type: "reasoning",
+          summary: ["Checked the parser", "Found the ordering issue"],
+          content: [],
+        },
+      }),
+      log("content", "codex", 2, {
+        type: "item.completed",
+        item: {
+          id: "reasoning-2",
+          type: "reasoning",
+          summary: [],
+          content: ["Verified the fix", "Tests pass"],
+        },
+      }),
+      log("empty", "codex", 3, {
+        type: "item.completed",
+        item: { id: "reasoning-3", type: "reasoning", summary: [], content: [] },
+      }),
+    ]);
+
+    expect(result.items.map((item) => item.text)).toEqual([
+      "Checked the parser\nFound the ordering issue",
+      "Verified the fix\nTests pass",
+    ]);
   });
 
   test("pairs production-shaped codex MCP calls and preserves failed status", () => {

--- a/src/tests/ui-logs-parser.test.ts
+++ b/src/tests/ui-logs-parser.test.ts
@@ -210,6 +210,168 @@ describe("ui logs parser", () => {
     expect(result.pairing.orphanResults).toEqual([]);
   });
 
+  test("coalesces live codex message deltas across upload batch line resets", () => {
+    const result = normalizeSessionLogs([
+      log(
+        "start",
+        "codex",
+        0,
+        {
+          type: "item.started",
+          item: { id: "msg-1", type: "agent_message", text: "" },
+        },
+        "2026-09-09T00:00:17.565Z",
+      ),
+      log(
+        "delta-2",
+        "codex",
+        0,
+        { type: "message.delta", item_id: "msg-1", delta: "world" },
+        "2026-09-09T00:00:22.615Z",
+      ),
+      log(
+        "delta-1",
+        "codex",
+        1,
+        { type: "message.delta", item_id: "msg-1", delta: "Hello " },
+        "2026-09-09T00:00:17.565Z",
+      ),
+    ]);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      kind: "text",
+      role: "assistant",
+      text: "Hello world",
+      recId: "delta-1",
+      coveredRecIds: ["delta-2"],
+    });
+  });
+
+  test("replaces codex deltas with the completed message without duplicating it", () => {
+    const result = normalizeSessionLogs([
+      log("start", "codex", 0, {
+        type: "item.started",
+        item: { id: "msg-1", type: "agent_message", text: "" },
+      }),
+      log("delta-1", "codex", 1, {
+        type: "message.delta",
+        item_id: "msg-1",
+        delta: "Draft",
+      }),
+      log("delta-2", "codex", 2, {
+        type: "message.delta",
+        item_id: "msg-1",
+        delta: " response",
+      }),
+      log("done", "codex", 3, {
+        type: "item.completed",
+        item: { id: "msg-1", type: "agent_message", text: "Final response" },
+      }),
+    ]);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      kind: "text",
+      role: "assistant",
+      text: "Final response",
+      recId: "delta-1",
+      coveredRecIds: ["delta-2", "done"],
+    });
+  });
+
+  test("keeps repeated codex item ids separate across sessions", () => {
+    const first = log("first", "codex", 1, {
+      type: "message.delta",
+      item_id: "msg-1",
+      delta: "First session",
+    });
+    const second = {
+      ...log("second", "codex", 1, {
+        type: "message.delta",
+        item_id: "msg-1",
+        delta: "Second session",
+      }),
+      sessionId: "session-2",
+      iteration: 2,
+    };
+    const result = normalizeSessionLogs([first, second]);
+
+    expect(result.items.map((item) => item.text)).toEqual(["First session", "Second session"]);
+  });
+
+  test("renders a wrapped codex user message once and omits empty reasoning items", () => {
+    const userItem = {
+      id: "user-1",
+      type: "unknown",
+      originalType: "userMessage",
+      value: {
+        type: "userMessage",
+        id: "user-1",
+        content: [{ type: "text", text: "Run the focused parser tests" }],
+        text_elements: [],
+      },
+    };
+    const result = normalizeSessionLogs([
+      log("user-start", "codex", 1, { type: "item.started", item: userItem }),
+      log("user-done", "codex", 2, { type: "item.completed", item: userItem }),
+      log("reasoning-start", "codex", 3, {
+        type: "item.started",
+        item: { id: "reasoning-1", type: "reasoning", summary: [], content: [] },
+      }),
+      log("reasoning-done", "codex", 4, {
+        type: "item.completed",
+        item: { id: "reasoning-1", type: "reasoning", summary: [], content: [] },
+      }),
+    ]);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      kind: "text",
+      role: "user",
+      text: "Run the focused parser tests",
+      recId: "user-start",
+      coveredRecIds: ["user-done"],
+    });
+  });
+
+  test("pairs production-shaped codex MCP calls and preserves failed status", () => {
+    const result = normalizeSessionLogs([
+      log("start", "codex", 1, {
+        type: "item.started",
+        item: {
+          id: "exec-1",
+          type: "mcp_tool_call",
+          server: "agent-swarm",
+          tool: "store-progress",
+          arguments: { status: "completed" },
+          status: "inProgress",
+          result: null,
+          error: null,
+        },
+      }),
+      log("done", "codex", 2, {
+        type: "item.completed",
+        item: {
+          id: "exec-1",
+          type: "mcp_tool_call",
+          server: "agent-swarm",
+          tool: "store-progress",
+          arguments: { status: "completed" },
+          status: "failed",
+          result: { content: [{ type: "text", text: "Input validation error" }] },
+          error: null,
+        },
+      }),
+    ]);
+
+    expect(result.items.map((item) => item.kind)).toEqual(["tool_call", "tool_result"]);
+    expect(result.items[1]?.result).toMatchObject({ id: "exec-1", isError: true });
+    expect(result.pairing).toEqual(
+      expect.objectContaining({ paired: 1, orphanCalls: [], orphanResults: [] }),
+    );
+  });
+
   test("pairs codex collaboration calls and surfaces collaboration state", () => {
     const result = normalizeSessionLogs([
       log("start", "codex", 1, {


### PR DESCRIPTION
Codex app-server sessions displayed each message fragment as an unknown event. The dashboard now combines fragments into readable messages and replaces them with completed text without duplication. It also renders user messages, preserves failed MCP tool status, and renders reasoning summaries. Completed text also rejects stale fragments from delayed uploads.

The context panel now selects one complete measurement. A later completion record can no longer combine its fallback 200K window with the measured 18% usage of a 1.05M window. When no complete measurement exists, current usage displays as unavailable.

Validation:

- Replayed 56 sanitized production records locally: zero unknown events and zero orphaned tools.
- 49 focused parser and context regression tests passed.
- Full root suite passed before the review follow-up: 8,454 tests, 12 skips. Final full runs each passed 8,457 tests, with an unrelated Slack ordering failure or OpenCode timeout. Both affected suites passed separately (5 and 41 tests). Ambient provider credentials were cleared for full runs.
- Black-box API E2E: 11 passed.
- UI E2E: 44 passed, 17 existing skips. New cases cover live polling, completion replacement, MCP results, mobile logs, and context snapshots.
- Root/UI lint, TypeScript checks, repository boundaries, coverage checks, and dependency graph passed.
- Real local Codex app-server 0.153.4 with the swarm API and worker: mid-turn steer remained in one turn; queue waited for the next turn and used two turns. Both produced the expected stored output and one matching assistant message. Native interruption cleaned up the app-server, and cancellation before queue acceptance preserved one promoted follow-up.
- Final GitHub CI is green, including both root test shards, UI E2E, and the merge gate.

[Real Codex steering validation report](https://fly.storage.tigris.dev/agent-fs-taras-storage/648a5f3c-35c8-4f11-8673-b89de52cd6bd/drives/2faf73ba-4eee-4472-8b3b-359c4ed6bfbb/qa/agent-swarm/2026-09-09-codex-log-rendering/steering-validation.json?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=tid_HmeSWgYTsPMlIrxsHowzHXHDjaeoDuEISZtTlyZVAXApPgFSNu%2F20260909%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260909T005331Z&X-Amz-Expires=604800&X-Amz-Signature=41b217cf53b67525afa2c3122421e27e5c239ecae4ce43d543fbee502f36ff80&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27steering-validation.json&response-content-type=application%2Fjson%3B%20charset%3Dutf-8&x-amz-checksum-mode=ENABLED&x-id=GetObject)

Local browser evidence:

![Corrected desktop transcript and context panel](https://fly.storage.tigris.dev/agent-fs-taras-storage/648a5f3c-35c8-4f11-8673-b89de52cd6bd/drives/2faf73ba-4eee-4472-8b3b-359c4ed6bfbb/qa/agent-swarm/2026-09-09-codex-log-rendering/desktop.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=tid_HmeSWgYTsPMlIrxsHowzHXHDjaeoDuEISZtTlyZVAXApPgFSNu%2F20260909%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260909T001833Z&X-Amz-Expires=604800&X-Amz-Signature=7523069f0a204c718367c4cdf9df37264874ce9871c601eb534dc373bf4daf92&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27desktop.png&response-content-type=image%2Fpng&x-amz-checksum-mode=ENABLED&x-id=GetObject)

![Corrected mobile transcript](https://fly.storage.tigris.dev/agent-fs-taras-storage/648a5f3c-35c8-4f11-8673-b89de52cd6bd/drives/2faf73ba-4eee-4472-8b3b-359c4ed6bfbb/qa/agent-swarm/2026-09-09-codex-log-rendering/mobile.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=tid_HmeSWgYTsPMlIrxsHowzHXHDjaeoDuEISZtTlyZVAXApPgFSNu%2F20260909%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260909T001852Z&X-Amz-Expires=604800&X-Amz-Signature=4332db8b1be53ddcc350fc6dfcba168d786f97cf7849d052c38c55bf754c90db&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27mobile.png&response-content-type=image%2Fpng&x-amz-checksum-mode=ENABLED&x-id=GetObject)
