### PR TITLE
feat(ui): flag Claude SDK transport on task detail and agent list

### DIFF
--- a/apps/ui/src/api/types.ts
+++ b/apps/ui/src/api/types.ts
@@ -139,6 +139,12 @@ export interface Agent {
    * worker hasn't booted yet, or `CRED_CHECK_DISABLE=1` opted it out.
    */
   credStatus?: AgentCredStatus | null;
+  /**
+   * Effective `CLAUDE_TRANSPORT` (global → agent precedence) for Claude
+   * agents. Absent for other harnesses. Reflects the next session, not
+   * necessarily the last one that ran.
+   */
+  claudeTransport?: ClaudeTransport;
   createdAt: string;
   lastUpdatedAt: string;
 }
@@ -252,7 +258,7 @@ export interface AgentTask {
   credentialKeyType?: string;
   swarmVersion?: string;
   provider?: ProviderName;
-  providerMeta?: DevinProviderMeta | Record<string, never>;
+  providerMeta?: DevinProviderMeta | ClaudeProviderMeta | Record<string, never>;
   harnessVariant?: string;
   harnessVariantMeta?: { version?: string; failureArtifact?: string };
   peakContextPercent?: number;
@@ -293,6 +299,10 @@ export type DevinProviderMeta = {
   sessionUrl: string;
   maxAcuLimit?: number;
   acuCostUsd?: number;
+};
+/** Persisted by the worker at session init (`providerMeta.transport`). */
+export type ClaudeProviderMeta = {
+  transport?: ClaudeTransport;
 };
 
 // ============================================================================

--- a/apps/ui/src/components/shared/agent-runtime-settings.test.tsx
+++ b/apps/ui/src/components/shared/agent-runtime-settings.test.tsx
@@ -307,4 +307,27 @@ describe("ACP harness presentation", () => {
     expect(html).toContain("ACP");
     expect(html).toContain("<svg");
   });
+
+  test("flags Claude agents on the SDK transport and stays quiet for CLI or other harnesses", () => {
+    const sdk = renderToStaticMarkup(
+      <TooltipProvider>
+        <HarnessCell harnessProvider="claude" credStatus={null} claudeTransport="sdk" />
+      </TooltipProvider>,
+    );
+    expect(sdk).toContain('data-testid="harness-transport-chip"');
+
+    const cli = renderToStaticMarkup(
+      <TooltipProvider>
+        <HarnessCell harnessProvider="claude" credStatus={null} claudeTransport="cli" />
+      </TooltipProvider>,
+    );
+    expect(cli).not.toContain('data-testid="harness-transport-chip"');
+
+    const codex = renderToStaticMarkup(
+      <TooltipProvider>
+        <HarnessCell harnessProvider="codex" credStatus={null} claudeTransport="sdk" />
+      </TooltipProvider>,
+    );
+    expect(codex).not.toContain('data-testid="harness-transport-chip"');
+  });
 });

