### PR TITLE
test: enforce provider registration coverage

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -151,7 +151,7 @@ elif [ "$HARNESS_PROVIDER" = "devin" ]; then
         echo "Devin API: configured (org: ${DEVIN_ORG_ID})"
     fi
 elif [ "$HARNESS_PROVIDER" = "codex" ]; then
-    WORKER_CODEX_HOME="${WORKER_CODEX_HOME:-/home/worker/.codex}"
+    WORKER_CODEX_HOME="/home/worker/.codex"
 
     # If a stale api-key-mode auth.json is on disk, drop it so the OAuth path
     # below can write fresh chatgpt-mode credentials. (codex_oauth wins over

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -151,7 +151,7 @@ elif [ "$HARNESS_PROVIDER" = "devin" ]; then
         echo "Devin API: configured (org: ${DEVIN_ORG_ID})"
     fi
 elif [ "$HARNESS_PROVIDER" = "codex" ]; then
-    WORKER_CODEX_HOME="/home/worker/.codex"
+    WORKER_CODEX_HOME="${WORKER_CODEX_HOME:-/home/worker/.codex}"
 
     # If a stale api-key-mode auth.json is on disk, drop it so the OAuth path
     # below can write fresh chatgpt-mode credentials. (codex_oauth wins over

--- a/src/be/seed-pricing.ts
+++ b/src/be/seed-pricing.ts
@@ -261,6 +261,18 @@ export function buildModelsDevSeedRows(cache: ModelsDevCache): PricingSeedRow[] 
   return rows;
 }
 
