### PR TITLE
feat(providers): implement BEDROCK_AUTH_MODE=bearer in the pi credential check

### DIFF
--- a/src/be/swarm-config-guard.ts
+++ b/src/be/swarm-config-guard.ts
@@ -223,7 +223,7 @@ const VALIDATED_KEYS: Record<string, ConfigValidator> = {
   },
   // AWS credential mode for the Bedrock path on the pi harness.
   //   sdk    — AWS SDK default credential chain (env, ~/.aws/*, SSO, IMDS, …)
-  //   bearer — explicit bearer token via AWS_BEARER_TOKEN_BEDROCK (future/Mantle)
+  //   bearer — explicit Bedrock API key via AWS_BEARER_TOKEN_BEDROCK (required in this mode)
   // When absent the worker infers the mode from MODEL_OVERRIDE (sdk semantics).
   BEDROCK_AUTH_MODE: (value) => {
     if (value === "sdk" || value === "bearer") return null;

--- a/src/commands/provider-credentials.ts
+++ b/src/commands/provider-credentials.ts
@@ -63,6 +63,27 @@ export function isBedrockMode(env: Record<string, string | undefined>): boolean 
 }
 
 /**
+ * Scheduling decision for the runner's post-task Bedrock enumeration refresh
+ * (see the throttled branch in `runner.ts`). Kept pure so the gate can be
+ * exercised without spinning the runner: it fires for the pi harness in any
+ * Bedrock mode (`sdk`, `bearer`, or the `MODEL_OVERRIDE=amazon-bedrock/*`
+ * inference) once `intervalMs` has elapsed since the last refresh.
+ */
+export function shouldRefreshBedrockStatus(opts: {
+  harnessProvider: string | null | undefined;
+  env: Record<string, string | undefined>;
+  lastRefreshAt: number;
+  now: number;
+  intervalMs: number;
+}): boolean {
+  return (
+    opts.harnessProvider === "pi" &&
+    isBedrockMode(opts.env) &&
+    opts.now - opts.lastRefreshAt > opts.intervalMs
+  );
+}
+
+/**
  * Static documentation of which env vars each provider considers when running
  * `checkCredentials`. Used by the dashboard to render hints before any worker
  * has reported its dynamic state. The arrays are illustrative — the real

--- a/src/commands/provider-credentials.ts
+++ b/src/commands/provider-credentials.ts
@@ -44,16 +44,20 @@ export type SupportedProvider =
   | "acp";
 
 /**
- * True when the pi harness should use the AWS SDK Bedrock path: either an
- * explicit `BEDROCK_AUTH_MODE=sdk`, or — preserving prefix-inference semantics —
+ * True when the pi harness authenticates against Bedrock rather than a provider
+ * API key: an explicit `BEDROCK_AUTH_MODE=sdk` (AWS credential chain), an
+ * explicit `BEDROCK_AUTH_MODE=bearer` (Bedrock API key in
+ * `AWS_BEARER_TOKEN_BEDROCK`), or — preserving prefix-inference semantics —
  * `BEDROCK_AUTH_MODE` absent with a `MODEL_OVERRIDE=amazon-bedrock/*` selection.
  * Single source of truth for the gate so the live-test arm and the worker
- * reconcile loop agree with `checkPiMonoCredentials`.
+ * reconcile loop agree with `checkPiMonoCredentials`, which owns the per-mode
+ * readiness rules (what must be present, how readiness is reported).
  */