--- a/apps/ui/src/components/shared/harness-cell.tsx
+++ b/apps/ui/src/components/shared/harness-cell.tsx
@@ -1,4 +1,4 @@
-import type { AgentCredStatus, ProviderName } from "@/api/types";
+import type { AgentCredStatus, ClaudeTransport, ProviderName } from "@/api/types";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { HarnessIcon } from "./harness-icon";
@@ -56,15 +56,23 @@ function formatRelative(ms: number): string {
 export interface HarnessCellProps {
   harnessProvider: ProviderName | string | null | undefined;
   credStatus: AgentCredStatus | null | undefined;
+  /** Effective Claude transport from the agents API. Only `sdk` renders a chip; CLI is the default. */
+  claudeTransport?: ClaudeTransport | null;
   className?: string;
 }
 
-export function HarnessCell({ harnessProvider, credStatus, className }: HarnessCellProps) {
+export function HarnessCell({
+  harnessProvider,
+  credStatus,
+  claudeTransport,
+  className,
+}: HarnessCellProps) {
   if (!harnessProvider) {
     return <span className="text-muted-foreground">—</span>;
   }
   const label = HARNESS_LABEL[harnessProvider] ?? harnessProvider;
   const health = classifyCred(credStatus);
+  const transport = harnessProvider === "claude" ? (claudeTransport ?? null) : null;
 
   return (
     <Tooltip>
@@ -77,6 +85,14 @@ export function HarnessCell({ harnessProvider, credStatus, className }: HarnessC
         >
           <HarnessIcon harness={String(harnessProvider)} />
           <span className="font-medium">{label}</span>
+          {transport === "sdk" ? (
+            <span
+              data-testid="harness-transport-chip"
+              className="rounded border border-border px-1 text-[9px] font-medium uppercase leading-4 text-muted-foreground"
+            >
+              sdk
+            </span>
+          ) : null}
           <span
             aria-hidden
             className={cn("h-1.5 w-1.5 rounded-full shrink-0", HEALTH_DOT[health])}
@@ -93,6 +109,7 @@ export function HarnessCell({ harnessProvider, credStatus, className }: HarnessC
           providerLabel={label}
           credStatus={credStatus ?? null}
           health={health}
+          transport={transport}
         />
       </TooltipContent>
     </Tooltip>
@@ -104,11 +121,13 @@ function CredBreakdown({
   providerLabel,
   credStatus,
   health,
+  transport,
 }: {
   provider: string;
   providerLabel: string;
   credStatus: AgentCredStatus | null;
   health: CredHealth;
+  transport: ClaudeTransport | null;
 }) {
   return (
     <div className="text-xs leading-relaxed space-y-1.5">
@@ -121,6 +140,15 @@ function CredBreakdown({
         <span className={cn("h-1.5 w-1.5 rounded-full", HEALTH_DOT[health])} />
         <span className="font-medium">{HEALTH_LABEL[health]}</span>
       </div>
+
+      {transport ? (
+        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 opacity-90">
+          <dt className="opacity-60">Transport</dt>
+          <dd className="font-mono">
+            {transport === "sdk" ? "sdk · Claude Agent SDK" : "cli · Claude Code CLI"}
+          </dd>
+        </dl>
+      ) : null}
 
       {!credStatus ? (
         <p className="opacity-80">

--- a/apps/ui/src/components/shared/session-id.tsx
+++ b/apps/ui/src/components/shared/session-id.tsx
@@ -1,10 +1,10 @@
 import { ExternalLink } from "lucide-react";
-import type { DevinProviderMeta, ProviderName } from "@/api/types";
+import type { ClaudeProviderMeta, DevinProviderMeta, ProviderName } from "@/api/types";
 
 interface SessionIdProps {
   sessionId: string;
   provider?: ProviderName;
-  providerMeta?: DevinProviderMeta | Record<string, never>;
+  providerMeta?: DevinProviderMeta | ClaudeProviderMeta | Record<string, never>;
 }
 
 export function SessionId({ sessionId, provider, providerMeta }: SessionIdProps) {

--- a/apps/ui/src/pages/agents/[id]/page.tsx
+++ b/apps/ui/src/pages/agents/[id]/page.tsx
@@ -352,6 +352,7 @@ export default function AgentDetailPage() {
                         <HarnessCell
                           harnessProvider={agent.harnessProvider}
                           credStatus={agent.credStatus}
+                          claudeTransport={agent.claudeTransport}
                         />
                       </InfoRow>
                       <InfoRow label="Runtime">

--- a/apps/ui/src/pages/agents/page.tsx
+++ b/apps/ui/src/pages/agents/page.tsx
@@ -120,6 +120,7 @@ export default function AgentsPage() {
           <HarnessCell
             harnessProvider={params.data?.harnessProvider}
             credStatus={params.data?.credStatus}
+            claudeTransport={params.data?.claudeTransport}
           />
         ),
       },

--- a/apps/ui/src/pages/tasks/[id]/page.tsx
+++ b/apps/ui/src/pages/tasks/[id]/page.tsx
@@ -49,6 +49,7 @@ import {
 import { useUsers } from "@/api/hooks/use-users";
 import type {
   AgentLog,
+  ClaudeProviderMeta,
   DevinProviderMeta,
   ProviderName,
   SessionCost,
@@ -281,7 +282,7 @@ function TaskCostSection({
   costs: SessionCost[] | undefined;
   isLoading: boolean;
   provider?: ProviderName;
-  providerMeta?: DevinProviderMeta | Record<string, never>;
+  providerMeta?: DevinProviderMeta | ClaudeProviderMeta | Record<string, never>;
 }) {
   const isDevin = provider === "devin";
   const devinMeta = isDevin ? (providerMeta as DevinProviderMeta | undefined) : undefined;
@@ -406,7 +407,7 @@ function TaskContextSection({
   context: TaskContextResponse | undefined;
   isLoading: boolean;
   provider?: ProviderName;
-  providerMeta?: DevinProviderMeta | Record<string, never>;
+  providerMeta?: DevinProviderMeta | ClaudeProviderMeta | Record<string, never>;
   costs?: SessionCost[];
 }) {
   const isDevin = provider === "devin";
@@ -1028,6 +1029,14 @@ export default function TaskDetailPage() {
               <span className="opacity-60">
                 {" · "}
                 {task.harnessVariantMeta.version}
+              </span>
+            ) : null}
+            {task.providerMeta &&
+            "transport" in task.providerMeta &&
+            task.providerMeta.transport === "sdk" ? (
+              <span className="opacity-60" title="Ran through the Claude Agent SDK transport">
+                {" · "}
+                sdk
               </span>
             ) : null}
           </Badge>

--- a/docs-site/public/openapi.d.ts
+++ b/docs-site/public/openapi.d.ts
@@ -2163,6 +2163,8 @@ export interface paths {
                                     max: number;
                                     available: number;
                                 };
+                                /** @enum {string} */
+                                claudeTransport?: "cli" | "sdk";
                             })[];
                         };
                     };
@@ -2799,6 +2801,8 @@ export interface paths {
                                 max: number;
                                 available: number;
                             };
+                            /** @enum {string} */
+                            claudeTransport?: "cli" | "sdk";
                         };
                     };
                 };

--- a/openapi.json
+++ b/openapi.json
@@ -9154,6 +9154,13 @@
                                   "max",
                                   "available"
                                 ]
+                              },
+                              "claudeTransport": {
+                                "type": "string",
+                                "enum": [
+                                  "cli",
+                                  "sdk"
+                                ]
                               }
                             },
                             "required": [
@@ -10188,6 +10195,13 @@
                             "current",
                             "max",
                             "available"
+                          ]
+                        },
+                        "claudeTransport": {
+                          "type": "string",
+                          "enum": [
+                            "cli",
+                            "sdk"
                           ]
                         }
                       },

--- a/src/http/agents.ts
+++ b/src/http/agents.ts
@@ -293,6 +293,43 @@ async function getClaudeRuntimeMetadata(
   };
 }
 
+/**
+ * Effective `CLAUDE_TRANSPORT` for a batch of agents, using the same
+ * global → agent precedence as `getClaudeRuntimeMetadata` (minus repo scope,
+ * which a list has no context for). Two queries total, not two per agent.
+ * Non-Claude agents and invalid values yield `undefined` so the list never
+ * fails on one bad config row.
+ */
+async function resolveListClaudeTransports(
+  agents: ReadonlyArray<{ id: string; harnessProvider?: ProviderName | null }>,
+): Promise<Map<string, ClaudeTransport>> {
+  const result = new Map<string, ClaudeTransport>();
+  if (!agents.some((agent) => agent.harnessProvider === "claude")) return result;
+  const [globalRows, agentRows] = await Promise.all([
+    getSwarmConfigs({ scope: "global", key: "CLAUDE_TRANSPORT" }),
+    getSwarmConfigs({ scope: "agent", key: "CLAUDE_TRANSPORT" }),
+  ]);
+  const globalValue = globalRows[0]?.value;
+  const agentValues = new Map(agentRows.map((row) => [row.scopeId, row.value]));
+  for (const agent of agents) {
+    if (agent.harnessProvider !== "claude") continue;
+    try {
+      result.set(
+        agent.id,
+        resolveClaudeTransport({ CLAUDE_TRANSPORT: agentValues.get(agent.id) ?? globalValue }),
+      );
+    } catch {
+      // Invalid stored value: leave the field absent rather than 500 the list.
+    }
+  }
+  return result;
+}
+
+/** List/detail rows carry the effective Claude transport so the dashboard can flag SDK agents. */
+const AgentListItemSchema = AgentWithCapacityAndTasksSchema.extend({
+  claudeTransport: ClaudeTransportSchema.optional(),
+});
+
 const listAgents = route({
   method: "get",
   path: "/api/agents",
@@ -309,7 +346,7 @@ const listAgents = route({
   responses: {
     200: {
       description: "Agent list with capacity info",
-      schema: z.object({ agents: z.array(AgentWithCapacityAndTasksSchema) }),
+      schema: z.object({ agents: z.array(AgentListItemSchema) }),
     },
   },
 });
@@ -442,7 +479,7 @@ const getAgent = route({
     include: z.enum(["tasks"]).optional(),
   }),
   responses: {
-    200: { description: "Agent with capacity info", schema: AgentWithCapacityAndTasksSchema },
+    200: { description: "Agent with capacity info", schema: AgentListItemSchema },
     404: { description: "Agent not found" },
   },
 });
@@ -701,8 +738,16 @@ export async function handleAgentsRest(
     const agents = includeTasks
       ? await getAllAgentsWithTasks({ slim })
       : await getAllAgents({ slim });
-    const agentsWithCapacity = await Promise.all(agents.map(agentWithCapacity));
-    listAgents.respond(res, 200, { agents: agentsWithCapacity });
+    const [agentsWithCapacity, transports] = await Promise.all([
+      Promise.all(agents.map(agentWithCapacity)),
+      resolveListClaudeTransports(agents),
+    ]);
+    listAgents.respond(res, 200, {
+      agents: agentsWithCapacity.map((agent) => {
+        const claudeTransport = transports.get(agent.id);
+        return claudeTransport ? { ...agent, claudeTransport } : agent;
+      }),
+    });
     return true;
   }
 
@@ -1279,7 +1324,16 @@ export async function handleAgentsRest(
       return true;
     }
 
-    getAgent.respond(res, 200, await agentWithCapacity(agent));
+    const [agentWithCap, transports] = await Promise.all([
+      agentWithCapacity(agent),
+      resolveListClaudeTransports([agent]),
+    ]);
+    const claudeTransport = transports.get(agent.id);
+    getAgent.respond(
+      res,
+      200,
+      claudeTransport ? { ...agentWithCap, claudeTransport } : agentWithCap,
+    );
     return true;
   }
 

--- a/src/tests/agents-harness-provider.test.ts
+++ b/src/tests/agents-harness-provider.test.ts
@@ -1011,3 +1011,73 @@ describe("deleteSwarmConfigByKey", () => {
     ).toBeUndefined();
   });
 });