+/** Build the exact provider rows inserted by the boot-time pricing seeder. */
+export function buildPricingSeedRows(cache: ModelsDevCache | null): PricingSeedRow[] {
+  const modelsdevRows = cache ? buildModelsDevSeedRows(cache) : [];
+  const manualRows = MANUAL_PRICING_OVERRIDES.map((override) => ({
+    provider: override.provider,
+    model: override.model,
+    tokenClass: override.tokenClass,
+    pricePerMillionUsd: override.pricePerMillionUsd,
+  }));
+  return [...modelsdevRows, ...manualRows];
+}
+
 /**
  * Phase 2 entrypoint. Idempotent — safe to call on every boot. Logs a one-line
  * summary so operators can tell whether the boot picked up new rates.
@@ -271,14 +283,7 @@ export function seedPricingFromModelsDev(opts?: { quiet?: boolean }): {
 } {
   const db = getDb();
   const cache = loadModelsDevCache();
-  const modelsdevRows = cache ? buildModelsDevSeedRows(cache) : [];
-  const manualRows = MANUAL_PRICING_OVERRIDES.map((o) => ({
-    provider: o.provider,
-    model: o.model,
-    tokenClass: o.tokenClass,
-    pricePerMillionUsd: o.pricePerMillionUsd,
-  }));
-  const allRows = [...modelsdevRows, ...manualRows];
+  const allRows = buildPricingSeedRows(cache);
 
   const insert = db.prepare<null, [string, string, string, number]>(
     `INSERT OR IGNORE INTO pricing

--- a/src/commands/provider-credentials.ts
+++ b/src/commands/provider-credentials.ts
@@ -82,6 +82,25 @@ export const REQUIRED_CRED_VARS_BY_PROVIDER: Record<SupportedProvider, readonly 
   acp: [],
 };
 
+type CredentialChecker = (
+  env: Record<string, string | undefined>,
+  opts?: CredCheckOptions,
+) => CredStatus | Promise<CredStatus>;
+
+/** The handlers used by the credential-readiness dispatcher. */
+export const CREDENTIAL_PROVIDER_CHECKERS: Record<SupportedProvider, CredentialChecker> = {
+  claude: (env) => checkClaudeCredentials(env),
+  "claude-managed": (env) => checkClaudeManagedCredentials(env),
+  codex: (env, opts) => checkCodexCredentials(env, opts),
+  devin: (env) => checkDevinCredentials(env),
+  opencode: (env, opts) => checkOpencodeCredentials(env, opts),
+  pi: async (env, opts) => {
+    const { checkPiMonoCredentials } = await import("../providers/pi-mono-adapter");
+    return checkPiMonoCredentials(env, opts);
+  },
+  acp: () => ({ ready: true, missing: [], satisfiedBy: "sdk-delegated" }),
+};
+
 /**
  * Run the predicate for `provider`. Unknown providers throw — call sites
  * should treat that as a configuration bug, not a user-correctable state.
@@ -95,28 +114,17 @@ export async function checkProviderCredentials(
   env: Record<string, string | undefined>,
   opts?: CredCheckOptions,
 ): Promise<CredStatus> {
-  switch (provider) {
-    case "claude":
-      return checkClaudeCredentials(env);
-    case "claude-managed":
-      return checkClaudeManagedCredentials(env);
-    case "codex":
-      return checkCodexCredentials(env, opts);
-    case "devin":
-      return checkDevinCredentials(env);
-    case "opencode":
-      return checkOpencodeCredentials(env, opts);
-    case "pi": {
-      const { checkPiMonoCredentials } = await import("../providers/pi-mono-adapter");
-      return checkPiMonoCredentials(env, opts);
-    }
-    case "acp":
-      return { ready: true, missing: [], satisfiedBy: "sdk-delegated" };
-    default:
-      throw new Error(
-        `checkProviderCredentials: unknown provider "${provider}". Supported: claude, claude-managed, codex, devin, opencode, pi, acp.`,
-      );
+  const checker = (CREDENTIAL_PROVIDER_CHECKERS as Record<string, CredentialChecker | undefined>)[
+    provider
+  ];
+  if (!checker) {
+    throw new Error(
+      `checkProviderCredentials: unknown provider "${provider}". Supported: ${Object.keys(
+        CREDENTIAL_PROVIDER_CHECKERS,
+      ).join(", ")}.`,
+    );
   }
+  return checker(env, opts);
 }
 
 // ─── Live "Test connection" dispatcher ───────────────────────────────────────

--- a/src/tests/provider-registration.test.ts
+++ b/src/tests/provider-registration.test.ts
@@ -1,48 +1,76 @@
 import { describe, expect, test } from "bun:test";
-import { type ProviderName, ProviderNameSchema } from "../types";
+import { buildPricingSeedRows } from "../be/seed-pricing";
+import { CREDENTIAL_PROVIDER_CHECKERS } from "../commands/provider-credentials";
+import { ProviderNameSchema } from "../types";
 
-const registrationSources = {
-  credentials: await Bun.file(
-    new URL("../commands/provider-credentials.ts", import.meta.url),
-  ).text(),
-  pricing: await Bun.file(new URL("../be/seed-pricing.ts", import.meta.url)).text(),
-  entrypoint: await Bun.file(new URL("../../docker-entrypoint.sh", import.meta.url)).text(),
+const entrypoint = await Bun.file(new URL("../../docker-entrypoint.sh", import.meta.url)).text();
+
+const bootstrapStart = 'if [ "$HARNESS_PROVIDER" = "pi" ]; then';
+const bootstrapEnd = "# ---- Verify provider binary is reachable ----";
+const bootstrapBlock = entrypoint.slice(
+  entrypoint.indexOf(bootstrapStart),
+  entrypoint.indexOf(bootstrapEnd),
+);
+
+const modelsDevFixture = {
+  anthropic: { models: { "claude-test": { cost: { input: 1, output: 2 } } } },
+  openai: { models: { "gpt-test": { cost: { input: 1, output: 2 } } } },
+  openrouter: { models: { "test/model": { cost: { input: 1, output: 2 } } } },
 };
 
-// Claude follows the entrypoint's default branch. ACP targets own their
-// credentials and pricing, and do not need the built-in shell bootstrap.
-const REGISTRATION_EXEMPTIONS: Partial<
-  Record<ProviderName, readonly (keyof typeof registrationSources)[]>
-> = {
-  claude: ["entrypoint"],
-  acp: ["pricing", "entrypoint"],
+const ENTRYPOINT_EXEMPTIONS = new Set(["claude", "acp"]);
+const ENTRYPOINT_OUTPUT: Record<string, string> = {
+  pi: "Warning: pi provider has no credentials yet",
+  opencode: "Warning: opencode provider has no credentials yet",
+  "claude-managed": "Warning: claude-managed provider missing:",
+  devin: "Warning: devin provider missing DEVIN_API_KEY / DEVIN_ORG_ID",
+  codex: "Warning: codex provider has no auth.json yet",
 };
 
-function hasRegistration(
-  touchpoint: keyof typeof registrationSources,
-  source: string,
-  provider: ProviderName,
-): boolean {
-  switch (touchpoint) {
-    case "credentials":
-      return source.includes(`case "${provider}":`);
-    case "entrypoint":
-      return source.includes(`HARNESS_PROVIDER" = "${provider}"`);
-    case "pricing":
-      return source.includes(`"${provider}"`);
-  }
+async function runCredentialBootstrap(provider: string): Promise<{
+  exitCode: number;
+  stdout: string;
+}> {
+  const proc = Bun.spawn(["bash", "-c", bootstrapBlock], {
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: "/tmp/provider-registration-test",
+      HARNESS_PROVIDER: provider,
+      API_KEY: "",
+      MCP_BASE_URL: "",
+      MCP_URL: "",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
+  return { exitCode, stdout: stdout.trim() };
 }
 
 describe("provider registration synchronization", () => {
-  for (const provider of ProviderNameSchema.options) {
-    for (const [touchpoint, source] of Object.entries(registrationSources)) {
-      test(`${provider} is registered for ${touchpoint} or explicitly exempt`, () => {
-        const exemptions = REGISTRATION_EXEMPTIONS[provider] ?? [];
-        expect(
-          hasRegistration(touchpoint as keyof typeof registrationSources, source, provider) ||
-            exemptions.includes(touchpoint as keyof typeof registrationSources),
-        ).toBeTrue();
-      });
-    }
-  }
+  test("credential dispatcher has a concrete handler for every provider", () => {
+    expect(Object.keys(CREDENTIAL_PROVIDER_CHECKERS).sort()).toEqual(
+      [...ProviderNameSchema.options].sort(),
+    );
+  });
+
+  test("pricing seeder emits rows for every provider except ACP", () => {
+    const registered = new Set(buildPricingSeedRows(modelsDevFixture).map((row) => row.provider));
+    const expected = ProviderNameSchema.options.filter((provider) => provider !== "acp");
+    expect([...registered].filter((provider) => expected.includes(provider)).sort()).toEqual(
+      [...expected].sort(),
+    );
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "entrypoint executes a credential bootstrap for every non-exempt provider",
+    async () => {
+      for (const provider of ProviderNameSchema.options) {
+        if (ENTRYPOINT_EXEMPTIONS.has(provider)) continue;
+        const result = await runCredentialBootstrap(provider);
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain(ENTRYPOINT_OUTPUT[provider]);
+      }
+    },
+  );
 });

--- a/src/tests/provider-registration.test.ts
+++ b/src/tests/provider-registration.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { type ProviderName, ProviderNameSchema } from "../types";
+
+const registrationSources = {
+  credentials: await Bun.file(
+    new URL("../commands/provider-credentials.ts", import.meta.url),
+  ).text(),
+  pricing: await Bun.file(new URL("../be/seed-pricing.ts", import.meta.url)).text(),
+  entrypoint: await Bun.file(new URL("../../docker-entrypoint.sh", import.meta.url)).text(),
+};
+
+// Claude follows the entrypoint's default branch. ACP targets own their
+// credentials and pricing, and do not need the built-in shell bootstrap.
+const REGISTRATION_EXEMPTIONS: Partial<
+  Record<ProviderName, readonly (keyof typeof registrationSources)[]>
+> = {
+  claude: ["entrypoint"],
+  acp: ["pricing", "entrypoint"],
+};
+
+function hasRegistration(
+  touchpoint: keyof typeof registrationSources,
+  source: string,
+  provider: ProviderName,
+): boolean {
+  switch (touchpoint) {
+    case "credentials":
+      return source.includes(`case "${provider}":`);
+    case "entrypoint":
+      return source.includes(`HARNESS_PROVIDER" = "${provider}"`);
+    case "pricing":
+      return source.includes(`"${provider}"`);
+  }
+}
+
+describe("provider registration synchronization", () => {
+  for (const provider of ProviderNameSchema.options) {
+    for (const [touchpoint, source] of Object.entries(registrationSources)) {
+      test(`${provider} is registered for ${touchpoint} or explicitly exempt`, () => {
+        const exemptions = REGISTRATION_EXEMPTIONS[provider] ?? [];
+        expect(
+          hasRegistration(touchpoint as keyof typeof registrationSources, source, provider) ||
+            exemptions.includes(touchpoint as keyof typeof registrationSources),
+        ).toBeTrue();
+      });
+    }
+  }
+});

--- a/src/tests/provider-registration.test.ts
+++ b/src/tests/provider-registration.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { buildPricingSeedRows } from "../be/seed-pricing";
 import { CREDENTIAL_PROVIDER_CHECKERS } from "../commands/provider-credentials";
 import { ProviderNameSchema } from "../types";
@@ -31,20 +34,26 @@ async function runCredentialBootstrap(provider: string): Promise<{
   exitCode: number;
   stdout: string;
 }> {
-  const proc = Bun.spawn(["bash", "-c", bootstrapBlock], {
-    env: {
-      PATH: process.env.PATH ?? "",
-      HOME: "/tmp/provider-registration-test",
-      HARNESS_PROVIDER: provider,
-      API_KEY: "",
-      MCP_BASE_URL: "",
-      MCP_URL: "",
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
-  return { exitCode, stdout: stdout.trim() };
+  const testRoot = await mkdtemp(join(tmpdir(), "provider-registration-"));
+  try {
+    const proc = Bun.spawn(["bash", "-c", bootstrapBlock], {
+      env: {
+        PATH: process.env.PATH ?? "",
+        HOME: join(testRoot, "home"),
+        WORKER_CODEX_HOME: join(testRoot, "codex"),
+        HARNESS_PROVIDER: provider,
+        API_KEY: "",
+        MCP_BASE_URL: "",
+        MCP_URL: "",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
+    return { exitCode, stdout: stdout.trim() };
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
 }
 
 describe("provider registration synchronization", () => {

--- a/src/tests/provider-registration.test.ts
+++ b/src/tests/provider-registration.test.ts
@@ -14,6 +14,14 @@ const bootstrapBlock = entrypoint.slice(
   entrypoint.indexOf(bootstrapStart),
   entrypoint.indexOf(bootstrapEnd),
 );
+const codexHomeAssignment = 'WORKER_CODEX_HOME="/home/worker/.codex"';
+const isolatedBootstrapBlock = bootstrapBlock.replace(
+  codexHomeAssignment,
+  'WORKER_CODEX_HOME="$TEST_WORKER_CODEX_HOME"',
+);
+if (isolatedBootstrapBlock === bootstrapBlock) {
+  throw new Error(`Could not isolate entrypoint assignment: ${codexHomeAssignment}`);
+}
 
 const modelsDevFixture = {
   anthropic: { models: { "claude-test": { cost: { input: 1, output: 2 } } } },
@@ -36,11 +44,11 @@ async function runCredentialBootstrap(provider: string): Promise<{
 }> {
   const testRoot = await mkdtemp(join(tmpdir(), "provider-registration-"));
   try {
-    const proc = Bun.spawn(["bash", "-c", bootstrapBlock], {
+    const proc = Bun.spawn(["bash", "-c", isolatedBootstrapBlock], {
       env: {
         PATH: process.env.PATH ?? "",
         HOME: join(testRoot, "home"),
-        WORKER_CODEX_HOME: join(testRoot, "codex"),
+        TEST_WORKER_CODEX_HOME: join(testRoot, "codex"),
         HARNESS_PROVIDER: provider,
         API_KEY: "",
         MCP_BASE_URL: "",


### PR DESCRIPTION
Provider names are defined centrally, but credential checks, pricing rows, and the Docker entrypoint previously had no synchronization guard. A new provider could therefore pass schema validation while missing one of those runtime registrations.

This PR makes the credential dispatcher's typed handler map and the pricing boot-row builder directly testable, then checks their concrete output against every `ProviderNameSchema` value. It also executes the entrypoint's actual credential-bootstrap block under Bash for each provider. The existing narrow exemptions remain documented: Claude uses the default branch, while ACP owns its external pricing and bootstrap.

The entrypoint test uses unique temporary home paths and substitutes the fixed Codex worker path only in its extracted test copy, so credentials on the host cannot affect the result and production configuration remains unchanged.

Closes #1421.

Validation:

- `bun test src/tests/provider-registration.test.ts src/tests/credential-check.test.ts src/tests/pricing-refresh.test.ts` (66 passed; Bash assertion skipped on Windows and active on Linux)
- `bunx biome check src/tests/provider-registration.test.ts src/commands/provider-credentials.ts src/be/seed-pricing.ts`
- `bun run tsc:check`