-export function isBedrockSdkMode(env: Record<string, string | undefined>): boolean {
+export function isBedrockMode(env: Record<string, string | undefined>): boolean {
   const mode = env.BEDROCK_AUTH_MODE?.toLowerCase();
   return (
     mode === "sdk" ||
+    mode === "bearer" ||
     (mode === undefined && Boolean(env.MODEL_OVERRIDE?.toLowerCase().startsWith("amazon-bedrock/")))
   );
 }
@@ -336,14 +340,14 @@ export async function validateProviderCredentials(provider: string): Promise<Liv
       }
       case "pi":
       case "opencode": {
-        // For the pi Bedrock path, the real credential check is the AWS SDK
+        // For the pi Bedrock path (sdk or bearer), the real credential check is the AWS SDK
         // enumeration (`ListFoundationModels` + `ListInferenceProfiles`) that
         // `checkProviderCredentials` (the `pi` dynamic-import arm) already ran.
         // That result is already in `buildCredStatusReport` — the live-test is a
         // pass-through / no-op so we never issue a second AWS SDK call here
         // (which would drag the SDK into the wrong binary or make slow IMDS
         // calls on non-EC2 hosts).
-        if (provider === "pi" && isBedrockSdkMode(env)) {
+        if (provider === "pi" && isBedrockMode(env)) {
           return presenceCheckOk();
         }
         // Both pi-mono and opencode resolve credentials in the same order:

--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -84,7 +84,7 @@ import {
 import {
   buildCredStatusReport,
   buildLatestModelReport,
-  isBedrockSdkMode,
+  isBedrockMode,
   isCredCheckDisabled,
   reportAcpStatus,
   reportCredStatus,
@@ -5929,7 +5929,7 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
           );
       } else if (
         currentHarness === "pi" &&
-        isBedrockSdkMode(process.env) &&
+        isBedrockMode(process.env) &&
         Date.now() - lastBedrockRefreshAt > BEDROCK_REFRESH_INTERVAL_MS
       ) {
         // Bedrock enumeration drifts independently of the harness_provider:

--- a/src/commands/runner.ts
+++ b/src/commands/runner.ts
@@ -84,12 +84,12 @@ import {
 import {
   buildCredStatusReport,
   buildLatestModelReport,
-  isBedrockMode,
   isCredCheckDisabled,
   reportAcpStatus,
   reportCredStatus,
   reportLatestModel,
   sendCredStatusReport,
+  shouldRefreshBedrockStatus,
 } from "./provider-credentials.ts";
 import {
   type ResumeSessionCandidate,
@@ -5928,9 +5928,13 @@ export async function runAgent(config: RunnerConfig, opts: RunnerOptions) {
             console.warn(`[${role}] cred_status post_task report failed (non-fatal): ${err}`),
           );
       } else if (
-        currentHarness === "pi" &&
-        isBedrockMode(process.env) &&
-        Date.now() - lastBedrockRefreshAt > BEDROCK_REFRESH_INTERVAL_MS
+        shouldRefreshBedrockStatus({
+          harnessProvider: currentHarness,
+          env: process.env,
+          lastRefreshAt: lastBedrockRefreshAt,
+          now: Date.now(),
+          intervalMs: BEDROCK_REFRESH_INTERVAL_MS,
+        })
       ) {
         // Bedrock enumeration drifts independently of the harness_provider:
         // access granted (or revoked) in the AWS console after boot won't flip

--- a/src/providers/pi-mono-adapter.ts
+++ b/src/providers/pi-mono-adapter.ts
@@ -191,19 +191,36 @@ export async function checkPiMonoCredentials(
   env: Record<string, string | undefined>,
   opts: CredCheckOptions = {},
 ): Promise<CredStatus> {
-  // Determine Bedrock SDK mode:
-  //   - Explicit:  BEDROCK_AUTH_MODE=sdk
+  // Determine the Bedrock mode:
+  //   - Explicit:  BEDROCK_AUTH_MODE=sdk — the AWS SDK default credential chain
+  //   - Explicit:  BEDROCK_AUTH_MODE=bearer — an explicit Bedrock API key in
+  //                AWS_BEARER_TOKEN_BEDROCK, which the AWS SDK picks up as the
+  //                bearer identity for the Bedrock clients
   //   - Fallback:  BEDROCK_AUTH_MODE absent AND MODEL_OVERRIDE starts with
   //                "amazon-bedrock/" (preserves today's prefix-inference semantics)
-  // BEDROCK_AUTH_MODE=bearer is declared/validated but the full bearer-token
-  // path is not implemented yet — it falls through to the standard auth check.
+  // Both explicit modes share the region check and the enumeration probe; they
+  // differ in what has to be present up front and in how readiness is reported.
   const bedrockAuthMode = env.BEDROCK_AUTH_MODE?.toLowerCase();
+  const isBedrockBearer = bedrockAuthMode === "bearer";
   const isBedrockSdk =
     bedrockAuthMode === "sdk" ||
     (bedrockAuthMode === undefined &&
       env.MODEL_OVERRIDE?.toLowerCase().startsWith("amazon-bedrock/"));
 
-  if (isBedrockSdk) {
+  if (isBedrockBearer && !env.AWS_BEARER_TOKEN_BEDROCK) {
+    // The token is the whole point of this mode; without it there is nothing
+    // the probe could authenticate with, and the standard API keys do not
+    // apply to Bedrock, so do not fall through to them.
+    return {
+      ready: false,
+      missing: ["AWS_BEARER_TOKEN_BEDROCK"],
+      hint: "BEDROCK_AUTH_MODE=bearer requires AWS_BEARER_TOKEN_BEDROCK (a Bedrock API key); set it, or use BEDROCK_AUTH_MODE=sdk to authenticate through the AWS credential chain.",
+      bedrockModels: [],
+      bedrockRegion: env.AWS_REGION ?? "",
+    };
+  }
+
+  if (isBedrockSdk || isBedrockBearer) {
     const region = env.AWS_REGION;
     if (!region) {
       // Do NOT fabricate a region. A guessed `us-east-1` can differ from where
@@ -231,7 +248,7 @@ export async function checkPiMonoCredentials(
       return {
         ready: true,
         missing: [],
-        satisfiedBy: "sdk-delegated",
+        satisfiedBy: isBedrockBearer ? "env" : "sdk-delegated",
         hint: `Bedrock models invocable in ${region} enumerated (${bedrockModels.length} usable; ListFoundationModels + ListInferenceProfiles).`,
         bedrockModels,
         bedrockRegion: region,

--- a/src/tests/credential-check.test.ts
+++ b/src/tests/credential-check.test.ts
@@ -410,21 +410,69 @@ describe("checkPiMonoCredentials", () => {
     expect(status.ready).toBe(false);
   });
 
-  test("BEDROCK_AUTH_MODE=bearer: does NOT trigger the sdk probe (falls through)", async () => {
-    // The bearer path is declared/validated but the full implementation is
-    // not implemented yet. With no other credentials set it should be not-ready
-    // via the standard permissive check, not via the sdk probe.
-    const env = { BEDROCK_AUTH_MODE: "bearer" };
-    // No other keys set, no auth.json → not-ready from the permissive path.
-    const status = await checkPiMonoCredentials(env, { homeDir: HOME, fs: noFiles });
+  // ─── BEDROCK_AUTH_MODE=bearer: explicit Bedrock API key ─────────────────────
+
+  test("BEDROCK_AUTH_MODE=bearer: missing AWS_BEARER_TOKEN_BEDROCK → not ready, no probe, no fall-through", async () => {
+    let probed = false;
+    // A standard key must not satisfy the bearer mode: it does not apply to Bedrock.
+    const env = { BEDROCK_AUTH_MODE: "bearer", AWS_REGION: "us-east-1", ANTHROPIC_API_KEY: "x" };
+    const status = await checkPiMonoCredentials(env, {
+      homeDir: HOME,
+      fs: noFiles,
+      bedrockProbe: async () => {
+        probed = true;
+      },
+    });
     expect(status.ready).toBe(false);
-    // Satisfying via any standard key still works for the bearer mode today.
-    const withKey = await checkPiMonoCredentials(
-      { BEDROCK_AUTH_MODE: "bearer", ANTHROPIC_API_KEY: "x" },
-      { homeDir: HOME, fs: noFiles },
-    );
-    expect(withKey.ready).toBe(true);
-    expect(withKey.satisfiedBy).toBe("env");
+    expect(status.missing).toEqual(["AWS_BEARER_TOKEN_BEDROCK"]);
+    expect(status.hint).toContain("AWS_BEARER_TOKEN_BEDROCK");
+    expect(probed).toBe(false);
+  });
+
+  test("BEDROCK_AUTH_MODE=bearer: token without AWS_REGION → not ready with the region hint", async () => {
+    const env = { BEDROCK_AUTH_MODE: "bearer", AWS_BEARER_TOKEN_BEDROCK: "bedrock-api-key" };
+    const status = await checkPiMonoCredentials(env, {
+      homeDir: HOME,
+      fs: noFiles,
+      bedrockProbe: bedrockProbeSuccess,
+    });
+    expect(status.ready).toBe(false);
+    expect(status.hint).toContain("AWS_REGION");
+    expect(status.bedrockRegion).toBe("");
+  });
+
+  test("BEDROCK_AUTH_MODE=bearer: token + region → probe runs, ready via env", async () => {
+    const env = {
+      BEDROCK_AUTH_MODE: "bearer",
+      AWS_BEARER_TOKEN_BEDROCK: "bedrock-api-key",
+      AWS_REGION: "eu-central-1",
+    };
+    const status = await checkPiMonoCredentials(env, {
+      homeDir: HOME,
+      fs: noFiles,
+      bedrockProbe: async () => [{ id: "anthropic.claude-sonnet", name: "Claude Sonnet" }],
+    });
+    expect(status.ready).toBe(true);
+    expect(status.satisfiedBy).toBe("env");
+    expect(status.bedrockRegion).toBe("eu-central-1");
+    expect(status.bedrockModels).toEqual([
+      { id: "anthropic.claude-sonnet", name: "Claude Sonnet" },
+    ]);
+  });
+
+  test("BEDROCK_AUTH_MODE=bearer: probe failure → ready:false with the classified hint", async () => {
+    const env = {
+      BEDROCK_AUTH_MODE: "bearer",
+      AWS_BEARER_TOKEN_BEDROCK: "bedrock-api-key",
+      AWS_REGION: "us-east-1",
+    };
+    const status = await checkPiMonoCredentials(env, {
+      homeDir: HOME,
+      fs: noFiles,
+      bedrockProbe: bedrockProbeAuthFail,
+    });
+    expect(status.ready).toBe(false);
+    expect(status.bedrockRegion).toBe("us-east-1");
   });
 
   test("BEDROCK_AUTH_MODE absent + no MODEL_OVERRIDE=amazon-bedrock: no probe", async () => {

--- a/src/tests/credential-check.test.ts
+++ b/src/tests/credential-check.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, mock, test } from "bun:test";
 import {
   buildCredStatusReport,
   checkProviderCredentials,
+  isBedrockMode,
   isCredCheckDisabled,
   REQUIRED_CRED_VARS_BY_PROVIDER,
+  validateProviderCredentials,
 } from "../commands/provider-credentials";
 import { checkClaudeCredentials } from "../providers/claude-adapter";
 import { checkClaudeManagedCredentials } from "../providers/claude-managed-adapter";
@@ -736,6 +738,42 @@ describe("snapshot: every provider", () => {
 });
 
 // ─── REQUIRED_CRED_VARS_BY_PROVIDER documentation map ────────────────────────
+
+describe("isBedrockMode (shared gate for the live test and the refresh loop)", () => {
+  test("recognizes both explicit modes and the MODEL_OVERRIDE prefix inference", () => {
+    expect(isBedrockMode({ BEDROCK_AUTH_MODE: "sdk" })).toBe(true);
+    expect(isBedrockMode({ BEDROCK_AUTH_MODE: "bearer" })).toBe(true);
+    expect(isBedrockMode({ BEDROCK_AUTH_MODE: "Bearer", MODEL_OVERRIDE: "some-model" })).toBe(true);
+    expect(isBedrockMode({ MODEL_OVERRIDE: "amazon-bedrock/anthropic.claude" })).toBe(true);
+    expect(isBedrockMode({ MODEL_OVERRIDE: "anthropic/claude" })).toBe(false);
+    expect(isBedrockMode({})).toBe(false);
+  });
+});
+
+describe("validateProviderCredentials: pi Bedrock pass-through", () => {
+  const saved = { ...process.env };
+  const restore = () => {
+    for (const key of Object.keys(process.env)) if (!(key in saved)) delete process.env[key];
+    Object.assign(process.env, saved);
+  };
+
+  test("bearer mode is a pass-through like sdk mode: no provider-key live test is issued", async () => {
+    const realFetch = globalThis.fetch;
+    // A stray provider key must not be live-tested: the Bedrock enumeration already ran.
+    process.env.BEDROCK_AUTH_MODE = "bearer";
+    process.env.AWS_BEARER_TOKEN_BEDROCK = "bedrock-api-key";
+    process.env.ANTHROPIC_API_KEY = "x";
+    globalThis.fetch = (async () => {
+      throw new Error("live test must not reach the network in Bedrock mode");
+    }) as typeof fetch;
+    try {
+      expect(await validateProviderCredentials("pi")).toEqual({ ok: true, latency_ms: 0 });
+    } finally {
+      globalThis.fetch = realFetch;
+      restore();
+    }
+  });
+});
 
 describe("REQUIRED_CRED_VARS_BY_PROVIDER", () => {
   test("covers every supported provider", () => {

--- a/src/tests/credential-check.test.ts
+++ b/src/tests/credential-check.test.ts
@@ -5,6 +5,7 @@ import {
   isBedrockMode,
   isCredCheckDisabled,
   REQUIRED_CRED_VARS_BY_PROVIDER,
+  shouldRefreshBedrockStatus,
   validateProviderCredentials,
 } from "../commands/provider-credentials";
 import { checkClaudeCredentials } from "../providers/claude-adapter";
@@ -747,6 +748,62 @@ describe("isBedrockMode (shared gate for the live test and the refresh loop)", (
     expect(isBedrockMode({ MODEL_OVERRIDE: "amazon-bedrock/anthropic.claude" })).toBe(true);
     expect(isBedrockMode({ MODEL_OVERRIDE: "anthropic/claude" })).toBe(false);
     expect(isBedrockMode({})).toBe(false);
+  });
+});
+
+describe("shouldRefreshBedrockStatus (runner post-task refresh gate)", () => {
+  const INTERVAL = 5 * 60 * 1000;
+  const base = { harnessProvider: "pi", lastRefreshAt: 1_000, intervalMs: INTERVAL };
+
+  test("bearer-only pi configuration is refreshed once the interval has elapsed", () => {
+    const env = {
+      BEDROCK_AUTH_MODE: "bearer",
+      AWS_BEARER_TOKEN_BEDROCK: "tok",
+      AWS_REGION: "us-east-1",
+    };
+    expect(shouldRefreshBedrockStatus({ ...base, env, now: 1_000 + INTERVAL + 1 })).toBe(true);
+  });
+
+  test("bearer mode stays throttled inside the interval", () => {
+    const env = {
+      BEDROCK_AUTH_MODE: "bearer",
+      AWS_BEARER_TOKEN_BEDROCK: "tok",
+      AWS_REGION: "us-east-1",
+    };
+    expect(shouldRefreshBedrockStatus({ ...base, env, now: 1_000 + INTERVAL })).toBe(false);
+    expect(shouldRefreshBedrockStatus({ ...base, env, now: 1_000 + 1 })).toBe(false);
+  });
+
+  test("sdk mode and the amazon-bedrock/ prefix inference refresh the same way", () => {
+    const now = 1_000 + INTERVAL + 1;
+    expect(shouldRefreshBedrockStatus({ ...base, env: { BEDROCK_AUTH_MODE: "sdk" }, now })).toBe(
+      true,
+    );
+    expect(
+      shouldRefreshBedrockStatus({
+        ...base,
+        env: { MODEL_OVERRIDE: "amazon-bedrock/anthropic.claude" },
+        now,
+      }),
+    ).toBe(true);
+  });
+
+  test("never fires outside Bedrock mode or for a non-pi harness", () => {
+    const now = 1_000 + INTERVAL + 1;
+    expect(shouldRefreshBedrockStatus({ ...base, env: { ANTHROPIC_API_KEY: "sk" }, now })).toBe(
+      false,
+    );
+    expect(
+      shouldRefreshBedrockStatus({ ...base, env: { MODEL_OVERRIDE: "anthropic/claude" }, now }),
+    ).toBe(false);
+    expect(
+      shouldRefreshBedrockStatus({
+        ...base,
+        harnessProvider: "claude",
+        env: { BEDROCK_AUTH_MODE: "bearer" },
+        now,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1145,8 +1145,8 @@ export type AgentLatestModel = z.infer<typeof AgentLatestModelSchema>;
 
 /**
  * Worker-reported Bedrock enumeration block. Only present when the pi harness
- * is in Bedrock SDK mode (`BEDROCK_AUTH_MODE=sdk` or
- * `MODEL_OVERRIDE=amazon-bedrock/*`). Rides inside `cred_status` JSON (no new
+ * is in a Bedrock mode (`BEDROCK_AUTH_MODE=sdk`, `BEDROCK_AUTH_MODE=bearer`,
+ * or `MODEL_OVERRIDE=amazon-bedrock/*`). Rides inside `cred_status` JSON (no new
  * DB column). `models` is the intersection of the models invocable by this
  * account/region (on-demand/ACTIVE foundation models ∪ inference profiles) with
  * the set the pi-ai Converse harness can actually drive — Converse-incompatible


### PR DESCRIPTION
Fixes #1420

## Summary

`BEDROCK_AUTH_MODE=bearer` passed validation in `swarm-config-guard.ts` and was described in the comments as a real mode, but `checkPiMonoCredentials` never branched on it: a worker configured with it silently fell through to the standard API-key check, which has nothing to do with Bedrock.

`src/providers/pi-mono-adapter.ts`

- `bearer` now requires `AWS_BEARER_TOKEN_BEDROCK` (the Bedrock API key the AWS SDK picks up as bearer identity for the Bedrock clients). When it is unset the check reports `ready: false` with `missing: ["AWS_BEARER_TOKEN_BEDROCK"]` and a hint pointing at the sdk mode as the alternative; it does not fall through, so a stray `ANTHROPIC_API_KEY` no longer makes a bearer worker look ready.
- With the token present, bearer shares the existing Bedrock path: the `AWS_REGION` check (no fabricated region, same hint) and the `ListFoundationModels` + `ListInferenceProfiles` enumeration probe, so `bedrockModels` / `bedrockRegion` are filled the same way. Readiness is reported as `satisfiedBy: "env"` rather than `"sdk-delegated"`, because the credential is an explicit env value.
- Prefix inference from `MODEL_OVERRIDE` is unchanged and still implies sdk semantics.

`src/be/swarm-config-guard.ts`: comment only, the mode is no longer "future".

## Tests

`src/tests/credential-check.test.ts`: the placeholder "does NOT trigger the sdk probe (falls through)" case is replaced by four bearer cases: missing token (not ready, `missing` names the token, the probe is not called, a standard key does not satisfy it), token without region (region hint), token + region (probe runs, ready via env, models and region reported), and probe failure (not ready). `bun test src/tests/credential-check.test.ts`: 61 pass. `biome check` is clean on the three files.