+
+// ─── GET /api/agents — effective Claude transport on list rows ───────────────
+
+describe("GET /api/agents claudeTransport", () => {
+  test("Claude agents carry the effective transport; other harnesses omit it", async () => {
+    const claudeInherit = await createAgent({
+      name: "transport-claude-inherit",
+      isLead: false,
+      status: "idle",
+      capabilities: [],
+      harnessProvider: "claude",
+    });
+    const claudeOverride = await createAgent({
+      name: "transport-claude-override",
+      isLead: false,
+      status: "idle",
+      capabilities: [],
+      harnessProvider: "claude",
+    });
+    const codex = await createAgent({
+      name: "transport-codex",
+      isLead: false,
+      status: "idle",
+      capabilities: [],
+      harnessProvider: "codex",
+    });
+    await upsertSwarmConfig({ scope: "global", key: "CLAUDE_TRANSPORT", value: "sdk" });
+    await upsertSwarmConfig({
+      scope: "agent",
+      scopeId: claudeOverride.id,
+      key: "CLAUDE_TRANSPORT",
+      value: "cli",
+    });
+
+    const res = await fetch(`${baseUrl}/api/agents`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      agents: { id: string; claudeTransport?: "cli" | "sdk" }[];
+    };
+    const byId = new Map(body.agents.map((agent) => [agent.id, agent]));
+    expect(byId.get(claudeInherit.id)?.claudeTransport).toBe("sdk");
+    expect(byId.get(claudeOverride.id)?.claudeTransport).toBe("cli");
+    expect(byId.get(codex.id)?.claudeTransport).toBeUndefined();
+
+    const single = await fetch(`${baseUrl}/api/agents/${claudeInherit.id}`);
+    expect(single.status).toBe(200);
+    expect(((await single.json()) as { claudeTransport?: string }).claudeTransport).toBe("sdk");
+  });
+
+  test("an invalid stored transport omits the field instead of failing the list", async () => {
+    const a = await createAgent({
+      name: "transport-claude-invalid",
+      isLead: false,
+      status: "idle",
+      capabilities: [],
+      harnessProvider: "claude",
+    });
+    await upsertSwarmConfig({
+      scope: "agent",
+      scopeId: a.id,
+      key: "CLAUDE_TRANSPORT",
+      value: "bogus",
+    });
+
+    const res = await fetch(`${baseUrl}/api/agents`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { agents: { id: string; claudeTransport?: string }[] };
+    expect(body.agents.find((agent) => agent.id === a.id)?.claudeTransport).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Follow-up to #1404. The worker already persists `providerMeta.transport` at session init and the runtime endpoint computes the effective `CLAUDE_TRANSPORT`, but the dashboard showed neither. A task that ran through the SDK looked identical to a CLI one.

## Changes

- `GET /api/agents` and `GET /api/agents/{id}` now carry `claudeTransport` for Claude agents (global then agent precedence, same rule as the runtime endpoint minus repo scope). Two queries per list, not two per agent. Absent for other harnesses and for invalid stored values, so one bad config row never fails the list.
- `HarnessCell` (agents list + agent detail) shows an `SDK` chip after the harness label and a `Transport` row in the tooltip. CLI is the default, so only `sdk` renders a chip.
- Task detail harness badge gets a `· sdk` suffix when `providerMeta.transport === "sdk"`.
- UI `providerMeta` type widened to include the Claude shape.
- OpenAPI regenerated.

## Screenshots

Agents list (Lead on SDK, Researcher inherits CLI, Codex unaffected):

![agents list](https://fly.storage.tigris.dev/agent-fs-taras-storage/648a5f3c-35c8-4f11-8673-b89de52cd6bd/drives/2faf73ba-4eee-4472-8b3b-359c4ed6bfbb/qa/agent-swarm/2026-09-09-claude-transport-indicator/agents-list.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=tid_HmeSWgYTsPMlIrxsHowzHXHDjaeoDuEISZtTlyZVAXApPgFSNu%2F20260909%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260909T180237Z&X-Amz-Expires=604800&X-Amz-Signature=cca63dc969697781a7dfd2c43cf2857660ac07c24410c89762059c00116842ea&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27agents-list.png&response-content-type=image%2Fpng&x-amz-checksum-mode=ENABLED&x-id=GetObject)

Tooltip:

![agents tooltip](https://fly.storage.tigris.dev/agent-fs-taras-storage/648a5f3c-35c8-4f11-8673-b89de52cd6bd/drives/2faf73ba-4eee-4472-8b3b-359c4ed6bfbb/qa/agent-swarm/2026-09-09-claude-transport-indicator/agents-tooltip.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=tid_HmeSWgYTsPMlIrxsHowzHXHDjaeoDuEISZtTlyZVAXApPgFSNu%2F20260909%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260909T180237Z&X-Amz-Expires=604800&X-Amz-Signature=7105a9d57cf2cec47519d51afd1329f665ba75d20cb89993839b44cd2f265153&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27agents-tooltip.png&response-content-type=image%2Fpng&x-amz-checksum-mode=ENABLED&x-id=GetObject)

Task detail badge:

![task badge](https://fly.storage.tigris.dev/agent-fs-taras-storage/648a5f3c-35c8-4f11-8673-b89de52cd6bd/drives/2faf73ba-4eee-4472-8b3b-359c4ed6bfbb/qa/agent-swarm/2026-09-09-claude-transport-indicator/task-badge.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=tid_HmeSWgYTsPMlIrxsHowzHXHDjaeoDuEISZtTlyZVAXApPgFSNu%2F20260909%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260909T180237Z&X-Amz-Expires=604800&X-Amz-Signature=6cab683cbbd6f74816d3c320bad3ff7e836bb9e9c1ffb4cee61e3bd207ee5a77&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%2A%3DUTF-8%27%27task-badge.png&response-content-type=image%2Fpng&x-amz-checksum-mode=ENABLED&x-id=GetObject)

## Verification

- `bun test src/tests/agents-harness-provider.test.ts`: 38 pass (2 new: list/detail carry the field, invalid value omits it)
- `apps/ui` `agent-runtime-settings.test.tsx`: 15 pass (1 new HarnessCell chip test)
- `bun run tsc:check`, `cd apps/ui && bun run lint && bunx tsc -b`, Biome on changed root files
- `bun run docs:openapi`, `check:openapi-response-coverage`, `check:rbac-coverage`, `check-db-boundary`, floating-promises, promise-sinks, dep-graph (16 pre-existing warnings, unchanged)
- Screenshots from a fresh local API + Vite dev server via agent-browser, uploaded to agent-fs (7-day links)
